### PR TITLE
Add resetForTesting() to LightweightLiquidGlass

### DIFF
--- a/lib/widgets/shared/lightweight_liquid_glass.dart
+++ b/lib/widgets/shared/lightweight_liquid_glass.dart
@@ -93,6 +93,15 @@ class LightweightLiquidGlass extends StatefulWidget {
   // On web: Each widget needs its own instance (CanvasKit requirement)
   static ui.FragmentShader? _sharedShader; // Native only
 
+  /// Resets static shader state for testing. Call between tests to ensure
+  /// each test gets the fallback rendering (no cached shader).
+  @visibleForTesting
+  static void resetForTesting() {
+    _cachedProgram = null;
+    _sharedShader = null;
+    _isPreparing = false;
+  }
+
   /// Global pre-warm method - loads and compiles the shader program.
   static Future<void> preWarm() async {
     if (_cachedProgram != null || _isPreparing) return;


### PR DESCRIPTION
## Summary

Adds a `@visibleForTesting` static method `resetForTesting()` to `LightweightLiquidGlass` that clears the cached `FragmentProgram`, shared shader, and preparing flag.

## Problem

The static shader cache (`_cachedProgram`, `_sharedShader`) persists across test runs. In test suites with many golden tests, the first test renders the shader fallback (clean, with shadow), while all subsequent tests use the cached shader (visible specular rim, different look). This causes visual inconsistencies between tests.

## Solution

```dart
@visibleForTesting
static void resetForTesting() {
  _cachedProgram = null;
  _sharedShader = null;
  _isPreparing = false;
}
```

Calling `setUp(LightweightLiquidGlass.resetForTesting)` in test files ensures each test starts with a clean shader state and gets consistent fallback rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)