### PR TITLE
Expose indicatorExpansion parameter on GlassBottomBar / GlassSearchableBottomBar

### DIFF
--- a/lib/widgets/surfaces/glass_bottom_bar.dart
+++ b/lib/widgets/surfaces/glass_bottom_bar.dart
@@ -197,6 +197,7 @@ class GlassBottomBar extends StatefulWidget {
     this.maskingQuality = MaskingQuality.high,
     this.backgroundKey,
     this.tabWidth,
+    this.indicatorExpansion = 14,
     this.interactionGlowColor,
     this.interactionGlowRadius = 1.5,
     this.interactionBehavior = GlassInteractionBehavior.full,
@@ -305,6 +306,13 @@ class GlassBottomBar extends StatefulWidget {
   ///   * [GlassSearchableBottomBar.tabWidth], the equivalent parameter on the
   ///     searchable variant which uses the same default and clamping logic.
   final double? tabWidth;
+
+  /// How far the jelly indicator's leading and trailing edges expand
+  /// past the tab boundary as the indicator translates between tabs.
+  /// Higher values give a more dramatic "puff" stretch; lower values
+  /// produce a tighter, more iOS-native feel. Defaults to `14` —
+  /// matches the pre-existing visual.
+  final double indicatorExpansion;
 
   /// List of tabs to display in the bottom bar.
   ///
@@ -575,6 +583,7 @@ class _GlassBottomBarState extends State<GlassBottomBar> {
                     tabPadding: widget.tabPadding,
                     backgroundKey: widget.backgroundKey,
                     maskingQuality: widget.maskingQuality,
+                    indicatorExpansion: widget.indicatorExpansion,
                     interactionGlowColor: widget.interactionBehavior.hasGlow
                         ? effectiveInteractionGlowColor
                         : Colors.transparent,

--- a/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
+++ b/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
@@ -95,6 +95,7 @@ class GlassSearchableBottomBar extends StatefulWidget {
     this.interactionBehavior = GlassInteractionBehavior.full,
     this.pressScale = 1.04,
     this.tabWidth,
+    this.indicatorExpansion = 14,
     this.onBarTap,
   })  : assert(tabs.length > 0,
             'GlassSearchableBottomBar requires at least one tab'),
@@ -332,6 +333,13 @@ class GlassSearchableBottomBar extends StatefulWidget {
   /// tabWidth: null,
   /// ```
   final double? tabWidth;
+
+  /// How far the jelly indicator's leading and trailing edges expand
+  /// past the tab boundary as the indicator translates between tabs.
+  /// Higher values give a more dramatic "puff" stretch; lower values
+  /// produce a tighter, more iOS-native feel. Defaults to `14` —
+  /// matches the pre-existing visual.
+  final double indicatorExpansion;
 
   /// Called when the user taps anywhere on the bar.
   ///
@@ -699,6 +707,7 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
                           magnification: widget.magnification,
                           innerBlur: widget.innerBlur,
                           indicatorColor: widget.indicatorColor,
+                          indicatorExpansion: widget.indicatorExpansion,
                           indicatorSettings: widget.indicatorSettings,
                           backgroundKey: widget.backgroundKey,
                           isSearchActive: searching,

--- a/lib/widgets/surfaces/shared/bottom_bar_internal.dart
+++ b/lib/widgets/surfaces/shared/bottom_bar_internal.dart
@@ -312,6 +312,7 @@ class TabIndicator extends StatefulWidget {
     required this.maskingQuality,
     this.indicatorSettings,
     this.backgroundKey,
+    this.indicatorExpansion = 14,
     this.interactionGlowColor,
     this.interactionGlowRadius = 1.5,
     this.interactionGlowBlurRadius = 0,
@@ -337,6 +338,14 @@ class TabIndicator extends StatefulWidget {
   final double innerBlur;
   final MaskingQuality maskingQuality;
   final GlobalKey? backgroundKey;
+
+  /// How far the jelly indicator's leading and trailing edges expand
+  /// past the tab boundary as the indicator translates. Higher values
+  /// give a more dramatic "puff" stretch; lower values produce a
+  /// tighter, more iOS-native feel. Defaults to `14` to match the
+  /// pre-existing visual.
+  final double indicatorExpansion;
+
   final Color? interactionGlowColor;
   final double interactionGlowRadius;
   final double interactionGlowBlurRadius;
@@ -585,7 +594,7 @@ class TabIndicatorState extends State<TabIndicator>
                 isBackgroundIndicator: false,
                 borderRadius: thickness < 1 ? backgroundRadius : glassRadius,
                 padding: const EdgeInsets.all(4),
-                expansion: 14,
+                expansion: widget.indicatorExpansion,
                 glassSettings: widget.indicatorSettings,
                 backgroundKey: widget.backgroundKey,
               ),
@@ -657,7 +666,7 @@ class TabIndicatorState extends State<TabIndicator>
               paintGlass: false,
               borderRadius: thickness < 1 ? backgroundRadius : glassRadius,
               padding: const EdgeInsets.all(4),
-              expansion: 14,
+              expansion: widget.indicatorExpansion,
               glassSettings: widget.indicatorSettings,
               backgroundKey: widget.backgroundKey,
             ),
@@ -676,7 +685,7 @@ class TabIndicatorState extends State<TabIndicator>
                         itemCount: widget.tabCount,
                         alignment: alignment,
                         thickness: thickness,
-                        expansion: 14,
+                        expansion: widget.indicatorExpansion,
                         transform: jellyTransform,
                         borderRadius:
                             thickness < 1 ? backgroundRadius : glassRadius,
@@ -694,7 +703,7 @@ class TabIndicatorState extends State<TabIndicator>
                         itemCount: widget.tabCount,
                         alignment: alignment,
                         thickness: thickness,
-                        expansion: 14,
+                        expansion: widget.indicatorExpansion,
                         transform: jellyTransform,
                         borderRadius:
                             thickness < 1 ? backgroundRadius : glassRadius,
@@ -725,7 +734,7 @@ class TabIndicatorState extends State<TabIndicator>
               paintGlass: true,
               borderRadius: thickness < 1 ? backgroundRadius : glassRadius,
               padding: const EdgeInsets.all(4),
-              expansion: 14,
+              expansion: widget.indicatorExpansion,
               glassSettings: widget.indicatorSettings,
               backgroundKey: widget.backgroundKey,
             ),

--- a/lib/widgets/surfaces/shared/searchable_bottom_bar_internal.dart
+++ b/lib/widgets/surfaces/shared/searchable_bottom_bar_internal.dart
@@ -110,6 +110,7 @@ class SearchableTabIndicator extends StatefulWidget {
     this.indicatorSettings,
     this.backgroundKey,
     this.collapsedLogoBuilder,
+    this.indicatorExpansion = 14,
     this.interactionGlowColor,
     this.interactionGlowRadius = 1.5,
     this.interactionGlowBlurRadius = 0,
@@ -139,6 +140,14 @@ class SearchableTabIndicator extends StatefulWidget {
   final bool isSearchActive;
   final VoidCallback onDismissSearch;
   final WidgetBuilder? collapsedLogoBuilder;
+
+  /// How far the jelly indicator's leading and trailing edges expand
+  /// past the tab boundary as the indicator translates. Higher values
+  /// give a more dramatic "puff" stretch; lower values produce a
+  /// tighter, more iOS-native feel. Defaults to `14` to match the
+  /// pre-existing visual.
+  final double indicatorExpansion;
+
   final Color? interactionGlowColor;
   final double interactionGlowRadius;
   final double interactionGlowBlurRadius;
@@ -383,7 +392,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                   isBackgroundIndicator: false,
                   borderRadius: thickness < 1 ? backgroundRadius : glassRadius,
                   padding: const EdgeInsets.all(4),
-                  expansion: 14,
+                  expansion: widget.indicatorExpansion,
                   glassSettings: widget.indicatorSettings,
                   backgroundKey: widget.backgroundKey,
                 ),
@@ -450,7 +459,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                 paintGlass: false,
                 borderRadius: effRadius,
                 padding: const EdgeInsets.all(4),
-                expansion: 14,
+                expansion: widget.indicatorExpansion,
                 glassSettings: widget.indicatorSettings,
                 backgroundKey: widget.backgroundKey,
               ),
@@ -465,7 +474,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                           itemCount: widget.tabCount,
                           alignment: alignment,
                           thickness: thickness,
-                          expansion: 14,
+                          expansion: widget.indicatorExpansion,
                           transform: jellyTransform,
                           borderRadius: effRadius,
                           inverse: true,
@@ -481,7 +490,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                           itemCount: widget.tabCount,
                           alignment: alignment,
                           thickness: thickness,
-                          expansion: 14,
+                          expansion: widget.indicatorExpansion,
                           transform: jellyTransform,
                           borderRadius: effRadius,
                         ),
@@ -511,7 +520,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                 paintGlass: true,
                 borderRadius: effRadius,
                 padding: const EdgeInsets.all(4),
-                expansion: 14,
+                expansion: widget.indicatorExpansion,
                 glassSettings: widget.indicatorSettings,
                 backgroundKey: widget.backgroundKey,
               ),


### PR DESCRIPTION
## Summary

Adds a new `indicatorExpansion: double = 14` parameter on both `GlassBottomBar` and `GlassSearchableBottomBar` and plumbs it through to the existing `expansion: 14` literals on `JellyClipper` and `AnimatedGlassIndicator` calls inside `TabIndicator` / `SearchableTabIndicator`.

Default unchanged (`14`) — **zero behavior change** for existing callers.

## Why

The jelly indicator's "puff" stretch during tab transitions is currently hardcoded as `expansion: 14` in 10 internal call sites. In our app, the default reads as roughly 2× more dramatic than iOS's native tab-bar morph. We've been carrying a fork that just changes the literal to `5`; this PR exposes the value as a configurable parameter so callers wanting a tighter, more iOS-native feel can opt in without forking.

## Plumbing

- `glass_bottom_bar.dart` — public ctor + field + dartdoc, pass-through to `TabIndicator`
- `glass_searchable_bottom_bar.dart` — public ctor + field + dartdoc, pass-through to `SearchableTabIndicator`
- `bottom_bar_internal.dart` — `TabIndicator` ctor + field, 5 callsites updated (`expansion: 14` → `expansion: widget.indicatorExpansion`)
- `searchable_bottom_bar_internal.dart` — `SearchableTabIndicator` ctor + field, 5 callsites updated (same pattern)

Total diff: 4 files, ~46 insertions / ~10 deletions.

## Naming

Open to feedback if `indicatorExpansion` isn't the cleanest spelling. Could also be `jellyExpansion` (matches `JellyClipper` terminology) or `indicatorOvershoot`. Happy to rename.