### PR TITLE
Fix: snap-to-state side effects skipped after drag-resolved transitions

### DIFF
--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -12,6 +12,27 @@ class _GlassModalSheetState extends State<GlassModalSheet>
   SheetState get _currentState => _currentStateNotifier.value;
   set _currentState(SheetState v) => _currentStateNotifier.value = v;
 
+  /// The state most recently published to consumers via
+  /// [GlassModalSheet.onStateChanged] (and through which any
+  /// snap-to-state side effects — haptics, scroll-to-top — fired).
+  ///
+  /// Distinct from [_currentState]: that value is mutated during
+  /// drag by [_applyDrag] and [_jumpTo] to drive in-flight visual
+  /// interpolation (radii, expand-progress, glass settings) toward
+  /// the resolved snap target. Comparing the snap target to
+  /// [_currentState] in [_snapToState] therefore misses the
+  /// transition whenever the drag had already crossed a snap
+  /// threshold mid-gesture: by the time the user releases and
+  /// [_onPointerUp] calls `_snapToState(target)`, [_currentState]
+  /// already equals `target`, and the side-effects branch is
+  /// silently skipped — no haptic, no `onStateChanged`, no
+  /// scroll-to-top reset on collapse.
+  ///
+  /// [_settledState] is updated only inside the side-effects branch
+  /// itself, so the equality check correctly reflects "did the
+  /// state change since the last time we told consumers about it".
+  late SheetState _settledState;
+
   double _currentPosition = 0.0;
   double _currentEffectiveHeight = 0.0;
 
@@ -35,6 +56,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
     WidgetsBinding.instance.addObserver(this);
 
     _currentStateNotifier = ValueNotifier(widget.initialState);
+    _settledState = widget.initialState;
     _geometry = _buildGeometry();
 
     _animationController = AnimationController.unbounded(vsync: this);
@@ -145,7 +167,15 @@ class _GlassModalSheetState extends State<GlassModalSheet>
       _animationController.value = targetPosition;
     }
 
-    if (state != _currentState) {
+    // Compare against `_settledState`, not `_currentState` — see the
+    // doc comment on `_settledState` for why. Briefly: `_currentState`
+    // tracks the in-flight snap target during drag (mutated silently
+    // by `_applyDrag` and `_jumpTo` to drive visual interpolation),
+    // so checking against it here would skip the side-effects branch
+    // whenever the drag itself had already updated the target. We
+    // want side effects to fire on every transition consumers care
+    // about — i.e. on every change to the published state.
+    if (state != _settledState) {
       if (state == SheetState.peek || state == SheetState.hidden) {
         HapticFeedback.lightImpact();
       } else {
@@ -153,6 +183,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
       }
 
       _currentState = state;
+      _settledState = state;
       widget.onStateChanged?.call(state);
 
       if (state != SheetState.full && _scrollController.hasClients) {

--- a/test/widgets/overlays/glass_modal_sheet_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_test.dart
@@ -799,6 +799,61 @@ void main() {
       expect(states, contains(SheetState.full));
     });
 
+    testWidgets(
+      'onStateChanged fires after slow drag past snap threshold',
+      (tester) async {
+        // Regression: a slow drag whose path crosses a snap threshold
+        // mid-gesture used to silently mutate `_currentState` to the
+        // resolved target via `_applyDrag`. By the time the user
+        // released and `_onPointerUp` called `_snapToState(target)`,
+        // the equality check against `_currentState` was already
+        // false and the side-effects branch (haptics, onStateChanged,
+        // scroll-to-top) was skipped. Consumers saw no callback for
+        // the transition. This test drags slowly enough that the
+        // mid-gesture target resolution kicks in, then asserts the
+        // callback fired anyway.
+        final controller = GlassModalSheetController();
+        final states = <SheetState>[];
+
+        await tester.pumpWidget(
+          createTestApp(
+            child: GlassModalSheetScaffold(
+              controller: controller,
+              initialState: SheetState.full,
+              onStateChanged: states.add,
+              body: const SizedBox.expand(),
+              sheet: const SizedBox.expand(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Slow drag from inside the sheet's content area down through
+        // the half-state position. Multiple small `moveBy` calls with
+        // pumps between them simulate a finger that lingers — enough
+        // frames for `_applyDrag` to resolve and commit the
+        // intermediate snap target.
+        final start = tester.getCenter(find.byType(GlassModalSheetScaffold));
+        final gesture = await tester.startGesture(start);
+        for (var i = 0; i < 20; i++) {
+          await gesture.moveBy(const Offset(0, 15));
+          await tester.pump(const Duration(milliseconds: 16));
+        }
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        // The exact intermediate state set isn't asserted (depends on
+        // geometry resolution), but the final transition to half MUST
+        // be reported.
+        expect(states, contains(SheetState.half),
+            reason:
+                'onStateChanged was not fired for the slow-drag-to-half '
+                'transition — `_snapToState` skipped its side-effects '
+                'branch because `_applyDrag` had already updated '
+                '`_currentState` to the resolved target mid-drag.');
+      },
+    );
+
     testWidgets('persistent mode prevents dismissal below peek',
         (tester) async {
       final controller = GlassModalSheetController();


### PR DESCRIPTION
## Summary

`_GlassModalSheetState._snapToState` decides whether to fire its side-effects branch (haptics, `onStateChanged`, `_scrollController.jumpTo(0)` on collapse) by comparing the requested target against `_currentState`. But `_currentState` is mutated **during drag** by `_applyDrag` and `_jumpTo` — they call `_geometry.resolveTarget` on the in-flight position and silently commit the result so the in-flight visuals (radii interpolation, expand-progress, glass settings) can interpolate toward the resolved snap target.

That mid-gesture mutation defeats the equality check: if the drag itself crosses a snap threshold, by the time the user releases and `_onPointerUp` calls `_snapToState(target)`, `_currentState` already equals `target` — and the entire side-effects branch is silently skipped.

## Symptoms

- **No haptic** on slow-drag settle. Fast snaps still haptic'd because the gesture didn't linger long enough for `_applyDrag` to commit the target.
- **`onStateChanged` never fires** for slow-drag transitions — the consumer's mirrored state field stays stale, and any state-derived UI (e.g. switching content scroll physics between full and half) never updates.
- **`_scrollController.jumpTo(0)` never runs** on a slow-drag full → half collapse, so a `SingleChildScrollView` wired to the package's `ScrollControllerProvider` keeps its full-state scroll offset into the half-state viewport (header cropped above the visible area, no way to recover because half-state physics is `NeverScrollable`).

## Repro

Drag a sheet slowly from full to half (slowly enough that the drag spans several frames during which the resolved snap target crosses `half`). Watch:
- The mirrored state field passed via `onStateChanged` stays at `full`.
- No haptic on settle.
- Any state-derived UI in the sheet content stays in its full-state mode.

The included test (`onStateChanged fires after slow drag past snap threshold`) reproduces this with `tester.startGesture` + 20× `moveBy(15)` calls spaced 16ms apart. Fails on `main`, passes under this change.

## Fix

Track the published state in a separate `_settledState` field, initialized from `widget.initialState` and only updated inside `_snapToState`'s side-effects branch. The equality check now correctly answers _\"did the state change since the last time we told consumers about it\"_ regardless of how many times `_applyDrag` reshuffled `_currentState` during the gesture. `_currentState` keeps its existing semantics for in-flight visuals.

Single-line conceptual change in `_snapToState` (`state != _currentState` → `state != _settledState`, plus assigning `_settledState` alongside `_currentState` inside the branch). New field, new initState assignment, doc comment, and a regression test.

## Test plan

- [x] All 159 existing tests still pass.
- [x] New regression test (\"onStateChanged fires after slow drag past snap threshold\") passes under this change and fails on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)