### PR TITLE
Asymmetric top/bottom corner radii in premium pipeline

### DIFF
--- a/lib/src/renderer/internal/render_liquid_glass_geometry.dart
+++ b/lib/src/renderer/internal/render_liquid_glass_geometry.dart
@@ -462,6 +462,7 @@ class ShapeGeometry extends Equatable {
     required this.shapeBounds,
     this.shapeToGeometry,
   })  : rawCornerRadius = _getRadiusFromGlassShape(shape),
+        rawBottomCornerRadius = _getBottomRadiusFromGlassShape(shape),
         rawShapeType = RawShapeType.fromLiquidGlassShape(shape);
 
   static double _getRadiusFromGlassShape(LiquidShape shape) {
@@ -479,6 +480,28 @@ class ShapeGeometry extends Equatable {
     }
   }
 
+  /// Bottom corner radius. For symmetric shapes this returns the same value
+  /// as [_getRadiusFromGlassShape]; for vertically-asymmetric shapes
+  /// ([LiquidVerticalRoundedSuperellipse], [LiquidVerticalRoundedRectangle])
+  /// it returns the distinct bottom radius. Consumed by the geometry shader
+  /// via the per-shape `[base+6]` slot so the SDF can paint different top vs.
+  /// bottom corners (e.g. iOS modal sheets whose bottom curves track the
+  /// device chassis radius).
+  static double _getBottomRadiusFromGlassShape(LiquidShape shape) {
+    switch (shape) {
+      case LiquidRoundedSuperellipse():
+        return shape.borderRadius;
+      case LiquidRoundedRectangle():
+        return shape.borderRadius;
+      case LiquidVerticalRoundedRectangle():
+        return shape.bottomRadius;
+      case LiquidOval():
+        return 0;
+      case LiquidVerticalRoundedSuperellipse():
+        return shape.bottomRadius;
+    }
+  }
+
   final RenderLiquidGlass renderObject;
 
   final LiquidShape shape;
@@ -486,6 +509,11 @@ class ShapeGeometry extends Equatable {
   final RawShapeType rawShapeType;
 
   final double rawCornerRadius;
+
+  /// Bottom corner radius — equal to [rawCornerRadius] for symmetric shapes,
+  /// distinct for vertically-asymmetric shapes. See
+  /// [_getBottomRadiusFromGlassShape].
+  final double rawBottomCornerRadius;
 
   final bool glassContainsChild;
 

--- a/lib/src/renderer/liquid_glass_blend_group.dart
+++ b/lib/src/renderer/liquid_glass_blend_group.dart
@@ -266,13 +266,19 @@ class RenderLiquidGlassBlendGroup extends RenderLiquidGlassGeometry
       for (final shape in shapes) {
         final center = shape.shapeBounds.center;
         final size = shape.shapeBounds.size;
+        // 7-float per-shape stride: type, center.xy, size.xy, top corner
+        // radius, bottom corner radius. For symmetric shapes top == bottom
+        // so the shader's `sdfRRectAsym` collapses to plain `sdfRRect`
+        // (mathematical identity, no behavior change). See sdf.glsl's
+        // shape-slot layout comment.
         value
           ..setFloat(shape.rawShapeType.shaderIndex)
           ..setFloat(center.dx * devicePixelRatio)
           ..setFloat(center.dy * devicePixelRatio)
           ..setFloat(size.width * devicePixelRatio)
           ..setFloat(size.height * devicePixelRatio)
-          ..setFloat(shape.rawCornerRadius * devicePixelRatio);
+          ..setFloat(shape.rawCornerRadius * devicePixelRatio)
+          ..setFloat(shape.rawBottomCornerRadius * devicePixelRatio);
       }
     });
   }

--- a/shaders/liquid_glass_geometry_blended.frag
+++ b/shaders/liquid_glass_geometry_blended.frag
@@ -22,7 +22,7 @@ precision highp float; // mediump caused ~1.5px displacement banding on mobile (
 layout(location = 0) uniform vec2 uSize;
 layout(location = 1) uniform vec4 uOpticalProps;
 layout(location = 2) uniform float uNumShapes;
-layout(location = 3) uniform float uShapeData[MAX_SHAPES * 6];
+layout(location = 3) uniform float uShapeData[MAX_SHAPES * 7];
 
 // sdf.glsl functions access uShapeData as a global (no array-by-value parameters,
 // which are rejected by glslang on Windows/Vulkan SPIR-V compilation).

--- a/shaders/sdf.glsl
+++ b/shaders/sdf.glsl
@@ -26,13 +26,14 @@
 // depth" error that the user-attempted loop-expansion triggered.
 //
 // ── Shape slots ──────────────────────────────────────────────────────────────
-// Each shape occupies 6 consecutive floats in uShapeData[]:
-//   [base+0] type         1=squircle/roundrect  2=ellipse  3=roundrect
+// Each shape occupies 7 consecutive floats in uShapeData[]:
+//   [base+0] type             1=squircle/superellipse  2=ellipse  3=roundrect
 //   [base+1] center.x
 //   [base+2] center.y
 //   [base+3] size.x
 //   [base+4] size.y
-//   [base+5] cornerRadius
+//   [base+5] cornerRadius     (top corners; or symmetric)
+//   [base+6] bottomCornerRadius (bottom corners; equals [base+5] for symmetric)
 
 #ifndef MAX_SHAPES
 #define MAX_SHAPES 16
@@ -45,6 +46,29 @@ float sdfRRect(in vec2 p, in vec2 b, in float r) {
     r = min(r, shortest);
     vec2 q = abs(p) - b + r;
     return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r;
+}
+
+// Asymmetric rounded-rect SDF: independent top/bottom corner radii.
+//
+// Computes two `sdfRRect` evaluations (one with rTop applied to all corners,
+// one with rBottom) and `mix`es them along p.y with a smooth `smoothstep`
+// across the horizontal centerline. This keeps the SDF — and therefore its
+// gradient — continuous across the centerline, which matters for the
+// geometry-blended pipeline that derives surface normals from dFdx/dFdy of
+// the SDF: a per-quadrant `r = p.y < 0 ? rTop : rBottom` lookup would emit
+// garbage normals along the centerline. 2-pixel half-width matches the
+// typical anti-aliasing band on Skia/Impeller.
+//
+// Outside the corner regions both inner SDFs agree (the radius doesn't enter
+// the distance formula along the straight edges), so the blend is a no-op
+// there and only the corner regions actually differ. When rTop == rBottom,
+// dT == dB and `mix` returns either value unchanged — symmetric shapes are
+// bit-exact identical to a plain `sdfRRect(p, b, r)` call.
+float sdfRRectAsym(in vec2 p, in vec2 b, in float rTop, in float rBottom) {
+    float dT = sdfRRect(p, b, rTop);
+    float dB = sdfRRect(p, b, rBottom);
+    float t = smoothstep(-2.0, 2.0, p.y);
+    return mix(dT, dB, t);
 }
 
 float sdfRect(vec2 p, vec2 b) {
@@ -75,10 +99,13 @@ float smoothUnion(float d1, float d2, float k) {
 
 // ── Per-type dispatch ─────────────────────────────────────────────────────────
 
-float getShapeSDF(float type, vec2 p, vec2 center, vec2 size, float r) {
-    if      (type == 1.0) return sdfRRect  (p - center, size / 2.0, r);
-    else if (type == 2.0) return sdfEllipse(p - center, size / 2.0);
-    else if (type == 3.0) return sdfRRect  (p - center, size / 2.0, r);
+// rTop / rBottom collapse to a single radius for symmetric shapes (caller
+// writes rBottom == rTop), so this dispatch is back-compat: routing through
+// `sdfRRectAsym` with equal radii is bit-identical to `sdfRRect`.
+float getShapeSDF(float type, vec2 p, vec2 center, vec2 size, float rTop, float rBottom) {
+    if      (type == 1.0) return sdfRRectAsym(p - center, size / 2.0, rTop, rBottom);
+    else if (type == 2.0) return sdfEllipse  (p - center, size / 2.0);
+    else if (type == 3.0) return sdfRRectAsym(p - center, size / 2.0, rTop, rBottom);
     return 0.0;
 }
 
@@ -86,29 +113,33 @@ float getShapeSDF(float type, vec2 p, vec2 center, vec2 size, float r) {
 // Macro reads uShapeData[] with *literal* offsets only — satisfies the GLSL ES
 // / SkSL / glslang requirement that array indices be constant expressions.
 // uShapeData[] is declared by the including shader before #include "sdf.glsl".
+//
+// Stride: 7 floats per shape (was 6). Slot +6 is the bottom corner radius;
+// see the layout comment near the top of this file.
 
 #define SDF_SHAPE_N(BASE) \
     getShapeSDF(uShapeData[BASE], p, \
                 vec2(uShapeData[BASE+1], uShapeData[BASE+2]), \
                 vec2(uShapeData[BASE+3], uShapeData[BASE+4]), \
-                uShapeData[BASE+5])
+                uShapeData[BASE+5], \
+                uShapeData[BASE+6])
 
-float sdf0(vec2 p)  { return SDF_SHAPE_N(0);  }
-float sdf1(vec2 p)  { return SDF_SHAPE_N(6);  }
-float sdf2(vec2 p)  { return SDF_SHAPE_N(12); }
-float sdf3(vec2 p)  { return SDF_SHAPE_N(18); }
-float sdf4(vec2 p)  { return SDF_SHAPE_N(24); }
-float sdf5(vec2 p)  { return SDF_SHAPE_N(30); }
-float sdf6(vec2 p)  { return SDF_SHAPE_N(36); }
-float sdf7(vec2 p)  { return SDF_SHAPE_N(42); }
-float sdf8(vec2 p)  { return SDF_SHAPE_N(48); }
-float sdf9(vec2 p)  { return SDF_SHAPE_N(54); }
-float sdf10(vec2 p) { return SDF_SHAPE_N(60); }
-float sdf11(vec2 p) { return SDF_SHAPE_N(66); }
-float sdf12(vec2 p) { return SDF_SHAPE_N(72); }
-float sdf13(vec2 p) { return SDF_SHAPE_N(78); }
-float sdf14(vec2 p) { return SDF_SHAPE_N(84); }
-float sdf15(vec2 p) { return SDF_SHAPE_N(90); }
+float sdf0(vec2 p)  { return SDF_SHAPE_N(0);   }
+float sdf1(vec2 p)  { return SDF_SHAPE_N(7);   }
+float sdf2(vec2 p)  { return SDF_SHAPE_N(14);  }
+float sdf3(vec2 p)  { return SDF_SHAPE_N(21);  }
+float sdf4(vec2 p)  { return SDF_SHAPE_N(28);  }
+float sdf5(vec2 p)  { return SDF_SHAPE_N(35);  }
+float sdf6(vec2 p)  { return SDF_SHAPE_N(42);  }
+float sdf7(vec2 p)  { return SDF_SHAPE_N(49);  }
+float sdf8(vec2 p)  { return SDF_SHAPE_N(56);  }
+float sdf9(vec2 p)  { return SDF_SHAPE_N(63);  }
+float sdf10(vec2 p) { return SDF_SHAPE_N(70);  }
+float sdf11(vec2 p) { return SDF_SHAPE_N(77);  }
+float sdf12(vec2 p) { return SDF_SHAPE_N(84);  }
+float sdf13(vec2 p) { return SDF_SHAPE_N(91);  }
+float sdf14(vec2 p) { return SDF_SHAPE_N(98);  }
+float sdf15(vec2 p) { return SDF_SHAPE_N(105); }
 
 // ── sceneSDF — fully unrolled, no loops, no dynamic indices ──────────────────
 //


### PR DESCRIPTION
## Summary

The lightweight (standard-quality) shader already supports per-corner radii
for `LiquidVerticalRoundedSuperellipse` via its asymmetric mode
(`uCornerRadius < 0` sentinel + per-corner radii in `uData6`). The premium
pipeline (two-pass geometry shader on Impeller) was collapsing the shape to
a single radius (`topRadius`), so consumers like `GlassModalSheet` couldn't
render different top vs. bottom corners at premium quality — necessary for
iOS-native looks where the sheet's bottom curve tracks the device chassis
radius (Apple Maps, Music).

This PR teaches the premium pipeline about a second corner radius.

## Changes

**`shaders/sdf.glsl`**
- Per-shape stride extended from 6 to 7 floats. Slot `+6` carries the bottom
  corner radius; the layout comment block at the top of the file documents it.
- New `sdfRRectAsym(p, b, rTop, rBottom)` SDF: computes two `sdfRRect`
  distances (one for each radius applied to all corners) and `mix`es them
  along `p.y` with a 2px-half-width `smoothstep` across the horizontal
  centerline. The blend keeps the SDF continuous so the geometry pipeline's
  `dFdx`/`dFdy`-derived surface normals stay clean — a per-quadrant
  `r = p.y < 0 ? rT : rB` lookup would emit garbage normals at the centerline.
- When `rTop == rBottom`, `dT == dB` and `mix` returns either value
  unchanged. Symmetric shapes are bit-exact identical to plain `sdfRRect`
  — backward compat is mathematical, not best-effort.
- `getShapeSDF` signature now takes both radii. Type 1 (squircle) and type 3
  (roundrect) route through `sdfRRectAsym`.
- The 16 hardcoded `sdf0`…`sdf15` offsets bumped from `N×6` to `N×7` to
  maintain SkSL/glslang's "array indices must be constant-integral-expression"
  rule (preserves the existing `sceneSDF` unrolling pattern).

**`shaders/liquid_glass_geometry_blended.frag`**
- `uShapeData[MAX_SHAPES * 6]` → `[MAX_SHAPES * 7]`.

**`lib/src/renderer/internal/render_liquid_glass_geometry.dart`**
- New `rawBottomCornerRadius` field on `ShapeGeometry`.
- New `_getBottomRadiusFromGlassShape` mirror of the existing
  `_getRadiusFromGlassShape`. For `LiquidVerticalRoundedSuperellipse` and
  `LiquidVerticalRoundedRectangle` it returns `bottomRadius`; for symmetric
  shapes it returns the same value as the top-radius helper, so consumers
  don't need to special-case.

**`lib/src/renderer/liquid_glass_blend_group.dart`**
- `updateGeometryShaderShapes` writes 7 floats per shape (added
  `rawBottomCornerRadius`).

## Performance

2× SDF evaluation per fragment for type 1 / 3 shapes (symmetric shapes pay
the same cost since the dispatch always routes through `sdfRRectAsym`). At
~6 FLOPs per `sdfRRect`, this is negligible — a 1000×1000 surface with 16
shapes adds ~16M FLOPs per frame, sub-millisecond on any modern GPU. If a
perf-critical consumer ever needs the old single-call cost back, a
`rTop == rBottom` short-circuit in `sdfRRectAsym` is one line.

## Test plan
- [x] `LiquidVerticalRoundedSuperellipse` at premium quality on iOS Impeller
      renders distinct top vs. bottom corners with full liquid-glass refraction
      (verified visually with `GlassModalSheet`).
- [x] Symmetric shapes (`LiquidRoundedSuperellipse`, etc.) unchanged at
      premium quality on iOS Impeller (verified via `GlassSearchableBottomBar`,
      no visual regression).
- [ ] Standard quality (lightweight shader) — unchanged, no patch in this
      pipeline.
- [ ] Android Impeller premium — same code path, should work, visually
      unverified.
- [ ] Web / Skia / SkSL compile — patch maintains literal-only indices;
      relying on maintainer CI.

**Note for reviewers**: testing requires `flutter clean && flutter run` if
your example app has an existing build — hot reload/restart bundles stale
shader bytecode (the per-shape stride changed from 6 to 7 floats), and a
Dart-side writer running against the old shader produces misaligned shape
data. Fresh builds work without this dance.