### PR TITLE
Expose searchIcon override on GlassSearchBarConfig

### DIFF
--- a/lib/widgets/surfaces/shared/glass_search_bar_config.dart
+++ b/lib/widgets/surfaces/shared/glass_search_bar_config.dart
@@ -28,6 +28,7 @@ class GlassSearchBarConfig {
     this.collapsedTabWidth,
     this.collapsedLogoBuilder,
     this.searchIconColor,
+    this.searchIcon,
     this.micIconColor,
     this.hintStyle,
     this.controller,
@@ -76,6 +77,19 @@ class GlassSearchBarConfig {
 
   /// Color for the 🔍 and 🎙️ icons. Defaults to `Colors.white60`.
   final Color? searchIconColor;
+
+  /// Custom widget rendered in place of the default magnifying-glass
+  /// icon on the collapsed search pill. When non-null, [searchIconColor]
+  /// is ignored for this particular slot — the caller's widget is
+  /// expected to handle its own coloring.
+  ///
+  /// The default (`null`) preserves the upstream behavior:
+  /// `Icon(CupertinoIcons.search, color: searchIconColor ?? Colors.white60)`.
+  ///
+  /// Useful when the caller wants a higher-fidelity glyph (e.g. real
+  /// SF Symbols via `flutter_sficon`) or a different icon set with
+  /// weight control (e.g. Material Symbols).
+  final Widget? searchIcon;
 
   /// Color for the microphone icon specifically. Falls back to [searchIconColor].
   ///

--- a/lib/widgets/surfaces/shared/searchable_bottom_bar_internal.dart
+++ b/lib/widgets/surfaces/shared/searchable_bottom_bar_internal.dart
@@ -110,6 +110,7 @@ class SearchableTabIndicator extends StatefulWidget {
     this.indicatorSettings,
     this.backgroundKey,
     this.collapsedLogoBuilder,
+    this.indicatorExpansion = 14,
     this.interactionGlowColor,
     this.interactionGlowRadius = 1.5,
     this.interactionGlowBlurRadius = 0,
@@ -139,6 +140,14 @@ class SearchableTabIndicator extends StatefulWidget {
   final bool isSearchActive;
   final VoidCallback onDismissSearch;
   final WidgetBuilder? collapsedLogoBuilder;
+
+  /// How far the jelly indicator's leading and trailing edges expand
+  /// past the tab boundary as the indicator translates. Higher values
+  /// give a more dramatic "puff" stretch; lower values produce a
+  /// tighter, more iOS-native feel. Defaults to `14` to match the
+  /// pre-existing visual.
+  final double indicatorExpansion;
+
   final Color? interactionGlowColor;
   final double interactionGlowRadius;
   final double interactionGlowBlurRadius;
@@ -383,7 +392,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                   isBackgroundIndicator: false,
                   borderRadius: thickness < 1 ? backgroundRadius : glassRadius,
                   padding: const EdgeInsets.all(4),
-                  expansion: 14,
+                  expansion: widget.indicatorExpansion,
                   glassSettings: widget.indicatorSettings,
                   backgroundKey: widget.backgroundKey,
                 ),
@@ -450,7 +459,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                 paintGlass: false,
                 borderRadius: effRadius,
                 padding: const EdgeInsets.all(4),
-                expansion: 14,
+                expansion: widget.indicatorExpansion,
                 glassSettings: widget.indicatorSettings,
                 backgroundKey: widget.backgroundKey,
               ),
@@ -465,7 +474,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                           itemCount: widget.tabCount,
                           alignment: alignment,
                           thickness: thickness,
-                          expansion: 14,
+                          expansion: widget.indicatorExpansion,
                           transform: jellyTransform,
                           borderRadius: effRadius,
                           inverse: true,
@@ -481,7 +490,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                           itemCount: widget.tabCount,
                           alignment: alignment,
                           thickness: thickness,
-                          expansion: 14,
+                          expansion: widget.indicatorExpansion,
                           transform: jellyTransform,
                           borderRadius: effRadius,
                         ),
@@ -511,7 +520,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                 paintGlass: true,
                 borderRadius: effRadius,
                 padding: const EdgeInsets.all(4),
-                expansion: 14,
+                expansion: widget.indicatorExpansion,
                 glassSettings: widget.indicatorSettings,
                 backgroundKey: widget.backgroundKey,
               ),
@@ -697,7 +706,15 @@ class SearchPillState extends State<SearchPill> {
             children: [
               GlassButton(
                 key: const ValueKey('pill-collapsed'),
-                icon: Icon(CupertinoIcons.search, color: iconColor),
+                // Use caller-supplied search icon when provided;
+                // otherwise fall back to the upstream default
+                // CupertinoIcons.search glyph. Letting callers
+                // override here lets apps that need a higher-fidelity
+                // glyph (real SF Symbols, Material Symbols at a
+                // specific weight, etc.) supply their own without
+                // forking — see GlassSearchBarConfig.searchIcon.
+                icon: widget.config.searchIcon ??
+                    Icon(CupertinoIcons.search, color: iconColor),
                 // No-op while mid-animation to avoid double-toggling, EXCEPT
                 // if expandWhenActive is false, which means this is a persistent
                 // collapsed search button that needs to be tappable to activate search.


### PR DESCRIPTION
## Summary

Adds a new `searchIcon: Widget?` field to `GlassSearchBarConfig`. When non-null, the supplied widget is used in place of the hardcoded `Icon(CupertinoIcons.search, color: iconColor)` on the collapsed search pill. Default `null` preserves existing behavior — **zero breaking change**.

## Why

The collapsed search-pill icon currently hardcodes `CupertinoIcons.search`. The `cupertino_icons` package is an aging static font whose `search` glyph doesn't quite match what real iOS renders — it's noticeably thinner than App Store / Apple Music's magnifyingglass, and the handle/circle proportions differ slightly from SF Pro's `magnifyingglass`. For a package that explicitly targets iOS 26 Liquid Glass design language, callers may want a higher-fidelity glyph.

Rather than picking a single "best" replacement and arguing for which icon is right, exposing the override lets each app supply what fits its visual system:

- Apps wanting exact iOS fidelity can pass `SFIcon(SFIcons.sf_magnifyingglass, ...)` from [`flutter_sficon`](https://pub.dev/packages/flutter_sficon)
- Apps wanting weight control on a Material aesthetic can pass `Icon(Symbols.search, weight: 600, ...)` from [`material_symbols_icons`](https://pub.dev/packages/material_symbols_icons)
- Apps fine with the current default just don't pass anything

## Plumbing

- `glass_search_bar_config.dart` — added `final Widget? searchIcon;` + ctor param + dartdoc
- `searchable_bottom_bar_internal.dart` — call site now reads `widget.config.searchIcon ?? Icon(CupertinoIcons.search, color: iconColor)`

Total diff: 2 files, ~25 insertions / ~3 deletions.

## Companion proposal (optional)

Separately worth considering: would you be open to changing the default itself to a real SF Symbol via `flutter_sficon`? It'd be a heavier package dep at the default level, but would give the package a baseline that matches the design language it's modeled on. Happy to draft that as a follow-up if there's interest. This PR is independent of that question — exposing the override solves the problem either way.