### PR TITLE
Fix: drop GlobalObjectKey(widget.child) from sheet's focus bridge

### DIFF
--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -696,8 +696,21 @@ class _GlassModalSheetState extends State<GlassModalSheet>
       fallback: kDefaultSheetSettings,
     );
 
+    // Focus listener that snaps the sheet to full whenever a focusable
+    // descendant gains focus (e.g. tapping a TextField inside the
+    // sheet). The Focus widget intentionally does NOT carry a key:
+    // any key derived from `widget.child` (e.g. `GlobalObjectKey(
+    // widget.child)`) changes every time the parent rebuilds — because
+    // the parent passes a fresh `child` widget instance each frame —
+    // and Flutter responds to a changed key by tearing down the entire
+    // child Element subtree and rebuilding it. That destroys the
+    // child's State (calling `dispose` and re-running `initState`) on
+    // every sheet expand/collapse, which surfaces in consumers as
+    // "scroll position resets", "controllers are re-initialised",
+    // "fetch fires again", etc. Focus management works the same
+    // without a key — the FocusNode is owned internally by the Focus
+    // widget for the lifetime of its Element.
     final focusBridge = Focus(
-      key: GlobalObjectKey(widget.child),
       onFocusChange: (hasFocus) {
         if (hasFocus && _currentState != SheetState.full) {
           _snapToState(SheetState.full);


### PR DESCRIPTION
## Summary

The internal Focus listener that snaps the sheet to full when a descendant gains focus was wrapped with `key: GlobalObjectKey(widget.child)`. Since parents typically pass a fresh `child` widget instance on every rebuild, this key changes every frame — and a changed key on a subtree's outer widget makes Flutter tear down the entire Element subtree (calling `dispose` and re-running `initState` on every descendant State).

For consumers, this manifested as the sheet's child being rebuilt from scratch on every state transition: scroll positions reset, controllers re-initialised, network fetches re-fired, "did initial auto-scroll" flags reset, etc.

## Repro

Wrap any `StatefulWidget` (e.g. one holding a `ScrollController` or a `bool _didInitialAutoScroll`) in a `GlassModalSheet`. Watch its `initState` / `dispose` fire on every half ↔ full transition. Any state stored in the child's `State` is lost on each transition.

## Fix

Removed the `GlobalObjectKey` from the focus bridge. The `Focus` widget does not need an external key for focus management — its internal `FocusNode` is owned by its `Element` and persists naturally as long as the same widget at the same position is rebuilt. State preservation across sheet transitions now works as expected.

A long inline comment explains why no key is correct here, so a future maintainer doesn't reintroduce one without understanding the rebuild semantics.

## Test plan

- [ ] Run the existing modal sheet tests / examples
- [ ] Confirm: a `StatefulWidget` child of `GlassModalSheet` keeps its State across half ↔ full transitions (e.g. a `TextField` inside the sheet retains its text and scroll position)
- [ ] Confirm: tapping a focusable descendant still snaps the sheet to full (the focus listener still fires; only the key was removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)