### PR TITLE
Pull Request: Refinement of GlassMenu Interaction & Physics Engine

### DIFF
--- a/docs/assets/GLASS_MENU_GUIDE.md
+++ b/docs/assets/GLASS_MENU_GUIDE.md
@@ -25,6 +25,7 @@ These parameters control how the menu responds to being touched and pressed.
 | :--- | :--- | :--- | :--- |
 | `interactionScale`| `double` | `1.02` | Squeeze effect applied to the container during touch interactions. `1.0` = no scale. |
 | `enableInteractionGlow`| `bool` | `true` | Enables/Disables the radial glare (glow) that follows the finger during touch. |
+| `glowOnTapOnly` | `bool` | `false` | When true, the interaction glow acts as a momentary tap indicator that fades out if the user starts dragging or stretching (>10px), instead of continuously tracking the finger. |
 | `glowColor` | `Color?` | `null` | Custom color for the interaction glare. Defaults to a subtle white (15% opacity). |
 | `glowRadius` | `double` | `0.6` | Size of the interaction glare relative to the container. |
 | `selectionColor`| `Color` | `0x3DFFFFFF`| Custom color for the sliding selection pill background. |

--- a/docs/assets/GLASS_MENU_GUIDE.md
+++ b/docs/assets/GLASS_MENU_GUIDE.md
@@ -9,11 +9,12 @@ The `GlassMenu` follows a "Trigger-to-Overlay" pattern where an initial widget m
 
 | Parameter | Type | Default | What it does (Technical Detail) |
 | :--- | :--- | :--- | :--- |
-| `items` | `List<Widget>` | **Required** | The payload of the menu. Supports `GlassMenuItem`, `GlassMenuDivider`, or any custom widget. |
+| `items` | `List<Widget>` | **Required** | The payload of the menu. Supports `GlassMenuItem`, `GlassMenuDivider`, `GlassMenuLabel`, or any custom widget. |
 | `trigger` | `Widget?` | `null` | A static widget that opens the menu on tap. Automatically wrapped in a gesture detector. |
 | `triggerBuilder` | `TriggerBuilder?`| `null` | Functional builder `(context, toggle)` for complex triggers needing direct control over the animation state. |
-| `menuWidth` | `double` | `200.0` | Target width of the expanded menu. If the trigger is wider, it will shrink during morph. |
-| `menuBorderRadius`| `double` | `32.0` | Target corner radius. Uses `Radius = Margin + InnerRadius` harmony (32 = 8 + 24). |
+| `menuWidth` | `double` | `200.0` | Target width of the expanded menu. |
+| `menuHeight` | `double?` | `null` | Optional fixed height. Enables internal scrolling if content exceeds this value. |
+| `menuBorderRadius`| `double` | `32.0` | Target corner radius. Uses `Radius = Margin + InnerRadius` harmony. |
 | `quality` | `GlassQuality?` | `null` | Rendering tier. If null, inherits from `GlassQualityScope`. |
 | `glassSettings` | `LiquidGlassSettings?` | `null` | Custom shader settings (blur, thickness, refractive index) for this specific menu. |
 
@@ -26,6 +27,7 @@ These parameters control how the menu responds to being touched and pressed.
 | `enableInteractionGlow`| `bool` | `true` | Enables/Disables the radial glare (glow) that follows the finger during touch. |
 | `glowColor` | `Color?` | `null` | Custom color for the interaction glare. Defaults to a subtle white (15% opacity). |
 | `glowRadius` | `double` | `0.6` | Size of the interaction glare relative to the container. |
+| `selectionColor`| `Color` | `0x3DFFFFFF`| Custom color for the sliding selection pill background. |
 
 ### 1.3 Stretching & Elasticity
 Control the "Liquid" physics of the menu when pulled beyond its boundaries or scrolled to the edge.
@@ -55,9 +57,19 @@ Control the "Liquid" physics of the menu when pulled beyond its boundaries or sc
 | `onTap` | `VoidCallback` | **Required** | Action to perform when the item is tapped. |
 | `isDestructive` | `bool` | `false` | Renders text/icon in `SystemRed` and applies distinct press logic. |
 | `enabled` | `bool` | `true` | When false, the item is grayed out and non-interactive. |
+| `titleStyle` | `TextStyle?` | `null` | Custom style for primary text. Overrides defaults. |
+| `subtitleStyle` | `TextStyle?` | `null` | Custom style for secondary text. Overrides defaults. |
+| `iconColor` | `Color?` | `null` | Custom color for the leading icon. |
+| `iconSize` | `double` | `20.0` | Custom size for the leading icon. |
 | `height` | `double` | `44.0` | Base height. Used by the parent's `_updateHoveredIndex` for tracking. |
 
-### 2.2 Visual Decoupling (Pixel Perfection)
+### 2.2 Smart Color Inheritance
+To reduce boilerplate, `GlassMenuItem` implements a color propagation system:
+*   **Priority**: `iconColor` > `titleStyle.color` > `isDestructive` (Red) > Default (White).
+*   **Inheritance**: If you set `iconColor`, the title and subtitle will automatically use that color unless they have their own `TextStyle.color`.
+*   **Subtitles**: Always inherit the base color but with **60% opacity** for visual hierarchy.
+
+### 2.3 Visual Decoupling (Pixel Perfection)
 To prevent "double-blur" artifacts, `GlassMenuItem` implements **Deferred Rendering**:
 - When `isSelected == true`, the item renders its background as `Colors.transparent`.
 - The parent `GlassMenu` renders a single `AnimatedPositioned` sliding pill at the item's coordinates.
@@ -100,25 +112,58 @@ GlassMenu(
 
 ---
 
-## 4. The Liquid Interaction Engine
-The `GlassMenu` uses a specialized version of the `LiquidStretch` renderer with directional constraints.
+## 4. Organizing with GlassMenuLabel
+`GlassMenuLabel` is a specialized, non-interactive widget designed for headers, section labels, or decorative content within the menu.
 
-### 4.1 Constrained Stretch
+### 4.1 Parameters
+| Parameter | Type | Default | What it does |
+| :--- | :--- | :--- | :--- |
+| `child` | `Widget` | **Required** | The label content (usually `Text` or `Icon`). |
+| `style` | `TextStyle?` | `null` | Default: 13px, w500, 60% white. Tailored for iOS headers. |
+
+### 4.2 Behavior
+*   **Interaction-Free**: Labels are completely ignored by the selection pill. Dragging across a label will not highlight it or trigger any action.
+*   **Logical Padding**: Automatically applies internal horizontal padding to align with `GlassMenuItem` text.
+
+---
+
+## 5. The Liquid Interaction Engine
+The `GlassMenu` uses a specialized version of the `LiquidStretch` renderer with directional constraints and scroll-aware selection logic.
+
+### 5.1 Constrained Stretch
 The menu automatically detects its position on the screen and limits elastic deformation:
 - **Vertical**: Stretches only **Down** (or **Up** if near the bottom of the screen).
 - **Horizontal**: Stretches only **Away** from the nearest screen edge.
 This prevents the menu from visually "breaking" the screen boundaries.
 
-### 4.2 The Sliding Pill Algorithm
-The `GlassMenu` manages a single selection highlight that tracks the user's finger.
+### 5.2 Tiered Interaction Zones
+The menu implements a three-tier gesture system to distinguish between precise selection, physical play, and intentional dismissal:
 
-1. **Geometry Mapping**: `_getItemOffset(index)` calculates the cumulative vertical position by summing the `height` of all previous widgets plus the `2px` item gap.
-2. **Hit Detection**: `_updateHoveredIndex(localPosition)` performs a linear scan through the `items` list, comparing the pointer's `y` coordinate (adjusted for `scrollOffset`) against pre-calculated item bounds.
-3. **Filtering**: Non-interactive widgets (like `GlassMenuDivider`) are skipped during the hit test to ensure the selection only snaps to actionable items.
+- **Zone 1: Active (0-20px)**
+  - A small buffer around the glass container.
+  - The selection pill is active and tracks the finger.
+  - Releasing the finger triggers the `onTap` action of the hovered item.
+
+- **Zone 2: Liquid (20-100px)**
+  - The "Physics Play" area.
+  - The selection pill is **deactivated** to prevent accidental triggers while stretching.
+  - Releasing the finger simply snaps the menu back to its original shape.
+
+- **Zone 3: Dismissal (>100px)**
+  - The "Pull-to-Dismiss" area.
+  - If the finger enters this zone, the menu enters a dismissal state.
+  - **Cancellation**: If the user moves their finger back into Zone 1 or 2 before releasing, the dismissal is aborted.
+  - **Release**: Releasing while in Zone 3 closes the menu.
+
+### 5.3 Scroll-Aware Selection
+To support `menuHeight` (fixed-size) menus with long lists, the selection engine distinguishes between scrolling and tapping:
+- **Displacement Check**: If the scroll offset changes by more than **10px** during a gesture, the selection pill is deactivated, and no `onTap` action is triggered upon release.
+- **Pill Sync**: The selection pill position is calculated as `ItemOffset - ScrollOffset`, ensuring it stays pinned to the correct item in the viewport during navigation.
+- **Edge-to-Edge Scrolling**: Vertical outer padding is eliminated in favor of internal spacers, allowing items to scroll seamlessly "under" the glass frame.
 
 ---
 
-## 5. Visual Fidelity & Rendering Tiers
+## 6. Visual Fidelity & Rendering Tiers
 The menu utilizes the library's multi-tier rendering architecture.
 
 | Quality | Feature Set | Implementation |
@@ -192,6 +237,7 @@ GlassMenu(
 
 ## 8. Geometry Logic Summary
 - **Item Gap**: `2.0px`.
-- **Vertical Padding**: `8.0px` (Top & Bottom).
+- **Vertical Padding**: `12.0px` (Top & Bottom, refined for spaciousness).
+- **Horizontal Padding**: `12.0px`.
 - **Radius Harmony**: `OuterRadius - Margin = InnerRadius`.
 - **Pill Animation**: `150ms` duration using `Curves.easeOutCubic` for a snappy, tactile feel.

--- a/docs/assets/GLASS_MENU_GUIDE.md
+++ b/docs/assets/GLASS_MENU_GUIDE.md
@@ -136,24 +136,18 @@ The menu automatically detects its position on the screen and limits elastic def
 - **Horizontal**: Stretches only **Away** from the nearest screen edge.
 This prevents the menu from visually "breaking" the screen boundaries.
 
-### 5.2 Tiered Interaction Zones
-The menu implements a three-tier gesture system to distinguish between precise selection, physical play, and intentional dismissal:
+### 5.2 Interaction & Safety Zones
+The menu implements a high-fidelity gesture engine that prioritizes physical play and prevents accidental closures:
 
-- **Zone 1: Active (0-20px)**
+- **Zone 1: Selection (0-20px)**
   - A small buffer around the glass container.
-  - The selection pill is active and tracks the finger.
-  - Releasing the finger triggers the `onTap` action of the hovered item.
+  - The selection pill tracks the finger.
+  - **Tap Guard**: Releasing the finger ONLY triggers a tap if the displacement (drag distance) is less than **10px**. This ensures that even small stretches within the active zone don't trigger items.
 
-- **Zone 2: Liquid (20-100px)**
-  - The "Physics Play" area.
-  - The selection pill is **deactivated** to prevent accidental triggers while stretching.
-  - Releasing the finger simply snaps the menu back to its original shape.
-
-- **Zone 3: Dismissal (>100px)**
-  - The "Pull-to-Dismiss" area.
-  - If the finger enters this zone, the menu enters a dismissal state.
-  - **Cancellation**: If the user moves their finger back into Zone 1 or 2 before releasing, the dismissal is aborted.
-  - **Release**: Releasing while in Zone 3 closes the menu.
+- **Zone 2: Liquid Play (>20px)**
+  - The extended interaction area.
+  - The selection pill is deactivated.
+  - **No Dismissal**: Pull-to-dismiss has been disabled. Users can stretch the menu indefinitely; releasing will always result in a smooth spring return to the original shape.
 
 ### 5.3 Scroll-Aware Selection
 To support `menuHeight` (fixed-size) menus with long lists, the selection engine distinguishes between scrolling and tapping:

--- a/docs/assets/GLASS_MENU_GUIDE.md
+++ b/docs/assets/GLASS_MENU_GUIDE.md
@@ -152,7 +152,8 @@ The menu implements a high-fidelity gesture engine that prioritizes physical pla
 ### 5.3 Scroll-Aware Selection
 To support `menuHeight` (fixed-size) menus with long lists, the selection engine distinguishes between scrolling and tapping:
 - **Displacement Check**: If the scroll offset changes by more than **10px** during a gesture, the selection pill is deactivated, and no `onTap` action is triggered upon release.
-- **Pill Sync**: The selection pill position is calculated as `ItemOffset - ScrollOffset`, ensuring it stays pinned to the correct item in the viewport during navigation.
+- **Pill Suppression**: In scrollable menus, the selection pill is automatically hidden during active finger movement (>10px) to prevent visual noise while navigating.
+- **Pill Sync**: The selection pill position is calculated as `ItemOffset - ScrollOffset`, ensuring it stays pinned to the correct item in the viewport during stationary touches.
 - **Edge-to-Edge Scrolling**: Vertical outer padding is eliminated in favor of internal spacers, allowing items to scroll seamlessly "under" the glass frame.
 
 ---

--- a/docs/assets/GLASS_MENU_GUIDE.md
+++ b/docs/assets/GLASS_MENU_GUIDE.md
@@ -1,0 +1,197 @@
+# Complete Guide to GlassMenu (Ultimate Edition)
+
+This is the definitive technical reference for the `GlassMenu` widget suite. It documents the architecture of the morphing interaction model, the selection pill tracking engine, and the precise geometric constraints that define the iOS 26 "Liquid Glass" experience.
+
+---
+
+## 1. Core Anatomy & Triggering
+The `GlassMenu` follows a "Trigger-to-Overlay" pattern where an initial widget morphs into a floating glass menu.
+
+| Parameter | Type | Default | What it does (Technical Detail) |
+| :--- | :--- | :--- | :--- |
+| `items` | `List<Widget>` | **Required** | The payload of the menu. Supports `GlassMenuItem`, `GlassMenuDivider`, or any custom widget. |
+| `trigger` | `Widget?` | `null` | A static widget that opens the menu on tap. Automatically wrapped in a gesture detector. |
+| `triggerBuilder` | `TriggerBuilder?`| `null` | Functional builder `(context, toggle)` for complex triggers needing direct control over the animation state. |
+| `menuWidth` | `double` | `200.0` | Target width of the expanded menu. If the trigger is wider, it will shrink during morph. |
+| `menuBorderRadius`| `double` | `32.0` | Target corner radius. Uses `Radius = Margin + InnerRadius` harmony (32 = 8 + 24). |
+| `quality` | `GlassQuality?` | `null` | Rendering tier. If null, inherits from `GlassQualityScope`. |
+| `glassSettings` | `LiquidGlassSettings?` | `null` | Custom shader settings (blur, thickness, refractive index) for this specific menu. |
+
+### 1.2 Interaction & Tactile Feedback
+These parameters control how the menu responds to being touched and pressed.
+
+| Parameter | Type | Default | What it does |
+| :--- | :--- | :--- | :--- |
+| `interactionScale`| `double` | `1.02` | Squeeze effect applied to the container during touch interactions. `1.0` = no scale. |
+| `enableInteractionGlow`| `bool` | `true` | Enables/Disables the radial glare (glow) that follows the finger during touch. |
+| `glowColor` | `Color?` | `null` | Custom color for the interaction glare. Defaults to a subtle white (15% opacity). |
+| `glowRadius` | `double` | `0.6` | Size of the interaction glare relative to the container. |
+
+### 1.3 Stretching & Elasticity
+Control the "Liquid" physics of the menu when pulled beyond its boundaries or scrolled to the edge.
+
+| Parameter | Type | Default | What it does |
+| :--- | :--- | :--- | :--- |
+| `stretch` | `double` | `0.5` | Elasticity factor. High values make the menu stretch more for the same drag distance. |
+| `stretchResistance`| `double` | `0.08` | "Stickiness" of the pull. Higher values make the menu feel heavier and harder to stretch. |
+| `stretchAxis` | `Axis?` | `null` | Constrain stretching to a single axis (`Axis.horizontal` or `Axis.vertical`). |
+| `allowPositiveXStretch`| `bool?` | `null` | Override: Allow pulling to the **Right**. If null, auto-calculated based on edge distance. |
+| `allowNegativeXStretch`| `bool?` | `null` | Override: Allow pulling to the **Left**. If null, auto-calculated based on edge distance. |
+| `allowPositiveYStretch`| `bool?` | `null` | Override: Allow pulling **Down**. If null, auto-calculated based on edge distance. |
+| `allowNegativeYStretch`| `bool?` | `null` | Override: Allow pulling **Up**. If null, auto-calculated based on edge distance. |
+
+---
+
+## 2. Mastering Menu Items (GlassMenuItem)
+`GlassMenuItem` is the primary interactive element. It is designed to work in tandem with the parent's sliding selection pill.
+
+### 2.1 Parameters
+| Parameter | Type | Default | What it does |
+| :--- | :--- | :--- | :--- |
+| `title` | `String` | **Required** | Primary label (17px, w400). |
+| `subtitle` | `String?` | `null` | Secondary text (13px, 60% opacity). Triggers a vertical layout (Column). |
+| `icon` | `Widget?` | `null` | Leading widget (usually 20px icon). Centered vertically. |
+| `trailing` | `Widget?` | `null` | Trailing widget (e.g., checkmark, shortcut). |
+| `onTap` | `VoidCallback` | **Required** | Action to perform when the item is tapped. |
+| `isDestructive` | `bool` | `false` | Renders text/icon in `SystemRed` and applies distinct press logic. |
+| `enabled` | `bool` | `true` | When false, the item is grayed out and non-interactive. |
+| `height` | `double` | `44.0` | Base height. Used by the parent's `_updateHoveredIndex` for tracking. |
+
+### 2.2 Visual Decoupling (Pixel Perfection)
+To prevent "double-blur" artifacts, `GlassMenuItem` implements **Deferred Rendering**:
+- When `isSelected == true`, the item renders its background as `Colors.transparent`.
+- The parent `GlassMenu` renders a single `AnimatedPositioned` sliding pill at the item's coordinates.
+- This ensures that as you drag your finger, the highlight "slides" smoothly without flickering or stacking layers.
+
+---
+
+## 3. Grouping with GlassMenuDivider
+The `GlassMenuDivider` is a non-interactive horizontal line used to organize menu items into logical groups. It is visually designed to be nearly invisible—a subtle "break" in the glass rather than a heavy separator.
+
+### 3.1 Parameters
+| Parameter | Type | Default | What it does |
+| :--- | :--- | :--- | :--- |
+| `height` | `double` | `12.0` | Total vertical space. The line is centered within this height. |
+| `color` | `Color?` | `null` | Custom color. Defaults to white with 15% opacity (hairline style). |
+| `indent` | `double` | `8.0` | Leading/Trailing padding for the line. |
+
+### 3.2 Visual Style
+*   **Hairline thickness**: The divider is exactly `0.5px` thick, ensuring it looks sharp on Retina displays.
+*   **Material Harmony**: It uses the same opacity logic as iOS 26 context menus, appearing as a translucent etch rather than a solid color.
+
+### 3.3 Technical Behavior (The "Jump" Logic)
+The `GlassMenu` selection engine is aware of dividers:
+*   **Zero Interaction**: Dividers do not respond to hover or drag.
+*   **Selection Skipping**: When you drag your finger across a divider, the selection pill "jumps" directly from the item above to the item below without stopping at the divider. This maintains the "Liquid" momentum.
+*   **Layout Weight**: Each divider adds its `height` plus the standard `2px` item gap to the total menu height.
+
+### 3.4 Usage Example
+```dart
+GlassMenu(
+  items: [
+    GlassMenuItem(title: 'Copy', icon: Icon(Icons.copy)),
+    GlassMenuItem(title: 'Paste', icon: Icon(Icons.paste)),
+    const GlassMenuDivider(height: 16, indent: 12), // Visual group break
+    GlassMenuItem(title: 'Delete', isDestructive: true),
+  ],
+  ...
+)
+```
+
+---
+
+## 4. The Liquid Interaction Engine
+The `GlassMenu` uses a specialized version of the `LiquidStretch` renderer with directional constraints.
+
+### 4.1 Constrained Stretch
+The menu automatically detects its position on the screen and limits elastic deformation:
+- **Vertical**: Stretches only **Down** (or **Up** if near the bottom of the screen).
+- **Horizontal**: Stretches only **Away** from the nearest screen edge.
+This prevents the menu from visually "breaking" the screen boundaries.
+
+### 4.2 The Sliding Pill Algorithm
+The `GlassMenu` manages a single selection highlight that tracks the user's finger.
+
+1. **Geometry Mapping**: `_getItemOffset(index)` calculates the cumulative vertical position by summing the `height` of all previous widgets plus the `2px` item gap.
+2. **Hit Detection**: `_updateHoveredIndex(localPosition)` performs a linear scan through the `items` list, comparing the pointer's `y` coordinate (adjusted for `scrollOffset`) against pre-calculated item bounds.
+3. **Filtering**: Non-interactive widgets (like `GlassMenuDivider`) are skipped during the hit test to ensure the selection only snaps to actionable items.
+
+---
+
+## 5. Visual Fidelity & Rendering Tiers
+The menu utilizes the library's multi-tier rendering architecture.
+
+| Quality | Feature Set | Implementation |
+| :--- | :--- | :--- |
+| **Minimal** | Basic Blur | `BackdropFilter` + `RRect` clipping. |
+| **Standard** | Liquid Glow | `GlassEffect` shader with specular rim and ambient saturation. |
+| **Premium** | Squircle (iOS) | `LiquidRoundedSuperellipse` math for perfect continuous curvature. |
+
+---
+
+## 6. The Recipe Book: Masterclass Scenarios
+
+### 1. iOS Context Menu (Modern Style)
+```dart
+GlassMenu(
+  menuWidth: 240,
+  menuBorderRadius: 32,
+  items: [
+    GlassMenuItem(
+      title: 'Open in New Window',
+      icon: Icon(Icons.open_in_new),
+      onTap: () {},
+    ),
+    GlassMenuItem(
+      title: 'Download Linked File',
+      icon: Icon(Icons.download),
+      onTap: () {},
+    ),
+    const GlassMenuDivider(),
+    GlassMenuItem(
+      title: 'Delete',
+      isDestructive: true,
+      icon: Icon(Icons.delete),
+      onTap: () {},
+    ),
+  ],
+  trigger: Icon(Icons.more_horiz),
+)
+```
+
+### 2. Information-Dense Menu (Subtitles)
+```dart
+GlassMenuItem(
+  title: 'Personal Account',
+  subtitle: 'sdegenar@liquid.design',
+  icon: CircleAvatar(child: Text('K')),
+  height: 60, // Taller for subtitle support
+  onTap: () {},
+)
+```
+
+### 3. Custom Trigger (Adaptive Morphing)
+```dart
+GlassMenu(
+  triggerBuilder: (context, toggle) => GestureDetector(
+    onTap: toggle,
+    child: MyPremiumCard(), // This card will morph into the menu
+  ),
+  items: [...],
+)
+```
+
+---
+
+## 7. Performance Checklist
+- [x] **RepaintBoundary**: Each `GlassMenuItem` is wrapped in a `RepaintBoundary` to isolate press animations from the rest of the menu.
+- [x] **Shader Pre-caching**: Use `LiquidGlass.initialize()` at the app root to warm up the superellipse shaders.
+- [x] **Scroll Synchronization**: The menu uses `ClampingScrollPhysics` to ensure that dragging to the edge of a long menu triggers the parent's `LiquidStretch` instead of a harsh scroll bounce.
+
+---
+
+## 8. Geometry Logic Summary
+- **Item Gap**: `2.0px`.
+- **Vertical Padding**: `8.0px` (Top & Bottom).
+- **Radius Harmony**: `OuterRadius - Margin = InnerRadius`.
+- **Pill Animation**: `150ms` duration using `Curves.easeOutCubic` for a snappy, tactile feel.

--- a/docs/assets/GLASS_MODAL_SHEETS_GUIDE.md
+++ b/docs/assets/GLASS_MODAL_SHEETS_GUIDE.md
@@ -119,6 +119,7 @@ Configure the realism of the glass and how it turns into a solid color.
 | :--- | :--- | :--- | :--- |
 | `interactionScale` | `double` | `1.01` | How much the sheet "squeezes" on touch. |
 | `enableInteractionGlow` | `bool` | `true` | Dynamic light glow following your touch point. |
+| `glowOnTapOnly` | `bool` | `false` | When true, the interaction glow acts as a momentary tap indicator that fades out if the user starts dragging (>10px), instead of tracking the finger. |
 | `enableSaturationGlow` | `bool` | `true` | Saturation pulse on the entire sheet background on touch. |
 | `glowColor` | `Color?` | `null` | Custom color for the tactile glare. |
 | `glowRadius` | `double` | `1.5` | Size of the touch glare effect. |

--- a/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
+++ b/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
@@ -108,7 +108,7 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
         ),
       ),
       bottomNavigationBar: Padding(
-        padding: EdgeInsets.only(bottom: sysBottom > 0 ? sysBottom - 25 : 0),
+        padding: EdgeInsets.only(bottom: sysBottom > 25 ? sysBottom - 25 : 0),
         child: GlassSearchableBottomBar(
           selectedIndex: _selectedTab,
           interactionBehavior: GlassInteractionBehavior.scaleOnly,

--- a/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
+++ b/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
@@ -366,7 +366,8 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
                     refractiveIndex: 1.2,
                     saturation: 1.2,
                   ),
-                  enableInteractionGlow: false,
+                  enableInteractionGlow: true,
+                  glowOnTapOnly: true,
                   glowRadius: 0.6,
                   interactionScale: 1.00,
                   triggerBuilder: (context, toggleMenu) => GlassButton(
@@ -632,6 +633,7 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
     GlassModalSheet.show(
       context: context,
       quality: widget.currentQuality,
+      glowOnTapOnly: true,
       builder: (context) => const GlassBackdropScope(
         child: BaseScenario(
           title: 'Standard Experience',

--- a/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
+++ b/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
@@ -447,6 +447,82 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
                     ),
                   ],
                 ),
+                const SizedBox(width: 16),
+
+                // 3. Photo configuration (Custom Widgets instead of Icons)
+                GlassMenu(
+                  menuWidth: 220,
+                  quality: widget.currentQuality,
+                  stretch: 0.0, // Disable liquid stretch physics
+                  glassSettings: LiquidGlassSettings(
+                    glassColor: Colors.transparent,
+                    thickness: 30,
+                    blur: 2,
+                    chromaticAberration: .01,
+                    lightAngle: GlassDefaults.lightAngle,
+                    lightIntensity: .5,
+                    ambientStrength: 0,
+                    refractiveIndex: 1.2,
+                    saturation: 1.2,
+                  ),
+                  enableInteractionGlow: false,
+                  glowRadius: 0.6,
+                  interactionScale: 1.00,
+                  triggerBuilder: (context, toggleMenu) => GlassButton(
+                    icon: const Icon(Icons.camera_alt_rounded),
+                    onTap: toggleMenu,
+                  ),
+                  items: [
+                    GlassMenuItem(
+                        title: 'Alice',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=1'),
+                        ),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Bob',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=2'),
+                        ),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Charlie',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=3'),
+                        ),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Diana',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=4'),
+                        ),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Ethan',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=5'),
+                        ),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Fiona',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=9'),
+                        ),
+                        onTap: () {}),
+                  ],
+                ),
               ],
             ),
           ],

--- a/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
+++ b/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
@@ -346,59 +346,106 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
               onTap: () => _showGlassPanel(context),
               color: Colors.green,
             ),
-            const SizedBox(height: 16),
-            GlassMenu(
-              menuWidth: 240,
-              quality: widget.currentQuality,
-              glassSettings: LiquidGlassSettings(
-                glassColor: Colors.transparent,
-                thickness: 30,
-                blur: 2,
-                chromaticAberration: .01,
-                lightAngle: GlassDefaults.lightAngle,
-                lightIntensity: .5,
-                ambientStrength: 0,
-                refractiveIndex: 1.2,
-                saturation: 1.2,
-                //specularSharpness: GlassSpecularSharpness.medium,
-              ),
-              enableInteractionGlow: false, // Show touch-following glare
-              glowRadius: 0.6,
-              interactionScale: 1.00,
-              triggerBuilder: (context, toggleMenu) => GlassButton(
-                icon: const Icon(Icons.menu_open_rounded),
-                onTap: toggleMenu,
-              ),
-              items: [
-                GlassMenuItem(
-                  title: 'Upgrade plan',
-                  icon: const Icon(Icons.upgrade),
-                  onTap: () {},
+            const SizedBox(height: 24),
+            const GlassMenuLabel(child: Text('MENU CONFIGURATIONS')),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                // 1. Basic configuration (User's original)
+                GlassMenu(
+                  menuWidth: 240,
+                  quality: widget.currentQuality,
+                  glassSettings: LiquidGlassSettings(
+                    glassColor: Colors.transparent,
+                    thickness: 30,
+                    blur: 2,
+                    chromaticAberration: .01,
+                    lightAngle: GlassDefaults.lightAngle,
+                    lightIntensity: .5,
+                    ambientStrength: 0,
+                    refractiveIndex: 1.2,
+                    saturation: 1.2,
+                  ),
+                  enableInteractionGlow: false,
+                  glowRadius: 0.6,
+                  interactionScale: 1.00,
+                  triggerBuilder: (context, toggleMenu) => GlassButton(
+                    icon: const Icon(Icons.menu_open_rounded),
+                    onTap: toggleMenu,
+                  ),
+                  items: [
+                    GlassMenuItem(
+                        title: 'Upgrade plan',
+                        icon: const Icon(Icons.upgrade),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Settings',
+                        icon: const Icon(Icons.settings),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Offline Pages',
+                        icon: const Icon(Icons.move_down_rounded),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Members',
+                        icon: const Icon(Icons.group_rounded),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Trash',
+                        icon: const Icon(Icons.delete_rounded),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Help & support',
+                        icon: const Icon(Icons.question_mark_rounded),
+                        onTap: () {}),
+                  ],
                 ),
-                GlassMenuItem(
-                  title: 'Settings',
-                  icon: const Icon(Icons.settings),
-                  onTap: () {},
-                ),
-                GlassMenuItem(
-                  title: 'Offline Pages',
-                  icon: const Icon(Icons.move_down_rounded),
-                  onTap: () {},
-                ),
-                GlassMenuItem(
-                  title: 'Members',
-                  icon: const Icon(Icons.group_rounded),
-                  onTap: () {},
-                ),
-                GlassMenuItem(
-                  title: 'Trash',
-                  icon: const Icon(Icons.delete_rounded),
-                  onTap: () {},
-                ),
-                GlassMenuItem(
-                  title: 'Help & support',
-                  icon: const Icon(Icons.question_mark_rounded),
-                  onTap: () {},
+                const SizedBox(width: 16),
+
+                // 2. Pro configuration (Advanced features)
+                GlassMenu(
+                  menuWidth: 260,
+                  menuHeight: 250, // Test scrolling
+                  quality: widget.currentQuality,
+                  selectionColor: Colors.blue.withValues(alpha: 0.3),
+                  triggerBuilder: (context, toggle) => GlassButton.custom(
+                    onTap: toggle,
+                    width: 56,
+                    height: 56,
+                    shape: const LiquidOval(),
+                    child: const Icon(CupertinoIcons.layers_alt,
+                        color: Colors.white),
+                  ),
+                  items: [
+                    const GlassMenuLabel(child: Text('PRIMARY ACTIONS')),
+                    GlassMenuItem(
+                      title: 'New Project',
+                      subtitle: 'Create from template',
+                      icon: const Icon(CupertinoIcons.add),
+                      onTap: () {},
+                    ),
+                    GlassMenuItem(
+                      title: 'Share Workspace',
+                      icon: const Icon(CupertinoIcons.share),
+                      iconColor: Colors.blueAccent, // Smart inheritance
+                      onTap: () {},
+                    ),
+                    const GlassMenuDivider(),
+                    const GlassMenuLabel(child: Text('MANAGEMENT')),
+                    GlassMenuItem(
+                      title: 'Settings',
+                      icon: const Icon(CupertinoIcons.settings),
+                      onTap: () {},
+                    ),
+                    const GlassMenuDivider(),
+                    const GlassMenuLabel(child: Text('DANGER ZONE')),
+                    GlassMenuItem(
+                      title: 'Delete Forever',
+                      isDestructive: true,
+                      icon: const Icon(CupertinoIcons.trash),
+                      onTap: () {},
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
+++ b/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
@@ -13,7 +13,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await LiquidGlassWidgets.initialize();
   runApp(LiquidGlassWidgets.wrap(
-      child: const ShowcaseApp(), adaptiveQuality: true));
+      child: const ShowcaseApp(), adaptiveQuality: false));
 }
 
 class ShowcaseApp extends StatefulWidget {
@@ -349,19 +349,34 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
             const SizedBox(height: 16),
             GlassMenu(
               menuWidth: 240,
-              triggerBuilder: (context, toggleMenu) => _buildScenarioTile(
-                title: 'Pull-Down Menu',
-                description: 'Tile morphs directly into a glass menu',
-                icon: Icons.menu_open_rounded,
+              quality: widget.currentQuality,
+              glassSettings: LiquidGlassSettings(
+                glassColor: Colors.transparent,
+                thickness: 30,
+                blur: 2,
+                chromaticAberration: .01,
+                lightAngle: GlassDefaults.lightAngle,
+                lightIntensity: .5,
+                ambientStrength: 0,
+                refractiveIndex: 1.2,
+                saturation: 1.2,
+                //specularSharpness: GlassSpecularSharpness.medium,
+              ),
+              enableInteractionGlow: true, // Show touch-following glare
+              glowRadius: 0.6,
+              interactionScale: 1.00,
+              triggerBuilder: (context, toggleMenu) => GlassButton(
+                icon: const Icon(Icons.menu_open_rounded),
                 onTap: toggleMenu,
-                color: Colors.purple,
               ),
               items: [
                 GlassMenuItem(
                   title: 'Edit Content',
+                  subtitle: 'Opens an edit view',
                   icon: const Icon(Icons.edit_rounded),
                   onTap: () {},
                 ),
+                const GlassMenuDivider(),
                 GlassMenuItem(
                   title: 'Share Scenario',
                   icon: const Icon(Icons.share_rounded),

--- a/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
+++ b/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
@@ -362,7 +362,7 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
                 saturation: 1.2,
                 //specularSharpness: GlassSpecularSharpness.medium,
               ),
-              enableInteractionGlow: true, // Show touch-following glare
+              enableInteractionGlow: false, // Show touch-following glare
               glowRadius: 0.6,
               interactionScale: 1.00,
               triggerBuilder: (context, toggleMenu) => GlassButton(
@@ -371,21 +371,33 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
               ),
               items: [
                 GlassMenuItem(
-                  title: 'Edit Content',
-                  subtitle: 'Opens an edit view',
-                  icon: const Icon(Icons.edit_rounded),
-                  onTap: () {},
-                ),
-                const GlassMenuDivider(),
-                GlassMenuItem(
-                  title: 'Share Scenario',
-                  icon: const Icon(Icons.share_rounded),
+                  title: 'Upgrade plan',
+                  icon: const Icon(Icons.upgrade),
                   onTap: () {},
                 ),
                 GlassMenuItem(
-                  title: 'Delete Demo',
+                  title: 'Settings',
+                  icon: const Icon(Icons.settings),
+                  onTap: () {},
+                ),
+                GlassMenuItem(
+                  title: 'Offline Pages',
+                  icon: const Icon(Icons.move_down_rounded),
+                  onTap: () {},
+                ),
+                GlassMenuItem(
+                  title: 'Members',
+                  icon: const Icon(Icons.group_rounded),
+                  onTap: () {},
+                ),
+                GlassMenuItem(
+                  title: 'Trash',
                   icon: const Icon(Icons.delete_rounded),
-                  isDestructive: true,
+                  onTap: () {},
+                ),
+                GlassMenuItem(
+                  title: 'Help & support',
+                  icon: const Icon(Icons.question_mark_rounded),
                   onTap: () {},
                 ),
               ],

--- a/lib/src/renderer/glass_glow.dart
+++ b/lib/src/renderer/glass_glow.dart
@@ -9,7 +9,7 @@ import '../../utils/glass_spring.dart';
 /// If placed as a descendant of a [GlassGlowLayer], this widget will
 /// send touch updates to that layer to create a glow effect.
 /// {@endtemplate}
-class GlassGlow extends StatelessWidget {
+class GlassGlow extends StatefulWidget {
   /// {@macro glass_glow}
   const GlassGlow({
     required this.child,
@@ -22,6 +22,7 @@ class GlassGlow extends StatelessWidget {
     this.clipper,
     this.hitTestBehavior = HitTestBehavior.opaque,
     this.enabled = true,
+    this.glowOnTapOnly = false,
     super.key,
   });
 
@@ -86,6 +87,13 @@ class GlassGlow extends StatelessWidget {
   /// [GlassGlowLayer].
   final bool enabled;
 
+  /// Whether the glow should act as a momentary tap indicator.
+  /// 
+  /// If true, the glow will appear on tap but will automatically fade out
+  /// if the user starts dragging (moving more than 10 pixels). It will not
+  /// reappear until a new tap starts.
+  final bool glowOnTapOnly;
+
   /// The child that will be painted above the glow effect.
   final Widget child;
 
@@ -94,20 +102,54 @@ class GlassGlow extends StatelessWidget {
   final CustomClipper<Path>? clipper;
 
   @override
+  State<GlassGlow> createState() => _GlassGlowState();
+}
+
+class _GlassGlowState extends State<GlassGlow> {
+  Offset? _initialPointerDown;
+  bool _glowSuppressed = false;
+
+  @override
   Widget build(BuildContext context) {
-    if (!enabled) return child;
+    if (!widget.enabled) return widget.child;
 
     return GlassGlowLayer(
-      clipper: clipper,
-      pulse: pulse,
+      clipper: widget.clipper,
+      pulse: widget.pulse,
       child: Builder(
         builder: (innerContext) => Listener(
-          behavior: hitTestBehavior,
-          onPointerDown: (event) => _handlePointer(innerContext, event),
-          onPointerMove: (event) => _handlePointer(innerContext, event),
-          onPointerUp: (event) => _removeTouch(innerContext),
-          onPointerCancel: (event) => _removeTouch(innerContext),
-          child: child,
+          behavior: widget.hitTestBehavior,
+          onPointerDown: (event) {
+            _initialPointerDown = event.localPosition;
+            _glowSuppressed = false;
+            _handlePointer(innerContext, event);
+          },
+          onPointerMove: (event) {
+            if (_glowSuppressed) return;
+
+            if (widget.glowOnTapOnly && _initialPointerDown != null) {
+              final distance =
+                  (event.localPosition - _initialPointerDown!).distance;
+              if (distance > 10.0) {
+                _glowSuppressed = true;
+                _removeTouch(innerContext);
+                return;
+              }
+            }
+
+            _handlePointer(innerContext, event);
+          },
+          onPointerUp: (event) {
+            _glowSuppressed = false;
+            _initialPointerDown = null;
+            _removeTouch(innerContext);
+          },
+          onPointerCancel: (event) {
+            _glowSuppressed = false;
+            _initialPointerDown = null;
+            _removeTouch(innerContext);
+          },
+          child: widget.child,
         ),
       ),
     );
@@ -138,11 +180,11 @@ class GlassGlow extends StatelessWidget {
 
     layerState.updateTouch(
       pos,
-      radius: glowRadius,
-      color: glowColor,
-      blurRadius: glowBlurRadius,
-      spreadRadius: glowSpreadRadius,
-      opacity: glowOpacity,
+      radius: widget.glowRadius,
+      color: widget.glowColor,
+      blurRadius: widget.glowBlurRadius,
+      spreadRadius: widget.glowSpreadRadius,
+      opacity: widget.glowOpacity,
     );
   }
 

--- a/lib/src/renderer/glass_glow.dart
+++ b/lib/src/renderer/glass_glow.dart
@@ -21,6 +21,7 @@ class GlassGlow extends StatelessWidget {
     this.pulse = 0,
     this.clipper,
     this.hitTestBehavior = HitTestBehavior.opaque,
+    this.enabled = true,
     super.key,
   });
 
@@ -79,6 +80,12 @@ class GlassGlow extends StatelessWidget {
   /// Defaults to [HitTestBehavior.opaque].
   final HitTestBehavior hitTestBehavior;
 
+  /// Whether the glow effect is enabled.
+  ///
+  /// If false, this widget will not register touch updates with the
+  /// [GlassGlowLayer].
+  final bool enabled;
+
   /// The child that will be painted above the glow effect.
   final Widget child;
 
@@ -88,6 +95,8 @@ class GlassGlow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (!enabled) return child;
+
     return GlassGlowLayer(
       clipper: clipper,
       pulse: pulse,

--- a/lib/src/renderer/stretch.dart
+++ b/lib/src/renderer/stretch.dart
@@ -261,9 +261,19 @@ class RenderRawLiquidStretch extends RenderProxyBox {
       return;
     }
 
-    // Check if the matrix is singular
+    // Check if the matrix is singular or has non-finite values
     final det = transform.determinant();
     if (det == 0 || !det.isFinite) {
+      layer = null;
+      return;
+    }
+
+    // Safety check for extremely small scales that break Impeller glyph bounds
+    final storage = transform.storage;
+    final scaleX = storage[0].abs();
+    final scaleY = storage[5].abs();
+    if (scaleX < 0.0001 || scaleY < 0.0001) {
+      // Don't paint if it's too small to be meaningful (prevents glyph errors)
       layer = null;
       return;
     }
@@ -358,6 +368,11 @@ class RenderRawLiquidStretch extends RenderProxyBox {
 
     var finalScaleX = baseScaleX * volumeCorrection;
     var finalScaleY = baseScaleY * volumeCorrection;
+
+    // Safety clamp: Ensure scale is finite and doesn't collapse to zero
+    // which causes Impeller font glyph bounds errors.
+    if (!finalScaleX.isFinite || finalScaleX < 0.01) finalScaleX = 0.01;
+    if (!finalScaleY.isFinite || finalScaleY < 0.01) finalScaleY = 0.01;
 
     // If axis is constrained, don't affect the other dimension
     if (_axis == Axis.vertical) {

--- a/lib/src/renderer/stretch.dart
+++ b/lib/src/renderer/stretch.dart
@@ -23,6 +23,10 @@ class LiquidStretch extends StatelessWidget {
     this.axis,
     this.allowPositive = true,
     this.allowNegative = true,
+    this.allowPositiveX,
+    this.allowNegativeX,
+    this.allowPositiveY,
+    this.allowNegativeY,
     this.suppressInteractionOnChildren = true,
     super.key,
   });
@@ -68,13 +72,23 @@ class LiquidStretch extends StatelessWidget {
   /// The axis to constrain the stretch to. If null, stretches in both axes.
   final Axis? axis;
 
-  /// Whether to allow stretch in the positive direction of the axis.
-  /// If [axis] is vertical, positive is down. If horizontal, positive is right.
+  /// Whether to allow stretch in the positive direction (Right/Down).
   final bool allowPositive;
 
-  /// Whether to allow stretch in the negative direction of the axis.
-  /// If [axis] is vertical, negative is up. If horizontal, negative is left.
+  /// Whether to allow stretch in the negative direction (Left/Up).
   final bool allowNegative;
+
+  /// Optional override for positive X direction (Right).
+  final bool? allowPositiveX;
+
+  /// Optional override for negative X direction (Left).
+  final bool? allowNegativeX;
+
+  /// Optional override for positive Y direction (Down).
+  final bool? allowPositiveY;
+
+  /// Optional override for negative Y direction (Up).
+  final bool? allowNegativeY;
 
   /// Whether to prevent scaling when interacting with children.
   final bool suppressInteractionOnChildren;
@@ -91,7 +105,6 @@ class LiquidStretch extends StatelessWidget {
     // mount a fresh one — which is exactly the regression we fixed in
     // lightweight_liquid_glass.dart.  Always returning `GlassDragBuilder`
     // keeps the tree structure stable throughout the animation.
-
     return GlassDragBuilder(
       behavior: hitTestBehavior,
       suppressInteractionOnChildren: suppressInteractionOnChildren,
@@ -115,18 +128,16 @@ class LiquidStretch extends StatelessWidget {
               } else if (axis == Axis.vertical) {
                 o = Offset(0, o.dy);
               }
-              if (!allowPositive) {
-                o = Offset(
-                  o.dx > 0 ? 0 : o.dx,
-                  o.dy > 0 ? 0 : o.dy,
-                );
-              }
-              if (!allowNegative) {
-                o = Offset(
-                  o.dx < 0 ? 0 : o.dx,
-                  o.dy < 0 ? 0 : o.dy,
-                );
-              }
+              final pX = allowPositiveX ?? allowPositive;
+              final nX = allowNegativeX ?? allowNegative;
+              final pY = allowPositiveY ?? allowPositive;
+              final nY = allowNegativeY ?? allowNegative;
+
+              if (!pX && o.dx > 0) o = Offset(0, o.dy);
+              if (!nX && o.dx < 0) o = Offset(0, o.dy);
+              if (!pY && o.dy > 0) o = Offset(o.dx, 0);
+              if (!nY && o.dy < 0) o = Offset(o.dx, 0);
+
               return o;
             }(),
             spring: value == null

--- a/lib/widgets/containers/glass_container.dart
+++ b/lib/widgets/containers/glass_container.dart
@@ -89,6 +89,7 @@ class GlassContainer extends StatelessWidget {
     this.clipBehavior = Clip.none,
     this.alignment,
     this.allowElevation = false,
+    this.glowIntensity = 0.0,
   });
 
   // ===========================================================================
@@ -199,6 +200,14 @@ class GlassContainer extends StatelessWidget {
   /// Defaults to false.
   final bool allowElevation;
 
+  /// Interactive glow intensity for Skia/Web (0.0-1.0).
+  ///
+  /// On Impeller, this is ignored and GlassGlow widget is used instead.
+  /// On Skia/Web, this controls shader-based button press feedback.
+  ///
+  /// Defaults to 0.0 (no glow).
+  final double glowIntensity;
+
   @override
   Widget build(BuildContext context) {
     // Inherit quality from parent layer if not explicitly set
@@ -240,6 +249,7 @@ class GlassContainer extends StatelessWidget {
       useOwnLayer: useOwnLayer,
       clipBehavior: clipBehavior,
       allowElevation: allowElevation, // Configurable elevation behavior
+      glowIntensity: glowIntensity,
       child: InheritedLiquidGlass(
         settings: effectiveSettings,
         quality: effectiveQuality,

--- a/lib/widgets/interactive/glass_pull_down_button.dart
+++ b/lib/widgets/interactive/glass_pull_down_button.dart
@@ -107,8 +107,10 @@ class GlassPullDownButton extends StatelessWidget {
         if (onSelected != null) {
           return GlassMenuItem(
             title: item.title,
+            subtitle: item.subtitle,
             icon: item.icon,
             isDestructive: item.isDestructive,
+            enabled: item.enabled,
             onTap: () {
               item.onTap.call();
               onSelected!(item.title);

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -696,19 +696,27 @@ class _GlassMenuState extends State<GlassMenu>
         dy < visibleHeight + 20;
 
     if (isWithinActiveZone) {
-      for (int i = 0; i < widget.items.length; i++) {
-      final item = widget.items[i];
-      final itemHeight = _getItemHeight(item);
+      // In scrollable menus, we disable pill tracking during significant movement
+      // to prevent visual noise and overlapping highlights during scrolling.
+      final isScrollable = widget.menuHeight != null;
+      final hasMoved =
+          _isDragging && (localPosition - _initialLocalPosition).distance > 10;
 
-      if (y >= currentOffset && y <= currentOffset + itemHeight) {
-        // Only select interactive items
-        if (item is GlassMenuItem) {
-          detectedIndex = i;
+      if (!isScrollable || !hasMoved) {
+        for (int i = 0; i < widget.items.length; i++) {
+          final item = widget.items[i];
+          final itemHeight = _getItemHeight(item);
+
+          if (y >= currentOffset && y <= currentOffset + itemHeight) {
+            // Only select interactive items
+            if (item is GlassMenuItem) {
+              detectedIndex = i;
+            }
+            break;
+          }
+          currentOffset += itemHeight + 2.0; // height + 2px gap
         }
-        break;
       }
-      currentOffset += itemHeight + 2.0; // height + 2px gap
-    }
     }
 
     _hoveredIndex = detectedIndex;

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -494,8 +494,8 @@ class _GlassMenuState extends State<GlassMenu>
                             AnimatedPositioned(
                               duration: const Duration(milliseconds: 150),
                               curve: Curves.easeOutCubic,
-                              left: 8,
-                              right: 8,
+                              left: 12,
+                              right: 12,
                               top: _getItemOffset(_hoveredIndex!),
                               height:
                                   _getItemHeight(widget.items[_hoveredIndex!]),
@@ -548,7 +548,7 @@ class _GlassMenuState extends State<GlassMenu>
                                   currentWidth, // Force exact container width
                               child: Padding(
                                 padding: const EdgeInsets.symmetric(
-                                    vertical: 8, horizontal: 8),
+                                    vertical: 12, horizontal: 12),
                                 child: SingleChildScrollView(
                                   controller: _scrollController,
                                   physics:
@@ -590,7 +590,7 @@ class _GlassMenuState extends State<GlassMenu>
   }
 
   double _getItemOffset(int index) {
-    double offset = 8.0; // Top padding
+    double offset = 12.0; // Top padding
     for (int i = 0; i < index; i++) {
       offset += _getItemHeight(widget.items[i]) + 2.0; // height + 2px gap
     }

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -111,6 +111,15 @@ class GlassMenu extends StatefulWidget {
   /// Radius of the touch interaction glow. Default: 0.6.
   final double glowRadius;
 
+  /// Custom color for the menu selection background.
+  final Color selectionColor;
+
+  /// Optional fixed height for the menu.
+  ///
+  /// If null, the menu will size itself to fit its items.
+  /// If provided, the menu will have a fixed height and internal scrolling.
+  final double? menuHeight;
+
   /// Creates a liquid glass menu.
   const GlassMenu({
     super.key,
@@ -129,6 +138,8 @@ class GlassMenu extends StatefulWidget {
     this.allowNegativeXStretch,
     this.allowPositiveYStretch,
     this.allowNegativeYStretch,
+    this.menuHeight,
+    this.selectionColor = const Color(0x3DFFFFFF),
     this.enableInteractionGlow = true,
     this.glowColor,
     this.glowRadius = 0.6,
@@ -150,6 +161,9 @@ class _GlassMenuState extends State<GlassMenu>
   double? _triggerBorderRadius;
   int? _hoveredIndex;
   bool _isDragging = false;
+  bool _hasStretched =
+      false; // Prevents closing if we moved into stretch territory
+  double _initialScrollOffset = 0.0;
 
   // iOS 26 Liquid Glass smooth spring physics
   // Gentle, fluid motion with subtle overshoot - NOT harsh bounces
@@ -369,10 +383,10 @@ class _GlassMenuState extends State<GlassMenu>
       (sum, item) => sum + _getItemHeight(item),
     );
 
-    // Add vertical padding (8px top + 8px bottom = 16px total)
+    // Add vertical padding (12px top + 12px bottom = 24px total)
     // plus vertical gaps between items (2px each)
     final gaps = (widget.items.length - 1) * 2.0;
-    return itemHeights + 16.0 + gaps;
+    return itemHeights + 24.0 + gaps;
   }
 
   Widget _buildMorphingContainer(double value) {
@@ -391,9 +405,10 @@ class _GlassMenuState extends State<GlassMenu>
     final currentWidth =
         lerpDouble(_triggerSize!.width, widget.menuWidth, value)!;
 
+    final targetHeight = widget.menuHeight ?? menuHeight;
     final currentHeight = value < 0.85
-        ? lerpDouble(_triggerSize!.height, menuHeight, value)!
-        : null; // Natural height when nearly expanded (prevents overflow)
+        ? lerpDouble(_triggerSize!.height, targetHeight, value)!
+        : widget.menuHeight; // Natural height (null) or fixed height
 
     // Interpolate border radius: circular button -> rounded menu
     final currentBorderRadius = lerpDouble(
@@ -476,7 +491,7 @@ class _GlassMenuState extends State<GlassMenu>
               shape:
                   LiquidRoundedSuperellipse(borderRadius: currentBorderRadius),
               clipBehavior:
-                  Clip.none, // High-fidelity clipping handled by AdaptiveGlass
+                  Clip.antiAlias, // Clip items at the edges for edge-to-edge feel
               child: Stack(
                 alignment: _morphAlignment, // Align internal stack content
                 clipBehavior:
@@ -496,12 +511,15 @@ class _GlassMenuState extends State<GlassMenu>
                               curve: Curves.easeOutCubic,
                               left: 12,
                               right: 12,
-                              top: _getItemOffset(_hoveredIndex!),
+                              top: _getItemOffset(_hoveredIndex!) -
+                                  (_scrollController.hasClients
+                                      ? _scrollController.offset
+                                      : 0.0),
                               height:
                                   _getItemHeight(widget.items[_hoveredIndex!]),
                               child: Container(
                                 decoration: BoxDecoration(
-                                  color: const Color(0x3DFFFFFF), // ~24% white
+                                  color: widget.selectionColor,
                                   borderRadius: BorderRadius.circular(24),
                                   border: Border.all(
                                     color: const Color(
@@ -515,6 +533,11 @@ class _GlassMenuState extends State<GlassMenu>
                             onPointerDown: (event) {
                               setState(() {
                                 _isDragging = true;
+                                _hasStretched = false;
+                                _initialScrollOffset =
+                                    _scrollController.hasClients
+                                        ? _scrollController.offset
+                                        : 0.0;
                                 _updateHoveredIndex(event.localPosition);
                               });
                             },
@@ -525,16 +548,33 @@ class _GlassMenuState extends State<GlassMenu>
                               }
                             },
                             onPointerUp: (event) {
-                              if (_isDragging && _hoveredIndex != null) {
-                                final item = widget.items[_hoveredIndex!];
-                                if (item is GlassMenuItem) {
-                                  item.onTap();
+                              if (_isDragging) {
+                                if (_hasStretched) {
+                                  // Pull-to-dismiss triggered
+                                  _closeMenu();
+                                } else if (_hoveredIndex != null) {
+                                  // Only trigger tap if we didn't scroll much
+                                  final currentOffset =
+                                      _scrollController.hasClients
+                                          ? _scrollController.offset
+                                          : 0.0;
+                                  final scrollDisplacement =
+                                      (currentOffset - _initialScrollOffset)
+                                          .abs();
+
+                                  if (scrollDisplacement < 10) {
+                                    final item = widget.items[_hoveredIndex!];
+                                    if (item is GlassMenuItem) {
+                                      item.onTap();
+                                    }
+                                    _closeMenu();
+                                  }
                                 }
-                                _closeMenu();
                               }
                               setState(() {
                                 _isDragging = false;
                                 _hoveredIndex = null;
+                                _hasStretched = false;
                               });
                             },
                             onPointerCancel: (_) {
@@ -544,11 +584,11 @@ class _GlassMenuState extends State<GlassMenu>
                               });
                             },
                             child: SizedBox(
-                              width:
-                                  currentWidth, // Force exact container width
+                              width: currentWidth,
+                              height: widget.menuHeight, // Apply fixed height
                               child: Padding(
-                                padding: const EdgeInsets.symmetric(
-                                    vertical: 12, horizontal: 12),
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 12),
                                 child: SingleChildScrollView(
                                   controller: _scrollController,
                                   physics:
@@ -558,6 +598,8 @@ class _GlassMenuState extends State<GlassMenu>
                                     crossAxisAlignment:
                                         CrossAxisAlignment.stretch,
                                     children: [
+                                      const SizedBox(
+                                          height: 12), // Inner top padding
                                       for (var i = 0;
                                           i < widget.items.length;
                                           i++) ...[
@@ -565,6 +607,8 @@ class _GlassMenuState extends State<GlassMenu>
                                         if (i < widget.items.length - 1)
                                           const SizedBox(height: 2),
                                       ],
+                                      const SizedBox(
+                                          height: 12), // Inner bottom padding
                                     ],
                                   ),
                                 ),
@@ -586,6 +630,7 @@ class _GlassMenuState extends State<GlassMenu>
   double _getItemHeight(Widget item) {
     if (item is GlassMenuItem) return item.height;
     if (item is GlassMenuDivider) return item.height;
+    if (item is GlassMenuLabel) return item.height;
     return 44.0;
   }
 
@@ -618,12 +663,36 @@ class _GlassMenuState extends State<GlassMenu>
   }
 
   void _updateHoveredIndex(Offset localPosition) {
-    final y = localPosition.dy + _scrollController.offset;
+    // Detect if we've moved into "stretch territory" (outside visible menu bounds)
+    // We use the visible container height if fixed, otherwise the natural height.
+    final visibleHeight = widget.menuHeight ?? _calculateMenuHeight();
+    final x = localPosition.dx;
+    final dy = localPosition.dy;
 
-    double currentOffset = 8.0;
+    // We add a 100px buffer to allow for intense liquid stretching without accidental closure.
+    // We also allow cancelling the stretch if the user moves their finger back.
+    final outsideBounds = dy < -100 ||
+        dy > visibleHeight + 100 ||
+        x < -100 ||
+        x > widget.menuWidth + 100;
+
+    if (_hasStretched != outsideBounds) {
+      setState(() => _hasStretched = outsideBounds);
+    }
+    final y = dy + (_scrollController.hasClients ? _scrollController.offset : 0.0);
+
+    double currentOffset = 12.0;
     int? detectedIndex;
 
-    for (int i = 0; i < widget.items.length; i++) {
+    // Only allow selecting items if we are within a small "active" buffer (20px)
+    // This prevents triggering items while intentionally stretching the menu.
+    final isWithinActiveZone = x > -20 &&
+        x < widget.menuWidth + 20 &&
+        dy > -20 &&
+        dy < visibleHeight + 20;
+
+    if (isWithinActiveZone) {
+      for (int i = 0; i < widget.items.length; i++) {
       final item = widget.items[i];
       final itemHeight = _getItemHeight(item);
 
@@ -635,6 +704,7 @@ class _GlassMenuState extends State<GlassMenu>
         break;
       }
       currentOffset += itemHeight + 2.0; // height + 2px gap
+    }
     }
 
     _hoveredIndex = detectedIndex;

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -164,6 +164,7 @@ class _GlassMenuState extends State<GlassMenu>
   bool _hasStretched =
       false; // Prevents closing if we moved into stretch territory
   double _initialScrollOffset = 0.0;
+  Offset _initialLocalPosition = Offset.zero;
 
   // iOS 26 Liquid Glass smooth spring physics
   // Gentle, fluid motion with subtle overshoot - NOT harsh bounces
@@ -534,6 +535,7 @@ class _GlassMenuState extends State<GlassMenu>
                               setState(() {
                                 _isDragging = true;
                                 _hasStretched = false;
+                                _initialLocalPosition = event.localPosition;
                                 _initialScrollOffset =
                                     _scrollController.hasClients
                                         ? _scrollController.offset
@@ -549,11 +551,8 @@ class _GlassMenuState extends State<GlassMenu>
                             },
                             onPointerUp: (event) {
                               if (_isDragging) {
-                                if (_hasStretched) {
-                                  // Pull-to-dismiss triggered
-                                  _closeMenu();
-                                } else if (_hoveredIndex != null) {
-                                  // Only trigger tap if we didn't scroll much
+                                if (_hoveredIndex != null) {
+                                  // Only trigger tap if we didn't scroll or drag much (prevents selection during stretching)
                                   final currentOffset =
                                       _scrollController.hasClients
                                           ? _scrollController.offset
@@ -561,8 +560,13 @@ class _GlassMenuState extends State<GlassMenu>
                                   final scrollDisplacement =
                                       (currentOffset - _initialScrollOffset)
                                           .abs();
+                                  final dragDisplacement =
+                                      (event.localPosition -
+                                              _initialLocalPosition)
+                                          .distance;
 
-                                  if (scrollDisplacement < 10) {
+                                  if (scrollDisplacement < 10 &&
+                                      dragDisplacement < 10) {
                                     final item = widget.items[_hoveredIndex!];
                                     if (item is GlassMenuItem) {
                                       item.onTap();
@@ -570,12 +574,12 @@ class _GlassMenuState extends State<GlassMenu>
                                     _closeMenu();
                                   }
                                 }
+                                setState(() {
+                                  _isDragging = false;
+                                  _hoveredIndex = null;
+                                  _hasStretched = false;
+                                });
                               }
-                              setState(() {
-                                _isDragging = false;
-                                _hoveredIndex = null;
-                                _hasStretched = false;
-                              });
                             },
                             onPointerCancel: (_) {
                               setState(() {

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -105,6 +105,13 @@ class GlassMenu extends StatefulWidget {
   /// Whether to show glow/glare on touch for tactile feedback. Default: true.
   final bool enableInteractionGlow;
 
+  /// Whether the glow should act as a momentary tap indicator.
+  /// 
+  /// If true, the glow will appear on tap but will automatically fade out
+  /// if the user starts dragging. It will not reappear until a new tap starts.
+  /// Default: false.
+  final bool glowOnTapOnly;
+
   /// Custom color for the touch interaction glow.
   final Color? glowColor;
 
@@ -141,6 +148,7 @@ class GlassMenu extends StatefulWidget {
     this.menuHeight,
     this.selectionColor = const Color(0x3DFFFFFF),
     this.enableInteractionGlow = true,
+    this.glowOnTapOnly = false,
     this.glowColor,
     this.glowRadius = 0.6,
   }) : assert(trigger != null || triggerBuilder != null,
@@ -473,6 +481,7 @@ class _GlassMenuState extends State<GlassMenu>
               widget.allowNegativeYStretch ?? (_morphAlignment.y > 0),
           child: GlassGlow(
             enabled: widget.enableInteractionGlow,
+            glowOnTapOnly: widget.glowOnTapOnly,
             glowColor: widget.glowColor ?? Colors.white.withValues(alpha: 0.15),
             glowRadius: widget.glowRadius,
             glowBlurRadius: 40,

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -55,14 +55,16 @@ class GlassMenu extends StatefulWidget {
       triggerBuilder;
 
   /// The list of items to display in the menu.
-  final List<GlassMenuItem> items;
+  ///
+  /// Typically contains [GlassMenuItem] and [GlassMenuDivider].
+  final List<Widget> items;
 
   /// Width of the expanded menu.
   final double menuWidth;
 
   /// Border radius of the expanded menu.
   ///
-  /// Defaults to 16.0 to match iOS 26 liquid glass menus.
+  /// Defaults to 28.0 for a modern rounded look.
   final double menuBorderRadius;
 
   /// Custom glass settings for the menu container.
@@ -71,6 +73,44 @@ class GlassMenu extends StatefulWidget {
   /// Rendering quality for the glass effect.
   final GlassQuality? quality;
 
+  /// Liquid stretch factor. Default: 0.5.
+  final double stretch;
+
+  /// Scale factor applied on touch. Default: 1.02.
+  final double interactionScale;
+
+  /// The resistance factor to apply to the drag offset.
+  /// Higher values make the drag feel "stickier". Default: 0.08.
+  final double stretchResistance;
+
+  /// The axis to constrain the stretch to. If null, stretches in both axes.
+  final Axis? stretchAxis;
+
+  /// Whether to allow stretch in the positive X direction (Right).
+  /// If null, automatically determined by menu position.
+  final bool? allowPositiveXStretch;
+
+  /// Whether to allow stretch in the negative X direction (Left).
+  /// If null, automatically determined by menu position.
+  final bool? allowNegativeXStretch;
+
+  /// Whether to allow stretch in the positive Y direction (Down).
+  /// If null, automatically determined by menu position.
+  final bool? allowPositiveYStretch;
+
+  /// Whether to allow stretch in the negative Y direction (Up).
+  /// If null, automatically determined by menu position.
+  final bool? allowNegativeYStretch;
+
+  /// Whether to show glow/glare on touch for tactile feedback. Default: true.
+  final bool enableInteractionGlow;
+
+  /// Custom color for the touch interaction glow.
+  final Color? glowColor;
+
+  /// Radius of the touch interaction glow. Default: 0.6.
+  final double glowRadius;
+
   /// Creates a liquid glass menu.
   const GlassMenu({
     super.key,
@@ -78,9 +118,20 @@ class GlassMenu extends StatefulWidget {
     this.triggerBuilder,
     required this.items,
     this.menuWidth = 200,
-    this.menuBorderRadius = 16.0,
+    this.menuBorderRadius = 32.0,
     this.glassSettings,
     this.quality,
+    this.stretch = 0.5,
+    this.interactionScale = 1.02,
+    this.stretchResistance = 0.08,
+    this.stretchAxis,
+    this.allowPositiveXStretch,
+    this.allowNegativeXStretch,
+    this.allowPositiveYStretch,
+    this.allowNegativeYStretch,
+    this.enableInteractionGlow = true,
+    this.glowColor,
+    this.glowRadius = 0.6,
   }) : assert(trigger != null || triggerBuilder != null,
             'Either trigger or triggerBuilder must be provided');
 
@@ -89,13 +140,16 @@ class GlassMenu extends StatefulWidget {
 }
 
 class _GlassMenuState extends State<GlassMenu>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   final LayerLink _layerLink = LayerLink();
   final OverlayPortalController _overlayController = OverlayPortalController();
 
   late final AnimationController _animationController;
+  late final ScrollController _scrollController;
   Size? _triggerSize;
   double? _triggerBorderRadius;
+  int? _hoveredIndex;
+  bool _isDragging = false;
 
   // iOS 26 Liquid Glass smooth spring physics
   // Gentle, fluid motion with subtle overshoot - NOT harsh bounces
@@ -130,11 +184,13 @@ class _GlassMenuState extends State<GlassMenu>
         _overlayController.hide();
       }
     });
+    _scrollController = ScrollController();
   }
 
   @override
   void dispose() {
     _animationController.dispose();
+    _scrollController.dispose();
     super.dispose();
   }
 
@@ -236,6 +292,10 @@ class _GlassMenuState extends State<GlassMenu>
   }
 
   void _closeMenu() {
+    setState(() {
+      _hoveredIndex = null;
+      _isDragging = false;
+    });
     _runSpring(0.0);
   }
 
@@ -306,11 +366,13 @@ class _GlassMenuState extends State<GlassMenu>
     // Sum all menu item heights (each defaults to 44.0)
     final itemHeights = widget.items.fold<double>(
       0.0,
-      (sum, item) => sum + item.height,
+      (sum, item) => sum + _getItemHeight(item),
     );
 
     // Add vertical padding (8px top + 8px bottom = 16px total)
-    return itemHeights + 16.0;
+    // plus vertical gaps between items (2px each)
+    final gaps = (widget.items.length - 1) * 2.0;
+    return itemHeights + 16.0 + gaps;
   }
 
   Widget _buildMorphingContainer(double value) {
@@ -377,12 +439,30 @@ class _GlassMenuState extends State<GlassMenu>
     return RepaintBoundary(
       child: Opacity(
         opacity: containerOpacity, // Fade entire container during closing
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(currentBorderRadius),
-          child: BackdropFilter(
-            filter: ImageFilter.blur(
-              sigmaX: effectiveSettings.blur,
-              sigmaY: effectiveSettings.blur,
+        child: LiquidStretch(
+          stretch: widget.stretch,
+          interactionScale: widget.interactionScale,
+          resistance: widget.stretchResistance,
+          axis: widget.stretchAxis,
+          suppressInteractionOnChildren: false,
+          // Constrain stretch to 'Down' and 'Away from screen edge' by default,
+          // but allow explicit user overrides.
+          allowPositiveX:
+              widget.allowPositiveXStretch ?? (_morphAlignment.x < 0),
+          allowNegativeX:
+              widget.allowNegativeXStretch ?? (_morphAlignment.x > 0),
+          allowPositiveY:
+              widget.allowPositiveYStretch ?? (_morphAlignment.y < 0),
+          allowNegativeY:
+              widget.allowNegativeYStretch ?? (_morphAlignment.y > 0),
+          child: GlassGlow(
+            enabled: widget.enableInteractionGlow,
+            glowColor: widget.glowColor ?? Colors.white.withValues(alpha: 0.15),
+            glowRadius: widget.glowRadius,
+            glowBlurRadius: 40,
+            clipper: ShapeBorderClipper(
+              shape:
+                  LiquidRoundedSuperellipse(borderRadius: currentBorderRadius),
             ),
             child: GlassContainer(
               useOwnLayer: true,
@@ -395,49 +475,103 @@ class _GlassMenuState extends State<GlassMenu>
                   currentHeight, // Constrained during morph, natural when open
               shape:
                   LiquidRoundedSuperellipse(borderRadius: currentBorderRadius),
-              clipBehavior: Clip.antiAlias, // Smooth anti-aliased edges
+              clipBehavior:
+                  Clip.none, // High-fidelity clipping handled by AdaptiveGlass
               child: Stack(
                 alignment: _morphAlignment, // Align internal stack content
                 clipBehavior:
-                    Clip.antiAlias, // Smooth clipping for overflow protection
+                    Clip.none, // Prevent double-clip artifacts during stretch
                 children: [
                   // Menu content - waits for container to be nearly full width
-                  // Width-constrained BEFORE layout to prevent overflow
-                  //
-                  // NOTE: We do NOT render the button inside this container during closing
-                  // because it would create double-glass (container glass + button glass).
-                  // The real trigger button (outside overlay) becomes visible at value < 0.05
                   if (value > 0.65)
                     Opacity(
                       opacity: menuOpacity,
-                      child: SizedBox(
-                        width: currentWidth, // Force exact container width
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                              vertical: 8, horizontal: 8),
-                          child: SingleChildScrollView(
-                            physics:
-                                const ClampingScrollPhysics(), // iOS-style scrolling
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: widget.items.map((item) {
-                                return GlassMenuItem(
-                                  key: item.key,
-                                  title: item.title,
-                                  icon: item.icon,
-                                  isDestructive: item.isDestructive,
-                                  trailing: item.trailing,
-                                  height: item.height,
-                                  onTap: () {
-                                    item.onTap();
-                                    _closeMenu();
-                                  },
-                                );
-                              }).toList(),
+                      child: Stack(
+                        clipBehavior: Clip.none,
+                        children: [
+                          // Sliding selection pill (background)
+                          if (_hoveredIndex != null)
+                            AnimatedPositioned(
+                              duration: const Duration(milliseconds: 150),
+                              curve: Curves.easeOutCubic,
+                              left: 8,
+                              right: 8,
+                              top: _getItemOffset(_hoveredIndex!),
+                              height:
+                                  _getItemHeight(widget.items[_hoveredIndex!]),
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: const Color(0x3DFFFFFF), // ~24% white
+                                  borderRadius: BorderRadius.circular(24),
+                                  border: Border.all(
+                                    color: const Color(
+                                        0x0DFFFFFF), // 5% white border
+                                    width: 0.5,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          Listener(
+                            onPointerDown: (event) {
+                              setState(() {
+                                _isDragging = true;
+                                _updateHoveredIndex(event.localPosition);
+                              });
+                            },
+                            onPointerMove: (event) {
+                              if (_isDragging) {
+                                setState(() =>
+                                    _updateHoveredIndex(event.localPosition));
+                              }
+                            },
+                            onPointerUp: (event) {
+                              if (_isDragging && _hoveredIndex != null) {
+                                final item = widget.items[_hoveredIndex!];
+                                if (item is GlassMenuItem) {
+                                  item.onTap();
+                                }
+                                _closeMenu();
+                              }
+                              setState(() {
+                                _isDragging = false;
+                                _hoveredIndex = null;
+                              });
+                            },
+                            onPointerCancel: (_) {
+                              setState(() {
+                                _isDragging = false;
+                                _hoveredIndex = null;
+                              });
+                            },
+                            child: SizedBox(
+                              width:
+                                  currentWidth, // Force exact container width
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    vertical: 8, horizontal: 8),
+                                child: SingleChildScrollView(
+                                  controller: _scrollController,
+                                  physics:
+                                      const ClampingScrollPhysics(), // iOS-style scrolling
+                                  child: Column(
+                                    mainAxisSize: MainAxisSize.min,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.stretch,
+                                    children: [
+                                      for (var i = 0;
+                                          i < widget.items.length;
+                                          i++) ...[
+                                        _buildItem(i),
+                                        if (i < widget.items.length - 1)
+                                          const SizedBox(height: 2),
+                                      ],
+                                    ],
+                                  ),
+                                ),
+                              ),
                             ),
                           ),
-                        ),
+                        ],
                       ),
                     ),
                 ],
@@ -447,5 +581,62 @@ class _GlassMenuState extends State<GlassMenu>
         ),
       ),
     );
+  }
+
+  double _getItemHeight(Widget item) {
+    if (item is GlassMenuItem) return item.height;
+    if (item is GlassMenuDivider) return item.height;
+    return 44.0;
+  }
+
+  double _getItemOffset(int index) {
+    double offset = 8.0; // Top padding
+    for (int i = 0; i < index; i++) {
+      offset += _getItemHeight(widget.items[i]) + 2.0; // height + 2px gap
+    }
+    return offset;
+  }
+
+  Widget _buildItem(int i) {
+    final item = widget.items[i];
+    if (item is GlassMenuItem) {
+      return GlassMenuItem(
+        key: item.key,
+        title: item.title,
+        subtitle: item.subtitle,
+        icon: item.icon,
+        isDestructive: item.isDestructive,
+        trailing: item.trailing,
+        height: item.height,
+        isSelected: _hoveredIndex == i,
+        isPressed: _isDragging && _hoveredIndex == i,
+        enabled: false, // Parent handles interaction
+        onTap: item.onTap,
+      );
+    }
+    return item;
+  }
+
+  void _updateHoveredIndex(Offset localPosition) {
+    final y = localPosition.dy + _scrollController.offset;
+
+    double currentOffset = 8.0;
+    int? detectedIndex;
+
+    for (int i = 0; i < widget.items.length; i++) {
+      final item = widget.items[i];
+      final itemHeight = _getItemHeight(item);
+
+      if (y >= currentOffset && y <= currentOffset + itemHeight) {
+        // Only select interactive items
+        if (item is GlassMenuItem) {
+          detectedIndex = i;
+        }
+        break;
+      }
+      currentOffset += itemHeight + 2.0; // height + 2px gap
+    }
+
+    _hoveredIndex = detectedIndex;
   }
 }

--- a/lib/widgets/overlays/glass_menu_item.dart
+++ b/lib/widgets/overlays/glass_menu_item.dart
@@ -19,6 +19,10 @@ class GlassMenuItem extends StatefulWidget {
     this.isPressed,
     this.isSelected = false,
     this.enabled = true,
+    this.titleStyle,
+    this.subtitleStyle,
+    this.iconColor,
+    this.iconSize = 20.0,
   });
 
   /// The primary text of the item.
@@ -54,6 +58,18 @@ class GlassMenuItem extends StatefulWidget {
 
   /// Whether the item should handle its own interactions.
   final bool enabled;
+
+  /// Custom text style for the title.
+  final TextStyle? titleStyle;
+
+  /// Custom text style for the subtitle.
+  final TextStyle? subtitleStyle;
+
+  /// Custom color for the icon.
+  final Color? iconColor;
+
+  /// Custom size for the icon.
+  final double iconSize;
 
   @override
   State<GlassMenuItem> createState() => _GlassMenuItemState();
@@ -93,6 +109,55 @@ class GlassMenuDivider extends StatelessWidget {
   }
 }
 
+/// A non-interactive label or content item for use within a [GlassMenu].
+///
+/// Use this for headers, section labels, or purely decorative content.
+/// It does not respond to hover/press and is ignored by the selection pill.
+class GlassMenuLabel extends StatelessWidget {
+  /// The content to display.
+  final Widget child;
+
+  /// The height of the item.
+  ///
+  /// Defaults to 32.0 (slightly shorter than a standard menu item).
+  final double height;
+
+  /// Horizontal padding for the content.
+  final double horizontalPadding;
+
+  /// Creates a glass menu label.
+  const GlassMenuLabel({
+    required this.child,
+    super.key,
+    this.height = 32.0,
+    this.horizontalPadding = 16.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+      alignment: Alignment.centerLeft,
+      child: DefaultTextStyle(
+        style: const TextStyle(
+          color: Color(0x99FFFFFF), // 60% white default
+          fontSize: 13,
+          fontWeight: FontWeight.w500,
+          letterSpacing: -0.1,
+        ),
+        child: IconTheme(
+          data: const IconThemeData(
+            color: Color(0x99FFFFFF),
+            size: 16,
+          ),
+          child: child,
+        ),
+      ),
+    );
+  }
+}
+
 class _GlassMenuItemState extends State<GlassMenuItem> {
   bool _isHovered = false;
   bool _isPressed = false;
@@ -100,14 +165,26 @@ class _GlassMenuItemState extends State<GlassMenuItem> {
   @override
   Widget build(BuildContext context) {
     // Performance: Cache static colors to avoid recalculation on every build
-    final Color textColor = widget.isDestructive
-        ? const Color(0xFFEF5350) // Colors.red.shade400 cached
-        : const Color(0xE6FFFFFF); // Colors.white.withValues(alpha: 0.9) cached
+    // Determine the base color of the item (inheritance logic)
+    // Priority: iconColor > titleStyle.color > destructiveRed > white
+    final Color baseColor = widget.iconColor ??
+        widget.titleStyle?.color ??
+        (widget.isDestructive
+            ? const Color(0xFFEF5350) // Colors.red.shade400
+            : Colors.white);
 
-    final Color iconColor = widget.isDestructive
-        ? const Color(0xFFEF5350)
-        : const Color(0xB3FFFFFF); // Colors.white.withValues(alpha: 0.7) cached
+    // Apply specific opacities based on original design specs:
+    // Icon: 100% (enabled), 50% (disabled)
+    // Text: 90% (static for enabled/disabled)
+    final Color iconColor = widget.iconColor ??
+        (widget.isDestructive
+            ? Colors.redAccent
+            : baseColor.withValues(alpha: widget.enabled ? 1.0 : 0.5));
 
+    final Color textColor = widget.titleStyle?.color ??
+        (widget.isDestructive
+            ? const Color(0xFFEF5350) // Colors.red.shade400
+            : baseColor.withValues(alpha: 0.9));
     // Dynamic background for hover/press states
     // We use a subtle white overlay to "brighten" the glass
     final bool effectivePressed = widget.isPressed ?? _isPressed;
@@ -155,7 +232,10 @@ class _GlassMenuItemState extends State<GlassMenuItem> {
                   // Icon
                   if (widget.icon != null) ...[
                     IconTheme(
-                      data: IconThemeData(color: iconColor, size: 20),
+                      data: IconThemeData(
+                        color: iconColor,
+                        size: widget.iconSize,
+                      ),
                       child: widget.icon!,
                     ),
                     const SizedBox(width: 12),
@@ -171,22 +251,24 @@ class _GlassMenuItemState extends State<GlassMenuItem> {
                           widget.title,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
-                            color: textColor,
-                            fontSize: 17,
-                            fontWeight: FontWeight.w400,
-                          ),
+                          style: widget.titleStyle ??
+                              TextStyle(
+                                color: textColor,
+                                fontSize: 17,
+                                fontWeight: FontWeight.w400,
+                              ),
                         ),
                         if (widget.subtitle != null)
                           Text(
                             widget.subtitle!,
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              color: textColor.withValues(alpha: 0.6),
-                              fontSize: 13,
-                              fontWeight: FontWeight.w400,
-                            ),
+                            style: widget.subtitleStyle ??
+                                TextStyle(
+                                  color: textColor.withValues(alpha: 0.6),
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w400,
+                                ),
                           ),
                       ],
                     ),

--- a/lib/widgets/overlays/glass_menu_item.dart
+++ b/lib/widgets/overlays/glass_menu_item.dart
@@ -15,6 +15,10 @@ class GlassMenuItem extends StatefulWidget {
     this.isDestructive = false,
     this.trailing,
     this.height = 44.0,
+    this.subtitle,
+    this.isPressed,
+    this.isSelected = false,
+    this.enabled = true,
   });
 
   /// The primary text of the item.
@@ -22,6 +26,9 @@ class GlassMenuItem extends StatefulWidget {
 
   /// The icon widget displayed before the title.
   final Widget? icon;
+
+  /// Optional subtitle text displayed below the title.
+  final String? subtitle;
 
   /// Callback when the item is tapped.
   final VoidCallback onTap;
@@ -39,8 +46,51 @@ class GlassMenuItem extends StatefulWidget {
   /// Defaults to 44.0 (standard iOS touch target).
   final double height;
 
+  /// External override for the pressed state.
+  final bool? isPressed;
+
+  /// Whether the item is currently selected (e.g. by a sliding pill).
+  final bool isSelected;
+
+  /// Whether the item should handle its own interactions.
+  final bool enabled;
+
   @override
   State<GlassMenuItem> createState() => _GlassMenuItemState();
+}
+
+/// A separator line for use within a [GlassMenu].
+class GlassMenuDivider extends StatelessWidget {
+  /// The height of the divider area (line + spacing).
+  final double height;
+
+  /// Custom color for the divider line.
+  final Color? color;
+
+  /// Horizontal padding for the divider line.
+  final double indent;
+
+  /// Creates a glass menu divider.
+  const GlassMenuDivider({
+    super.key,
+    this.height = 12.0,
+    this.color,
+    this.indent = 8.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      child: Center(
+        child: Container(
+          height: 0.5,
+          margin: EdgeInsets.symmetric(horizontal: indent),
+          color: color ?? const Color(0x26FFFFFF), // 15% white line default
+        ),
+      ),
+    );
+  }
 }
 
 class _GlassMenuItemState extends State<GlassMenuItem> {
@@ -60,22 +110,30 @@ class _GlassMenuItemState extends State<GlassMenuItem> {
 
     // Dynamic background for hover/press states
     // We use a subtle white overlay to "brighten" the glass
-    final Color backgroundColor = _isPressed
-        ? const Color(0x26FFFFFF) // alpha: 0.15
-        : _isHovered
-            ? const Color(0x1AFFFFFF) // alpha: 0.1
-            : Colors.transparent;
+    final bool effectivePressed = widget.isPressed ?? _isPressed;
+    final bool effectiveSelected = widget.isSelected;
+
+    final Color backgroundColor = effectiveSelected
+        ? Colors.transparent // Parent renders the sliding pill
+        : effectivePressed
+            ? const Color(0x26FFFFFF) // Standalone press
+            : _isHovered
+                ? const Color(0x1AFFFFFF)
+                : Colors.transparent;
 
     // Scale effect on press (subtle squash like iOS buttons)
-    final double scale = _isPressed ? 0.98 : 1.0;
+    final double scale = effectivePressed ? 0.98 : 1.0;
 
     // Performance: RepaintBoundary isolates this item from siblings
     return RepaintBoundary(
       child: GestureDetector(
-        onTapDown: (_) => setState(() => _isPressed = true),
-        onTapUp: (_) => setState(() => _isPressed = false),
-        onTapCancel: () => setState(() => _isPressed = false),
-        onTap: widget.onTap,
+        onTapDown:
+            widget.enabled ? (_) => setState(() => _isPressed = true) : null,
+        onTapUp:
+            widget.enabled ? (_) => setState(() => _isPressed = false) : null,
+        onTapCancel:
+            widget.enabled ? () => setState(() => _isPressed = false) : null,
+        onTap: widget.enabled ? widget.onTap : null,
         child: MouseRegion(
           onEnter: (_) => setState(() => _isHovered = true),
           onExit: (_) => setState(() => _isHovered = false),
@@ -90,7 +148,7 @@ class _GlassMenuItemState extends State<GlassMenuItem> {
               padding: const EdgeInsets.symmetric(horizontal: 16),
               decoration: BoxDecoration(
                 color: backgroundColor,
-                borderRadius: BorderRadius.circular(10), // Inner radius
+                borderRadius: BorderRadius.circular(24), // Match sliding pill
               ),
               child: Row(
                 children: [
@@ -103,15 +161,34 @@ class _GlassMenuItemState extends State<GlassMenuItem> {
                     const SizedBox(width: 12),
                   ],
 
-                  // Title
+                  // Text Content (Title & Subtitle)
                   Expanded(
-                    child: Text(
-                      widget.title,
-                      style: TextStyle(
-                        color: textColor,
-                        fontSize: 17,
-                        fontWeight: FontWeight.w400,
-                      ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          widget.title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: textColor,
+                            fontSize: 17,
+                            fontWeight: FontWeight.w400,
+                          ),
+                        ),
+                        if (widget.subtitle != null)
+                          Text(
+                            widget.subtitle!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: textColor.withValues(alpha: 0.6),
+                              fontSize: 13,
+                              fontWeight: FontWeight.w400,
+                            ),
+                          ),
+                      ],
                     ),
                   ),
 

--- a/lib/widgets/overlays/glass_modal_sheet.dart
+++ b/lib/widgets/overlays/glass_modal_sheet.dart
@@ -139,6 +139,13 @@ class GlassModalSheet extends StatefulWidget {
   /// Velocity threshold for flick gestures (pixels/sec). Default: 700.0.
   final double velocityThreshold;
 
+  /// Whether the glow should act as a momentary tap indicator.
+  /// 
+  /// If true, the glow will appear on tap but will automatically fade out
+  /// if the user starts dragging. It will not reappear until a new tap starts.
+  /// Default: false.
+  final bool glowOnTapOnly;
+
   /// Custom color for the touch interaction glow.
   final Color? glowColor;
 
@@ -228,6 +235,7 @@ class GlassModalSheet extends StatefulWidget {
     this.glowColor,
     this.glowRadius = 1.5,
     this.suppressInteractionOnChildren = false,
+    this.glowOnTapOnly = false,
     this.padding,
     this.enableTopFade = false,
     this.topFadeHeight = 40.0,
@@ -282,6 +290,7 @@ class GlassModalSheet extends StatefulWidget {
     Color? glowColor,
     double glowRadius = 1.5,
     bool suppressInteractionOnChildren = false,
+    bool glowOnTapOnly = false,
     EdgeInsetsGeometry? padding,
     bool enableTopFade = false,
     double topFadeHeight = 40.0,
@@ -359,6 +368,7 @@ class GlassModalSheet extends StatefulWidget {
           glowColor: glowColor,
           glowRadius: glowRadius,
           suppressInteractionOnChildren: suppressInteractionOnChildren,
+          glowOnTapOnly: glowOnTapOnly,
           padding: padding,
           enableTopFade: enableTopFade,
           topFadeHeight: topFadeHeight,

--- a/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
@@ -39,6 +39,7 @@ class _SheetLayout extends StatelessWidget {
   final bool enableSaturationGlow;
   final VoidCallback onFocusGained;
   final bool suppressInteractionOnChildren;
+  final bool glowOnTapOnly;
 
   const _SheetLayout({
     required this.interactionScale,
@@ -79,6 +80,7 @@ class _SheetLayout extends StatelessWidget {
     required this.enableSaturationGlow,
     required this.onFocusGained,
     required this.suppressInteractionOnChildren,
+    required this.glowOnTapOnly,
   });
 
   @override
@@ -248,6 +250,7 @@ class _SheetLayout extends StatelessWidget {
                                     ? (glowColor ??
                                         Colors.white.withValues(alpha: 0.15))
                                     : Colors.transparent,
+                                glowOnTapOnly: glowOnTapOnly,
                                 glowRadius: glowRadius,
                                 hitTestBehavior: HitTestBehavior.translucent,
                                 pulse: (enableSaturationGlow &&
@@ -583,6 +586,9 @@ class GlassModalSheetScaffold extends StatelessWidget {
   /// Whether to prevent sheet scaling when interacting with children. Default: false.
   final bool suppressInteractionOnChildren;
 
+  /// Whether the glow should act as a momentary tap indicator. Default: false.
+  final bool glowOnTapOnly;
+
   /// Internal padding for the sheet content.
   final EdgeInsetsGeometry? padding;
 
@@ -675,6 +681,7 @@ class GlassModalSheetScaffold extends StatelessWidget {
     this.glowColor,
     this.glowRadius = 1.5,
     this.suppressInteractionOnChildren = false,
+    this.glowOnTapOnly = false,
     this.padding,
     this.enableTopFade = false,
     this.topFadeHeight = 40.0,
@@ -739,6 +746,7 @@ class GlassModalSheetScaffold extends StatelessWidget {
           glowColor: glowColor,
           glowRadius: glowRadius,
           suppressInteractionOnChildren: suppressInteractionOnChildren,
+          glowOnTapOnly: glowOnTapOnly,
           padding: padding,
           enableTopFade: enableTopFade,
           topFadeHeight: topFadeHeight,

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -795,6 +795,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
         Widget result = _SheetLayout(
           interactionScale: metrics.interactionScale,
           enableInteractionGlow: widget.enableInteractionGlow,
+          glowOnTapOnly: widget.glowOnTapOnly,
           glowColor: widget.glowColor,
           glowRadius: widget.glowRadius,
           stretch: widget.stretch,

--- a/lib/widgets/shared/adaptive_glass.dart
+++ b/lib/widgets/shared/adaptive_glass.dart
@@ -221,7 +221,7 @@ class AdaptiveGlass extends StatelessWidget {
           shape: shape,
           settings: effectiveSettings,
           densityFactor: 0.0, // Containers are never elevated
-          glowIntensity: 0.0, // Containers don't glow
+          glowIntensity: glowIntensity, // Allow interactive containers to glow
           child: InheritedLiquidGlass(
             settings: effectiveSettings,
             quality: quality,


### PR DESCRIPTION
## Summary
This PR represents a massive architectural overhaul of the `GlassMenu` and interaction engine, evolving it from a static overlay into a highly robust, interactive, and physics-driven "Liquid Glass" component. It resolves critical performance bottlenecks, introduces new tactile feedback capabilities, and fixes cross-platform layout assertions.

### 1. Liquid Physics, Elasticity & Infinite Stretch
**Files:** `lib/widgets/overlays/glass_menu.dart`, `lib/src/renderer/stretch.dart`, `lib/widgets/containers/glass_container.dart`, `lib/widgets/interactive/glass_pull_down_button.dart`
**Action:** Interaction Engine Refactor
**What was done:** Refactored the core `LiquidStretch` mathematics. Removed the hardcoded pull-to-dismiss threshold and implemented a 10-pixel displacement guard that clearly separates a "tap" from a "stretch" gesture. Added directional axis constraints.
**Why:** Previously, pulling the menu too far would abruptly close it, interrupting the physical interaction. Furthermore, slight finger movements during a tap could accidentally trigger the physics engine.
**Result:** Users can now seamlessly stretch and "play" with the glass menu infinitely without accidental closures or unintentional item selections. The stretch engine is now smarter and constrained dynamically.

### 2. Scroll-Aware Selection Pill
**Files:** `lib/widgets/overlays/glass_menu.dart`, `lib/widgets/overlays/glass_menu_item.dart`
**Action:** Pill Navigation Optimization
**What was done:** Integrated scroll-offset awareness into the selection pill tracking engine and increased the visual indentation (padding) of the pill from the menu's outer frame. 
**Why:** In menus with long lists, the selection pill would jitter or erroneously track the finger while the user was simply trying to scroll through the content.
**Result:** The selection pill now smoothly disappears during active scrolling and perfectly syncs with item positions, providing a clean and stable navigation experience. The increased indentation also improves the visual harmony of the inner elements.

### 3. Container & Interactive Element Scalability
**Files:** `lib/widgets/shared/adaptive_glass.dart`, `lib/widgets/containers/glass_container.dart`, `lib/widgets/overlays/shared/glass_modal_sheet_internal.dart`
**Action:** API & Rendering Pipeline Update
**What was done:** Removed the hardcoded `glowIntensity: 0.0` from `AdaptiveGlass` to properly pass the user-defined `glowIntensity` value. Additionally, `GlassContainer` was updated to support native `stretch` physics to match the new `GlassMenu` interaction model.
**Why:** Previously, `GlassContainer` was forcefully stripped of glow effects at the root `AdaptiveGlass` level, making it impossible for generic interactive glass containers to inherit the same tactile glow as menus or sheets.
**Result:** Any widget utilizing `GlassContainer` can now seamlessly inherit and display the new physics and interaction glow, perfectly matching the library's design language.

### 4. Custom Complex Widgets in Menu Items
**Files:** `lib/widgets/overlays/glass_menu_item.dart`, `example/lib/modal_sheet_showcase/modal_sheet_showcase.dart`
**Action:** API Expansion
**What was done:** Upgraded the `icon` parameter in `GlassMenuItem` to accept generic `Widget` types and decoupled the internal flex layout.
**Why:** Developers needed to place complex UI elements, such as `CircleAvatar` or `NetworkImage` profile photos, inside menu items, which the previous strict icon-only layout broke.
**Result:** Menus now fully support rich, custom layouts while maintaining perfect alignment and layout boundaries. Expanded the showcase demo to visually prove this functionality.

### 5. Android Safe Area Assertion Fix
**Files:** `example/lib/modal_sheet_showcase/modal_sheet_showcase.dart`
**Action:** Bug Fix
**What was done:** Wrapped the bottom safe-area padding calculations in a protective bounding check (`sysBottom > 25 ? sysBottom - 25 : 0`).
**Why:** On Android devices with small gesture navigation bars (e.g., 16px), subtracting 25px resulted in a negative padding value. This caused a fatal `padding.isNonNegative is not true` rendering crash on Android.
**Result:** The UI now scales safely and flawlessly across all devices, regardless of OS-level safe area dimensions.

### 6. Momentary Tap Feedback (`glowOnTapOnly`)
**Files:** `lib/src/renderer/glass_glow.dart`, `lib/widgets/overlays/glass_modal_sheet.dart`, `lib/widgets/overlays/shared/glass_modal_sheet_state.dart`, `lib/widgets/overlays/glass_menu.dart`
**Action:** Tactile Feedback Enhancement
**What was done:** Converted `GlassGlow` to a `StatefulWidget` to track pointer drag distances and introduced a new `glowOnTapOnly` parameter propagated through all major overlays.
**Why:** The standard continuous "flashlight" tracking glare was visually distracting during active gestures like scrolling or heavy stretching.
**Result:** Developers can now opt-in to a momentary, ripple-like tactile feedback. The glow beautifully illuminates on touch but gracefully fades out if the gesture turns into a drag (>10px), keeping the UI pristine during active use.

### 7. Documentation Overhaul
**Files:** `docs/assets/GLASS_MENU_GUIDE.md`, `docs/assets/GLASS_MODAL_SHEETS_GUIDE.md`
**Action:** Documentation Update
**What was done:** Massively expanded the `GLASS_MENU_GUIDE.md` to cover the new "Liquid Play" zones, scroll-aware selection logic, custom widgets, and the "Infinite Stretch" mechanics. Added `glowOnTapOnly` documentation to both guides.
**Why:** To ensure the ultimate source of truth matches the heavily refactored codebase.
**Result:** Developers have a 101% complete technical reference for all newly introduced behaviors.


### Demo new GlassMenu:
<img width="304" height="310" alt="изображение" src="https://github.com/user-attachments/assets/bedf7c98-f44b-4752-bca0-89abdb47be08" />

### Reference for example from Notion iOS Version:
![image](https://github.com/user-attachments/assets/66784f6d-eb33-438c-8f46-0f9ffc56985c)