### PR TITLE
Refine Modal Interpolation Geometry & Showcase Components

### DIFF
--- a/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
+++ b/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
@@ -456,6 +456,7 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
       quality: widget.currentQuality,
       initialState: SheetState.peek,
       enablePeek: true,
+      peekTopBorderRadius: 46,
       builder: (context) => const GlassBackdropScope(
         child: BaseScenario(
           title: 'Standard Peek',

--- a/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
+++ b/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
@@ -335,6 +335,46 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
             ),
           ],
 
+          // Peek Scenarios
+          if (_selectedTab == 1) ...[
+            _buildScenarioTile(
+              title: 'Glass Panel',
+              description: 'Standalone GlassPanel component demo',
+              icon: Icons.window_rounded,
+              onTap: () => _showGlassPanel(context),
+              color: Colors.green,
+            ),
+            const SizedBox(height: 16),
+            GlassMenu(
+              menuWidth: 240,
+              triggerBuilder: (context, toggleMenu) => _buildScenarioTile(
+                title: 'Pull-Down Menu',
+                description: 'Tile morphs directly into a glass menu',
+                icon: Icons.menu_open_rounded,
+                onTap: toggleMenu,
+                color: Colors.purple,
+              ),
+              items: [
+                GlassMenuItem(
+                  title: 'Edit Content',
+                  icon: const Icon(Icons.edit_rounded),
+                  onTap: () {},
+                ),
+                GlassMenuItem(
+                  title: 'Share Scenario',
+                  icon: const Icon(Icons.share_rounded),
+                  onTap: () {},
+                ),
+                GlassMenuItem(
+                  title: 'Delete Demo',
+                  icon: const Icon(Icons.delete_rounded),
+                  isDestructive: true,
+                  onTap: () {},
+                ),
+              ],
+            ),
+          ],
+
           // Apple Maps Style Tab
           if (_selectedTab == 2) ...[
             _buildScenarioTile(
@@ -461,6 +501,44 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
         child: BaseScenario(
           title: 'Standard Peek',
           subtitle: 'A full-width persistent bar at the bottom.',
+        ),
+      ),
+    );
+  }
+
+  void _showGlassPanel(BuildContext context) {
+    GlassSheet.show(
+      context: context,
+      quality: widget.currentQuality,
+      builder: (context) => const GlassBackdropScope(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: EdgeInsets.all(24),
+              child: GlassPanel(
+                useOwnLayer: true,
+                child: SizedBox(
+                  height: 120,
+                  child: Center(
+                    child: Text(
+                      'Glass Panel',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Text(
+              'Standalone GlassPanel component demo.',
+              style: TextStyle(color: Colors.white54),
+            ),
+            SizedBox(height: 24),
+          ],
         ),
       ),
     );

--- a/lib/theme/glass_theme_helpers.dart
+++ b/lib/theme/glass_theme_helpers.dart
@@ -291,8 +291,9 @@ class GlassThemeHelpers {
     if (bottom == 0) return 0.0;
 
     if (isIOS) {
-      // 2. iPhone Pro Max / Plus with Dynamic Island (e.g. 17 Pro Max: height 956)
-      if (height >= 900 || top >= 59) return 54.0;
+      // 2. iPhone Pro Max / Plus with Dynamic Island (e.g. 15 Pro Max: height 932)
+      // Height is the most reliable indicator; top padding can fluctuate.
+      if (height >= 900) return 54.0;
 
       // 3. iPhone Pro / Base with Dynamic Island (e.g. 15 Pro: height 852)
       if (height >= 800 || top >= 54) return 46.0;

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -608,26 +608,25 @@ class _GlassModalSheetState extends State<GlassModalSheet>
               2.0;
       final frozenBottom = widget.bottomMargin - frozenBottomOffset;
 
-      const syncThreshold = 0.90;
-      final syncProgress =
-          ((t - syncThreshold) / (1.0 - syncThreshold)).clamp(0.0, 1.0);
+      // Phase 1: Wrap corners (t: 0.0 -> 0.92) - movement is diagonal towards the screen corners.
+      // Phase 2: Final sink (t: 0.92 -> 1.0) - the sheet submerges only when it's fully expanded.
+      const transitionEnd = 0.92;
+      final marginProgress = (t / transitionEnd).clamp(0.0, 1.0);
+      final sinkProgress = ((t - transitionEnd) / (1.0 - transitionEnd)).clamp(0.0, 1.0);
 
-      // Hide bottom rounding beyond the screen bottom when expanding to full
       if (_frozenState != null) {
-        effectiveBottom = syncProgress > 0
-            ? lerpDouble(frozenBottom, -extraHeight, syncProgress)!
-            : frozenBottom;
+        final baseBottom = lerpDouble(frozenBottom, 0.0, marginProgress)!;
+        effectiveBottom = lerpDouble(baseBottom, -extraHeight, sinkProgress)!;
       } else {
-        effectiveBottom = syncProgress > 0
-            ? lerpDouble(widget.bottomMargin, -extraHeight, syncProgress)!
-            : widget.bottomMargin;
+        final baseBottom = lerpDouble(widget.bottomMargin, 0.0, marginProgress)!;
+        effectiveBottom = lerpDouble(baseBottom, -extraHeight, sinkProgress)!;
       }
 
       // Physical height adjusts so the top edge always stays at targetVisualHeight
       effectiveHeight = targetVisualHeight - effectiveBottom;
 
       hPad =
-          lerpDouble(widget.horizontalMargin, 0.0, (t / 0.8).clamp(0.0, 1.0))!;
+          lerpDouble(widget.horizontalMargin, 0.0, (t / 0.92).clamp(0.0, 1.0))!;
       // Independent lerp for top and bottom radii
       final baseRadiusTop = lerpDouble(
           topRadiusBase,
@@ -639,8 +638,8 @@ class _GlassModalSheetState extends State<GlassModalSheet>
           _saturationAnimation.value)!;
 
       topRadius = lerpDouble(baseRadiusTop, topRadiusFull, t)!;
-      bottomRadius = syncProgress > 0
-          ? lerpDouble(baseRadiusBottom, bottomRadiusFull, syncProgress)!
+      bottomRadius = sinkProgress > 0
+          ? lerpDouble(baseRadiusBottom, bottomRadiusFull, sinkProgress)!
           : baseRadiusBottom;
     }
 
@@ -687,7 +686,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
     final topRadiusFull = widget.fullTopBorderRadius ?? topRadiusBase;
     final bottomRadiusFull = widget.fullBottomBorderRadius ?? bottomRadiusBase;
 
-    final extraHeight = mqPadding.bottom + topRadiusBase;
+    final extraHeight = mqPadding.bottom + bottomRadiusBase;
 
     final baseSettings = GlassThemeHelpers.resolveSettings(
       context,

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -612,13 +612,15 @@ class _GlassModalSheetState extends State<GlassModalSheet>
       // Phase 2: Final sink (t: 0.92 -> 1.0) - the sheet submerges only when it's fully expanded.
       const transitionEnd = 0.92;
       final marginProgress = (t / transitionEnd).clamp(0.0, 1.0);
-      final sinkProgress = ((t - transitionEnd) / (1.0 - transitionEnd)).clamp(0.0, 1.0);
+      final sinkProgress =
+          ((t - transitionEnd) / (1.0 - transitionEnd)).clamp(0.0, 1.0);
 
       if (_frozenState != null) {
         final baseBottom = lerpDouble(frozenBottom, 0.0, marginProgress)!;
         effectiveBottom = lerpDouble(baseBottom, -extraHeight, sinkProgress)!;
       } else {
-        final baseBottom = lerpDouble(widget.bottomMargin, 0.0, marginProgress)!;
+        final baseBottom =
+            lerpDouble(widget.bottomMargin, 0.0, marginProgress)!;
         effectiveBottom = lerpDouble(baseBottom, -extraHeight, sinkProgress)!;
       }
 


### PR DESCRIPTION
## Summary
This PR focuses on polishing the visual fidelity of the `GlassModalSheet` during state transitions and expanding the demonstration suite with standard liquid glass components. Key improvements include a new two-phase interpolation model for the sheet's bottom edge and refined adaptive geometry for different device tiers.

## Key Changes

### 1. Interpolation & Geometry Polishing (`GlassModalSheet`)
*   **Two-Phase Organic Interpolation**: Replaced linear lerping with a specialized two-phase model for the `Half` → `Full` transition:
    *   **Phase 1 (t: 0.0 – 0.92)**: Synchronizes horizontal margins and bottom edge movement to ensure the sheet perfectly wraps the device's rounded corners without sinking prematurely.
    *   **Phase 2 (t: 0.92 – 1.0)**: Triggers the final "sink" below the screen bottom to transition into a solid full-screen layout, eliminating visual "snapping" or sub-pixel gaps.
*   **Adaptive Radius Detection**: Refined the logic to distinguish between Pro and Pro Max device tiers (thresholds 46.0 vs 54.0), ensuring pixel-perfect alignment across different screen sizes.
*   **Geometric Defaults**: Standardized default margins (5/6) and corner radii to match Apple's latest design language.

### 2. Showcase Modernization & Component Previews
*   **Standard Sheet Demo**: Added a demonstration of the non-morphing `GlassSheet.show`.
*   **GlassPanel Integration**: Added a standalone `GlassPanel` demonstration to show its usage as a reusable surface component.
*   **Direct Menu Morphing**: Refactored the `Pull-Down Menu` demo to trigger directly from the scenario tile using `GlassMenu`, showcasing the seamless morphing transition.

### 3. Bug Fixes & Refinement
*   **Interaction Suppression**: Gated haptic feedback and interaction glow to disable once the sheet is fully expanded (`isFull`), preventing distracting effects during content scrolling.
*   **Syntax & Layout**: Resolved several layout assertion errors by ensuring proper `GlassBackdropScope` isolation in the showcase app.

## Future Work & Roadmap
> [!NOTE]
> **GlassSheet** and **GlassMenu** have been added to the showcase as a foundation for upcoming refinements.
> *   **GlassSheet**: Further internal logic work is planned to improve its standalone behavior.
> *   **GlassMenu**: A major refactor is upcoming to achieve absolute parity with native iOS 26 context menus, including updated spring physics and interaction timing.

## Verification Results
- [x] Verified seamless `Half` → `Full` expansion on iPhone 15 Pro (46px radius).
- [x] Verified "sink" phase on iPhone 15 Pro Max (54px radius).
