### PR TITLE
Expose dragIndicatorWidth on GlassModalSheet

### DIFF
--- a/lib/widgets/overlays/glass_modal_sheet.dart
+++ b/lib/widgets/overlays/glass_modal_sheet.dart
@@ -173,6 +173,12 @@ class GlassModalSheet extends StatefulWidget {
   /// Custom color for the drag handle.
   final Color? dragIndicatorColor;
 
+  /// Width of the drag handle pill in logical pixels. Defaults to 36
+  /// (iOS native). Bump higher (e.g. 64) for sheets where the handle
+  /// reads as the primary affordance and the thinner default feels
+  /// too subtle relative to the rest of the sheet's content.
+  final double dragIndicatorWidth;
+
   /// Whether to enable a gradient fade effect at the top of the sheet.
   final bool enableTopFade;
 
@@ -218,6 +224,7 @@ class GlassModalSheet extends StatefulWidget {
     this.fillTransition = FillTransition.instant,
     this.showDragIndicator = true,
     this.dragIndicatorColor,
+    this.dragIndicatorWidth = 36,
     this.glowColor,
     this.glowRadius = 1.5,
     this.suppressInteractionOnChildren = false,
@@ -262,6 +269,7 @@ class GlassModalSheet extends StatefulWidget {
     FillTransition fillTransition = FillTransition.instant,
     bool showDragIndicator = true,
     Color? dragIndicatorColor,
+    double dragIndicatorWidth = 36,
     double? topBorderRadius = 56,
     double? bottomBorderRadius,
     double? fullTopBorderRadius = 46,
@@ -338,6 +346,7 @@ class GlassModalSheet extends StatefulWidget {
           fillTransition: fillTransition,
           showDragIndicator: showDragIndicator,
           dragIndicatorColor: dragIndicatorColor,
+          dragIndicatorWidth: dragIndicatorWidth,
           topBorderRadius: topBorderRadius,
           bottomBorderRadius: bottomBorderRadius,
           fullTopBorderRadius: fullTopBorderRadius,

--- a/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
@@ -30,6 +30,7 @@ class _SheetLayout extends StatelessWidget {
   final Widget child;
   final bool showDragIndicator;
   final Color? dragIndicatorColor;
+  final double dragIndicatorWidth;
   final EdgeInsetsGeometry? padding;
   final bool maintainContentGlass;
   final LiquidGlassSettings? fullStateContentSettings;
@@ -69,6 +70,7 @@ class _SheetLayout extends StatelessWidget {
     required this.child,
     required this.showDragIndicator,
     this.dragIndicatorColor,
+    required this.dragIndicatorWidth,
     this.padding,
     required this.maintainContentGlass,
     this.fullStateContentSettings,
@@ -81,7 +83,7 @@ class _SheetLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const handleZone = _SheetHandleZone();
+    final handleZone = _SheetHandleZone(indicatorWidth: dragIndicatorWidth);
 
     final contentZone = _SheetContent(
       scrollController: scrollController,
@@ -261,7 +263,7 @@ class _SheetLayout extends StatelessWidget {
                                       ),
                                     ),
                                     if (showDragIndicator)
-                                      const Positioned(
+                                      Positioned(
                                         top: 0,
                                         left: 0,
                                         right: 0,
@@ -319,7 +321,9 @@ class _SheetLayout extends StatelessWidget {
 // ===========================================================================
 
 class _SheetHandleZone extends StatelessWidget {
-  const _SheetHandleZone();
+  const _SheetHandleZone({required this.indicatorWidth});
+
+  final double indicatorWidth;
 
   @override
   Widget build(BuildContext context) {
@@ -331,7 +335,7 @@ class _SheetHandleZone extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           const SizedBox(height: 8),
-          _GlassDragIndicator(isGlass: isGlass),
+          _GlassDragIndicator(isGlass: isGlass, width: indicatorWidth),
           const SizedBox(height: 8),
         ],
       ),
@@ -340,9 +344,10 @@ class _SheetHandleZone extends StatelessWidget {
 }
 
 class _GlassDragIndicator extends StatelessWidget {
-  const _GlassDragIndicator({required this.isGlass});
+  const _GlassDragIndicator({required this.isGlass, required this.width});
 
   final bool isGlass;
+  final double width;
 
   @override
   Widget build(BuildContext context) {
@@ -355,7 +360,7 @@ class _GlassDragIndicator extends StatelessWidget {
       label: 'Drag handle',
       hint: 'Swipe down to dismiss',
       child: Container(
-        width: 36,
+        width: width,
         height: 4,
         decoration: BoxDecoration(
           color: defaultColor,
@@ -596,6 +601,12 @@ class GlassModalSheetScaffold extends StatelessWidget {
   /// Custom color for the drag handle.
   final Color? dragIndicatorColor;
 
+  /// Width of the drag handle pill in logical pixels. Defaults to 36
+  /// (iOS native). Bump higher (e.g. 64) for sheets where the handle
+  /// reads as the primary affordance and the thinner default feels
+  /// too subtle relative to the rest of the sheet's content.
+  final double dragIndicatorWidth;
+
   /// Whether to enable a gradient fade effect at the top.
   final bool enableTopFade;
 
@@ -660,6 +671,7 @@ class GlassModalSheetScaffold extends StatelessWidget {
     this.fillTransition = FillTransition.gradual,
     this.showDragIndicator = true,
     this.dragIndicatorColor,
+    this.dragIndicatorWidth = 36,
     this.glowColor,
     this.glowRadius = 1.5,
     this.suppressInteractionOnChildren = false,
@@ -723,6 +735,7 @@ class GlassModalSheetScaffold extends StatelessWidget {
           fillTransition: fillTransition,
           showDragIndicator: showDragIndicator,
           dragIndicatorColor: dragIndicatorColor,
+          dragIndicatorWidth: dragIndicatorWidth,
           glowColor: glowColor,
           glowRadius: glowRadius,
           suppressInteractionOnChildren: suppressInteractionOnChildren,

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -807,6 +807,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
           bottomRadius: metrics.bottomRadius,
           showDragIndicator: widget.showDragIndicator,
           dragIndicatorColor: widget.dragIndicatorColor,
+          dragIndicatorWidth: widget.dragIndicatorWidth,
           colorOpacity: metrics.colorOpacity,
           glassOpacity: metrics.glassOpacity,
           effectiveExpandedColor: metrics.effectiveExpandedColor,

--- a/test/widgets/overlays/glass_modal_sheet_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_test.dart
@@ -151,6 +151,47 @@ void main() {
       expect(widget.topBorderRadius, customRadius);
     });
 
+    testWidgets('dragIndicatorWidth defaults to 36 (iOS native)',
+        (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          child: Stack(
+            children: [
+              GlassModalSheet(
+                child: const SizedBox(height: 100),
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final widget =
+          tester.widget<GlassModalSheet>(find.byType(GlassModalSheet));
+      expect(widget.dragIndicatorWidth, 36);
+    });
+
+    testWidgets('respects custom dragIndicatorWidth', (tester) async {
+      const customWidth = 64.0;
+      await tester.pumpWidget(
+        createTestApp(
+          child: Stack(
+            children: [
+              GlassModalSheet(
+                dragIndicatorWidth: customWidth,
+                child: const SizedBox(height: 100),
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final widget =
+          tester.widget<GlassModalSheet>(find.byType(GlassModalSheet));
+      expect(widget.dragIndicatorWidth, customWidth);
+    });
+
     testWidgets('GlassInteractionSilence can be used in content',
         (tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
## Summary

Adds a public `dragIndicatorWidth` parameter to `GlassModalSheet`, its static `show()` factory, and `GlassModalSheetScaffold`. Default is `36` (logical pixels) — the existing hardcoded value, so behaviour is unchanged for every existing call site.

## Motivation

The iOS-native 36pt pill reads as a subtle hint when the sheet content is dense and the handle isn't the primary affordance — e.g. a maps-style sheet whose header includes a title + chips + a search field, where the user is more likely to tap a control than the handle. In those cases bumping the handle to ~56–64pt makes it visible enough to invite the drag gesture without crowding the header.

Apple themselves tune this — Music's queue sheet uses ~36pt while Maps' destination card uses a noticeably wider pill. Exposing the parameter removes the need for consumers to fork the package for what is otherwise a single hardcoded number.

## Plumbing

Same shape as the existing `dragIndicatorColor` plumbing:

```
GlassModalSheet
  → _GlassModalSheetState
    → _SheetLayout
      → _SheetHandleZone     (new constructor param: indicatorWidth)
        → _GlassDragIndicator (new constructor param: width)
```

`_SheetHandleZone` and `_GlassDragIndicator` lose their `const` constructors, since they now take a runtime value. The previously-`const` `Positioned` wrapping `handleZone` in `_SheetLayout.build` becomes non-const for the same reason — no behavioural impact, just no longer eligible for the const elision.

## Test plan

- [x] All 161 existing tests still pass.
- [x] New test: `dragIndicatorWidth defaults to 36 (iOS native)` — confirms backwards compat.
- [x] New test: `respects custom dragIndicatorWidth` — confirms a custom value (64) propagates to the public widget instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)