### PR TITLE
feat(bottom_bar): opt-in indicator behind icons via indicatorBehindIcons

### DIFF
--- a/lib/widgets/surfaces/glass_bottom_bar.dart
+++ b/lib/widgets/surfaces/glass_bottom_bar.dart
@@ -195,6 +195,7 @@ class GlassBottomBar extends StatefulWidget {
     this.interactionGlowRadius = 1.5,
     this.interactionBehavior = GlassInteractionBehavior.full,
     this.pressScale = 1.04,
+    this.indicatorBehindIcons = false,
   })  : assert(tabs.length > 0, 'GlassBottomBar requires at least one tab'),
         assert(
           selectedIndex >= 0 && selectedIndex < tabs.length,
@@ -269,6 +270,16 @@ class GlassBottomBar extends StatefulWidget {
   ///
   /// Defaults to 1.04 (4% growth — matches iOS 26 Apple News pill).
   final double pressScale;
+
+  /// Whether the moving glass indicator is drawn *behind* the tab icons
+  /// instead of *on top* of them.
+  ///
+  /// Defaults to `false`, preserving the original "magic lens" behaviour
+  /// where the translucent indicator refracts the icon underneath. The lens
+  /// effect can wash out saturated icon colours, however — set this to
+  /// `true` for the iOS-native pattern (icons paint over a background pill)
+  /// when icon colour fidelity matters more than the refraction effect.
+  final bool indicatorBehindIcons;
 
   // ===========================================================================
   // Tab Configuration
@@ -533,6 +544,7 @@ class _GlassBottomBarState extends State<GlassBottomBar> {
                 interactionScale: widget.interactionBehavior.hasScale
                     ? widget.pressScale
                     : 1.0,
+                indicatorBehindIcons: widget.indicatorBehindIcons,
                 childUnselected: Row(
                   children: [
                     for (var i = 0; i < widget.tabs.length; i++)

--- a/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
+++ b/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
@@ -93,6 +93,7 @@ class GlassSearchableBottomBar extends StatefulWidget {
     // ── Interaction ──────────────────────────────────────────────────────────
     this.interactionBehavior = GlassInteractionBehavior.full,
     this.pressScale = 1.04,
+    this.indicatorBehindIcons = false,
   })  : assert(tabs.length > 0,
             'GlassSearchableBottomBar requires at least one tab'),
         assert(
@@ -281,6 +282,14 @@ class GlassSearchableBottomBar extends StatefulWidget {
   ///
   /// Defaults to 1.04 (4% growth — matches iOS 26 Apple News pill).
   final double pressScale;
+
+  /// Whether the moving glass indicator is drawn *behind* the tab icons
+  /// instead of *on top* of them. Mirrors [GlassBottomBar.indicatorBehindIcons].
+  ///
+  /// Defaults to `false`, preserving the "magic lens" effect. Set to `true`
+  /// to keep the active icon's colour at full saturation (the iOS-native
+  /// pattern), at the cost of the lens refraction.
+  final bool indicatorBehindIcons;
 
   // ── Advanced ─────────────────────────────────────────────────────────────────
   /// Magnification factor for the selected indicator lens effect. Defaults to 1.0.
@@ -655,6 +664,7 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
                           enableBackgroundAnimation:
                               widget.interactionBehavior.hasScale,
                           backgroundPressScale: widget.pressScale,
+                          indicatorBehindIcons: widget.indicatorBehindIcons,
                           collapsedLogoBuilder:
                               widget.searchConfig.collapsedLogoBuilder ??
                                   (context) {

--- a/lib/widgets/surfaces/shared/bottom_bar_internal.dart
+++ b/lib/widgets/surfaces/shared/bottom_bar_internal.dart
@@ -287,6 +287,7 @@ class TabIndicator extends StatefulWidget {
     this.interactionGlowColor,
     this.interactionGlowRadius = 1.5,
     this.interactionScale = 1.0,
+    this.indicatorBehindIcons = false,
     super.key,
   });
 
@@ -314,6 +315,17 @@ class TabIndicator extends StatefulWidget {
   /// Pass `1.0` to disable scaling. Resolved by the parent widget from
   /// [GlassInteractionBehavior] before being forwarded here.
   final double interactionScale;
+
+  /// Whether the moving glass indicator is drawn *behind* the tab icons
+  /// instead of *on top* of them.
+  ///
+  /// Defaults to `false`, preserving the original "magic lens" behaviour
+  /// where the indicator's translucent glass refracts the icon underneath.
+  ///
+  /// Set to `true` for the iOS-native pattern where the indicator is a
+  /// background pill and icons paint on top — keeps the active icon's
+  /// colour at full saturation, at the cost of the lens-refraction effect.
+  final bool indicatorBehindIcons;
 
   @override
   State<TabIndicator> createState() => TabIndicatorState();
@@ -508,6 +520,29 @@ class TabIndicatorState extends State<TabIndicator>
     required double glassRadius,
     required Color indicatorColor,
   }) {
+    final iconsLayer = Positioned.fill(
+      child: Container(
+        padding: widget.tabPadding,
+        child: widget.childUnselected,
+      ),
+    );
+    final indicatorLayer = (widget.visible && thickness > 0.05)
+        ? AnimatedGlassIndicator(
+            velocity: velocity,
+            itemCount: widget.tabCount,
+            alignment: alignment,
+            thickness: thickness,
+            quality: widget.quality,
+            indicatorColor: indicatorColor,
+            isBackgroundIndicator: false,
+            borderRadius: thickness < 1 ? backgroundRadius : glassRadius,
+            padding: const EdgeInsets.all(4),
+            expansion: 14,
+            glassSettings: widget.indicatorSettings,
+            backgroundKey: widget.backgroundKey,
+          )
+        : null;
+
     return SizedBox(
       height: widget.barHeight,
       child: _wrapWithGlow(
@@ -525,30 +560,16 @@ class TabIndicatorState extends State<TabIndicator>
               ),
             ),
 
-            // Unselected icons above background
-            Positioned.fill(
-              child: Container(
-                padding: widget.tabPadding,
-                child: widget.childUnselected,
-              ),
-            ),
-
-            // Glass indicator
-            if (widget.visible && thickness > 0.05)
-              AnimatedGlassIndicator(
-                velocity: velocity,
-                itemCount: widget.tabCount,
-                alignment: alignment,
-                thickness: thickness,
-                quality: widget.quality,
-                indicatorColor: indicatorColor,
-                isBackgroundIndicator: false,
-                borderRadius: thickness < 1 ? backgroundRadius : glassRadius,
-                padding: const EdgeInsets.all(4),
-                expansion: 14,
-                glassSettings: widget.indicatorSettings,
-                backgroundKey: widget.backgroundKey,
-              ),
+            // When indicatorBehindIcons is true, the indicator is drawn first
+            // (so icons paint over it). When false (default), icons paint
+            // first and the indicator's glass lens refracts them on top.
+            if (widget.indicatorBehindIcons) ...[
+              if (indicatorLayer != null) indicatorLayer,
+              iconsLayer,
+            ] else ...[
+              iconsLayer,
+              if (indicatorLayer != null) indicatorLayer,
+            ],
           ],
         ),
       ),
@@ -567,6 +588,65 @@ class TabIndicatorState extends State<TabIndicator>
     required double glassRadius,
     required Color indicatorColor,
   }) {
+    final iconsLayer = Positioned.fill(
+      child: RepaintBoundary(
+        child: Stack(
+          children: [
+            // Unselected (inverse clipped)
+            ClipPath(
+              clipper: JellyClipper(
+                itemCount: widget.tabCount,
+                alignment: alignment,
+                thickness: thickness,
+                expansion: 14,
+                transform: jellyTransform,
+                borderRadius:
+                    thickness < 1 ? backgroundRadius : glassRadius,
+                inverse: true,
+              ),
+              child: Container(
+                padding: widget.tabPadding,
+                height: widget.barHeight,
+                child: widget.childUnselected,
+              ),
+            ),
+            // Selected (forward clipped)
+            ClipPath(
+              clipper: JellyClipper(
+                itemCount: widget.tabCount,
+                alignment: alignment,
+                thickness: thickness,
+                expansion: 14,
+                transform: jellyTransform,
+                borderRadius:
+                    thickness < 1 ? backgroundRadius : glassRadius,
+              ),
+              child: Container(
+                padding: widget.tabPadding,
+                height: widget.barHeight,
+                child: widget.selectedTabBuilder(
+                    context, thickness, alignment),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    final indicatorLayer = AnimatedGlassIndicator(
+      velocity: velocity,
+      itemCount: widget.tabCount,
+      alignment: alignment,
+      thickness: thickness,
+      quality: widget.quality,
+      indicatorColor: indicatorColor,
+      isBackgroundIndicator: false,
+      borderRadius: thickness < 1 ? backgroundRadius : glassRadius,
+      padding: const EdgeInsets.all(4),
+      expansion: 14,
+      glassSettings: widget.indicatorSettings,
+      backgroundKey: widget.backgroundKey,
+    );
+
     return SizedBox(
       height: widget.barHeight,
       child: _wrapWithGlow(
@@ -584,69 +664,17 @@ class TabIndicatorState extends State<TabIndicator>
               ),
             ),
 
-            // 2. Icon Content Layer (Unselected + Selected combined for refraction)
-            // Put both layers into a single RepaintBoundary BEFORE the glass indicator
-            // so that the glass lens correctly refracts both layers.
-            Positioned.fill(
-              child: RepaintBoundary(
-                child: Stack(
-                  children: [
-                    // Unselected (inverse clipped)
-                    ClipPath(
-                      clipper: JellyClipper(
-                        itemCount: widget.tabCount,
-                        alignment: alignment,
-                        thickness: thickness,
-                        expansion: 14,
-                        transform: jellyTransform,
-                        borderRadius:
-                            thickness < 1 ? backgroundRadius : glassRadius,
-                        inverse: true,
-                      ),
-                      child: Container(
-                        padding: widget.tabPadding,
-                        height: widget.barHeight,
-                        child: widget.childUnselected,
-                      ),
-                    ),
-                    // Selected (forward clipped)
-                    ClipPath(
-                      clipper: JellyClipper(
-                        itemCount: widget.tabCount,
-                        alignment: alignment,
-                        thickness: thickness,
-                        expansion: 14,
-                        transform: jellyTransform,
-                        borderRadius:
-                            thickness < 1 ? backgroundRadius : glassRadius,
-                      ),
-                      child: Container(
-                        padding: widget.tabPadding,
-                        height: widget.barHeight,
-                        child: widget.selectedTabBuilder(
-                            context, thickness, alignment),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-
-            // 3. Moving Glass Indicator Layer
-            AnimatedGlassIndicator(
-              velocity: velocity,
-              itemCount: widget.tabCount,
-              alignment: alignment,
-              thickness: thickness,
-              quality: widget.quality,
-              indicatorColor: indicatorColor,
-              isBackgroundIndicator: false,
-              borderRadius: thickness < 1 ? backgroundRadius : glassRadius,
-              padding: const EdgeInsets.all(4),
-              expansion: 14,
-              glassSettings: widget.indicatorSettings,
-              backgroundKey: widget.backgroundKey,
-            ),
+            // Icons + indicator. Default ordering puts icons first and the
+            // indicator's glass lens refracts them on top. Setting
+            // [indicatorBehindIcons] to true swaps the order so the active
+            // icon retains full saturation.
+            if (widget.indicatorBehindIcons) ...[
+              indicatorLayer,
+              iconsLayer,
+            ] else ...[
+              iconsLayer,
+              indicatorLayer,
+            ],
           ],
         ),
       ),

--- a/lib/widgets/surfaces/shared/searchable_bottom_bar_internal.dart
+++ b/lib/widgets/surfaces/shared/searchable_bottom_bar_internal.dart
@@ -114,6 +114,7 @@ class SearchableTabIndicator extends StatefulWidget {
     this.interactionGlowRadius = 1.5,
     required this.enableBackgroundAnimation,
     required this.backgroundPressScale,
+    this.indicatorBehindIcons = false,
     super.key,
   });
 
@@ -140,6 +141,10 @@ class SearchableTabIndicator extends StatefulWidget {
   final double interactionGlowRadius;
   final bool enableBackgroundAnimation;
   final double backgroundPressScale;
+
+  /// See [TabIndicator.indicatorBehindIcons]. Defaults to `false` so existing
+  /// integrations are unaffected.
+  final bool indicatorBehindIcons;
 
   @override
   State<SearchableTabIndicator> createState() => SearchableTabIndicatorState();
@@ -334,6 +339,29 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
     required double glassRadius,
     required Color indicatorColor,
   }) {
+    final iconsLayer = Positioned.fill(
+      child: Container(
+        padding: widget.tabPadding,
+        child: widget.childUnselected,
+      ),
+    );
+    final indicatorLayer = (widget.visible && thickness > 0.05)
+        ? AnimatedGlassIndicator(
+            velocity: velocity,
+            itemCount: widget.tabCount,
+            alignment: alignment,
+            thickness: thickness,
+            quality: widget.quality,
+            indicatorColor: indicatorColor,
+            isBackgroundIndicator: false,
+            borderRadius: thickness < 1 ? backgroundRadius : glassRadius,
+            padding: const EdgeInsets.all(4),
+            expansion: 14,
+            glassSettings: widget.indicatorSettings,
+            backgroundKey: widget.backgroundKey,
+          )
+        : null;
+
     return SizedBox(
         height: widget.barHeight,
         child: _wrapWithGlow(
@@ -351,28 +379,16 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                 ),
               ),
 
-              // Unselected icons above background
-              Positioned.fill(
-                child: Container(
-                  padding: widget.tabPadding,
-                  child: widget.childUnselected,
-                ),
-              ),
-              if (widget.visible && thickness > 0.05)
-                AnimatedGlassIndicator(
-                  velocity: velocity,
-                  itemCount: widget.tabCount,
-                  alignment: alignment,
-                  thickness: thickness,
-                  quality: widget.quality,
-                  indicatorColor: indicatorColor,
-                  isBackgroundIndicator: false,
-                  borderRadius: thickness < 1 ? backgroundRadius : glassRadius,
-                  padding: const EdgeInsets.all(4),
-                  expansion: 14,
-                  glassSettings: widget.indicatorSettings,
-                  backgroundKey: widget.backgroundKey,
-                ),
+              // Icons + indicator. Order swapped when [indicatorBehindIcons]
+              // is true so icons paint over the indicator and retain full
+              // saturation in their selected colour.
+              if (widget.indicatorBehindIcons) ...[
+                if (indicatorLayer != null) indicatorLayer,
+                iconsLayer,
+              ] else ...[
+                iconsLayer,
+                if (indicatorLayer != null) indicatorLayer,
+              ],
             ],
           ),
         ));
@@ -388,6 +404,61 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
     required Color indicatorColor,
   }) {
     final effRadius = thickness < 1 ? backgroundRadius : glassRadius;
+    final iconsLayer = Positioned.fill(
+      child: RepaintBoundary(
+        child: Stack(
+          children: [
+            ClipPath(
+              clipper: JellyClipper(
+                itemCount: widget.tabCount,
+                alignment: alignment,
+                thickness: thickness,
+                expansion: 14,
+                transform: jellyTransform,
+                borderRadius: effRadius,
+                inverse: true,
+              ),
+              child: Container(
+                padding: widget.tabPadding,
+                height: widget.barHeight,
+                child: widget.childUnselected,
+              ),
+            ),
+            ClipPath(
+              clipper: JellyClipper(
+                itemCount: widget.tabCount,
+                alignment: alignment,
+                thickness: thickness,
+                expansion: 14,
+                transform: jellyTransform,
+                borderRadius: effRadius,
+              ),
+              child: Container(
+                padding: widget.tabPadding,
+                height: widget.barHeight,
+                child: widget.selectedTabBuilder(
+                    context, thickness, alignment),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    final indicatorLayer = AnimatedGlassIndicator(
+      velocity: velocity,
+      itemCount: widget.tabCount,
+      alignment: alignment,
+      thickness: thickness,
+      quality: widget.quality,
+      indicatorColor: indicatorColor,
+      isBackgroundIndicator: false,
+      borderRadius: effRadius,
+      padding: const EdgeInsets.all(4),
+      expansion: 14,
+      glassSettings: widget.indicatorSettings,
+      backgroundKey: widget.backgroundKey,
+    );
+
     return SizedBox(
         height: widget.barHeight,
         child: _wrapWithGlow(
@@ -405,61 +476,16 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                 ),
               ),
 
-              // 2. Icon Content Layer (Unselected + Selected combined for refraction)
-              Positioned.fill(
-                child: RepaintBoundary(
-                  child: Stack(
-                    children: [
-                      ClipPath(
-                        clipper: JellyClipper(
-                          itemCount: widget.tabCount,
-                          alignment: alignment,
-                          thickness: thickness,
-                          expansion: 14,
-                          transform: jellyTransform,
-                          borderRadius: effRadius,
-                          inverse: true,
-                        ),
-                        child: Container(
-                          padding: widget.tabPadding,
-                          height: widget.barHeight,
-                          child: widget.childUnselected,
-                        ),
-                      ),
-                      ClipPath(
-                        clipper: JellyClipper(
-                          itemCount: widget.tabCount,
-                          alignment: alignment,
-                          thickness: thickness,
-                          expansion: 14,
-                          transform: jellyTransform,
-                          borderRadius: effRadius,
-                        ),
-                        child: Container(
-                          padding: widget.tabPadding,
-                          height: widget.barHeight,
-                          child: widget.selectedTabBuilder(
-                              context, thickness, alignment),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              AnimatedGlassIndicator(
-                velocity: velocity,
-                itemCount: widget.tabCount,
-                alignment: alignment,
-                thickness: thickness,
-                quality: widget.quality,
-                indicatorColor: indicatorColor,
-                isBackgroundIndicator: false,
-                borderRadius: effRadius,
-                padding: const EdgeInsets.all(4),
-                expansion: 14,
-                glassSettings: widget.indicatorSettings,
-                backgroundKey: widget.backgroundKey,
-              ),
+              // Icons + indicator. Order swapped when [indicatorBehindIcons]
+              // is true so icons paint over the indicator and retain full
+              // saturation in their selected colour.
+              if (widget.indicatorBehindIcons) ...[
+                indicatorLayer,
+                iconsLayer,
+              ] else ...[
+                iconsLayer,
+                indicatorLayer,
+              ],
             ],
           ),
         ));


### PR DESCRIPTION
## Summary

Adds a non-breaking `indicatorBehindIcons: bool = false` flag to `GlassBottomBar` and `GlassSearchableBottomBar` that swaps the Z-order of the moving glass indicator and the icon content layer.

- **Default (`false`)**: unchanged — indicator paints *on top* of icons (the current "magic lens" refraction behaviour).
- **Opt-in (`true`)**: indicator paints *behind* icons. Matches iOS-native tab bar (`UITabBar`) where the active-state pill is a background layer and icons render on top.

## Motivation

When using a saturated `selectedIconColor` (e.g. iOS `systemBlue`), the indicator's translucent white glass lens visibly washes the active icon's colour out. The icon ends up looking grey/muted in its selected state, even with `indicatorColor` set very low. This is because the indicator is currently the *topmost* layer in the Stack (lines 528–551 in `bottom_bar_internal.dart` and the equivalent spots in the high-quality builder + searchable variant) — anything translucent painted on top of an icon dims its colour.

iOS's own `UITabBar` paints the indicator pill behind the icon, which is why an Apple `systemBlue` icon stays vivid even when selected. Apps that want this behaviour currently have no way to get it without forking.

## Approach

- Added a `final bool indicatorBehindIcons` field (default `false`) to both public widgets and both internal `*TabIndicator` widgets.
- Plumbed the value through public → internal.
- In each of the four Stack builders (simple + high-quality × bottom-bar + searchable-bottom-bar), the icons-layer and indicator-layer are now extracted into local `final` variables and conditionally ordered:

```dart
if (widget.indicatorBehindIcons) ...[
  indicatorLayer,
  iconsLayer,
] else ...[
  iconsLayer,
  indicatorLayer,
],
```

No public layout/sizing shifts, no new dependencies. The lens-refraction effect is preserved as the default; only opted-in apps see the new ordering.

## Test plan

- [x] `flutter analyze` clean (no new errors / warnings)
- [x] Tested with `dependency_overrides` in a real app (Hero Dirt — bottom-bar with searchable variant + 3 tabs + saturated active-tab tint). Default `false` matches main; `true` resolves the icon-washing issue cleanly.
- [ ] Maintainer to spot-check that animated transitions (jelly clip, spring-driven indicator move) still look correct in both modes — they should, since the indicator and icon widgets are unchanged; only their position in the parent Stack differs.

## Notes

- I'm happy to add a CHANGELOG entry / docs example / test if useful — let me know what you'd like.
- If a different name (e.g. `indicatorBelowIcons`, `iconsAboveIndicator`) reads better, easy to rename.