### PR TITLE
fix: Restore GlassMenu performance, caching and resolve visual artifacts

### DIFF
--- a/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
+++ b/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
@@ -13,7 +13,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await LiquidGlassWidgets.initialize();
   runApp(LiquidGlassWidgets.wrap(
-      child: const ShowcaseApp(), adaptiveQuality: true));
+      child: const ShowcaseApp(), adaptiveQuality: false));
 }
 
 class ShowcaseApp extends StatefulWidget {
@@ -346,32 +346,183 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
               onTap: () => _showGlassPanel(context),
               color: Colors.green,
             ),
-            const SizedBox(height: 16),
-            GlassMenu(
-              menuWidth: 240,
-              triggerBuilder: (context, toggleMenu) => _buildScenarioTile(
-                title: 'Pull-Down Menu',
-                description: 'Tile morphs directly into a glass menu',
-                icon: Icons.menu_open_rounded,
-                onTap: toggleMenu,
-                color: Colors.purple,
-              ),
-              items: [
-                GlassMenuItem(
-                  title: 'Edit Content',
-                  icon: const Icon(Icons.edit_rounded),
-                  onTap: () {},
+            const SizedBox(height: 24),
+            const GlassMenuLabel(child: Text('MENU CONFIGURATIONS')),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                // 1. Basic configuration (User's original)
+                GlassMenu(
+                  menuWidth: 240,
+                  quality: widget.currentQuality,
+                  glassSettings: LiquidGlassSettings(
+                    glassColor: Colors.transparent,
+                    thickness: 30,
+                    blur: 2,
+                    chromaticAberration: .01,
+                    lightAngle: GlassDefaults.lightAngle,
+                    lightIntensity: .5,
+                    ambientStrength: 0,
+                    refractiveIndex: 1.2,
+                    saturation: 1.2,
+                  ),
+                  enableInteractionGlow: true,
+                  glowOnTapOnly: true,
+                  glowRadius: 0.6,
+                  interactionScale: 1.00,
+                  triggerBuilder: (context, toggleMenu) => GlassButton(
+                    icon: const Icon(Icons.menu_open_rounded),
+                    onTap: toggleMenu,
+                  ),
+                  items: [
+                    GlassMenuItem(
+                        title: 'Upgrade plan',
+                        icon: const Icon(Icons.upgrade),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Settings',
+                        icon: const Icon(Icons.settings),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Offline Pages',
+                        icon: const Icon(Icons.move_down_rounded),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Members',
+                        icon: const Icon(Icons.group_rounded),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Trash',
+                        icon: const Icon(Icons.delete_rounded),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Help & support',
+                        icon: const Icon(Icons.question_mark_rounded),
+                        onTap: () {}),
+                  ],
                 ),
-                GlassMenuItem(
-                  title: 'Share Scenario',
-                  icon: const Icon(Icons.share_rounded),
-                  onTap: () {},
+                const SizedBox(width: 16),
+
+                // 2. Pro configuration (Advanced features)
+                GlassMenu(
+                  menuWidth: 260,
+                  menuHeight: 250, // Test scrolling
+                  quality: widget.currentQuality,
+                  selectionColor: Colors.blue.withValues(alpha: 0.3),
+                  triggerBuilder: (context, toggle) => GlassButton.custom(
+                    onTap: toggle,
+                    width: 56,
+                    height: 56,
+                    shape: const LiquidOval(),
+                    child: const Icon(CupertinoIcons.layers_alt,
+                        color: Colors.white),
+                  ),
+                  items: [
+                    const GlassMenuLabel(child: Text('PRIMARY ACTIONS')),
+                    GlassMenuItem(
+                      title: 'New Project',
+                      subtitle: 'Create from template',
+                      icon: const Icon(CupertinoIcons.add),
+                      onTap: () {},
+                    ),
+                    GlassMenuItem(
+                      title: 'Share Workspace',
+                      icon: const Icon(CupertinoIcons.share),
+                      iconColor: Colors.blueAccent, // Smart inheritance
+                      onTap: () {},
+                    ),
+                    const GlassMenuDivider(),
+                    const GlassMenuLabel(child: Text('MANAGEMENT')),
+                    GlassMenuItem(
+                      title: 'Settings',
+                      icon: const Icon(CupertinoIcons.settings),
+                      onTap: () {},
+                    ),
+                    const GlassMenuDivider(),
+                    const GlassMenuLabel(child: Text('DANGER ZONE')),
+                    GlassMenuItem(
+                      title: 'Delete Forever',
+                      isDestructive: true,
+                      icon: const Icon(CupertinoIcons.trash),
+                      onTap: () {},
+                    ),
+                  ],
                 ),
-                GlassMenuItem(
-                  title: 'Delete Demo',
-                  icon: const Icon(Icons.delete_rounded),
-                  isDestructive: true,
-                  onTap: () {},
+                const SizedBox(width: 16),
+
+                // 3. Photo configuration (Custom Widgets instead of Icons)
+                GlassMenu(
+                  menuWidth: 220,
+                  quality: widget.currentQuality,
+                  stretch: 0.0, // Disable liquid stretch physics
+                  glassSettings: LiquidGlassSettings(
+                    glassColor: Colors.transparent,
+                    thickness: 30,
+                    blur: 2,
+                    chromaticAberration: .01,
+                    lightAngle: GlassDefaults.lightAngle,
+                    lightIntensity: .5,
+                    ambientStrength: 0,
+                    refractiveIndex: 1.2,
+                    saturation: 1.2,
+                  ),
+                  enableInteractionGlow: false,
+                  glowRadius: 0.6,
+                  interactionScale: 1.00,
+                  triggerBuilder: (context, toggleMenu) => GlassButton(
+                    icon: const Icon(Icons.camera_alt_rounded),
+                    onTap: toggleMenu,
+                  ),
+                  items: [
+                    GlassMenuItem(
+                        title: 'Alice',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=1'),
+                        ),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Bob',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=2'),
+                        ),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Charlie',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=3'),
+                        ),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Diana',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=4'),
+                        ),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Ethan',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=5'),
+                        ),
+                        onTap: () {}),
+                    GlassMenuItem(
+                        title: 'Fiona',
+                        icon: const CircleAvatar(
+                          radius: 12,
+                          backgroundImage:
+                              NetworkImage('https://i.pravatar.cc/100?img=9'),
+                        ),
+                        onTap: () {}),
+                  ],
                 ),
               ],
             ),

--- a/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
+++ b/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
@@ -347,7 +347,7 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
               color: Colors.green,
             ),
             const SizedBox(height: 24),
-            const GlassMenuLabel(child: Text('MENU CONFIGURATIONS')),
+            const GlassMenuLabel(title: 'MENU CONFIGURATIONS'),
             const SizedBox(height: 12),
             Row(
               children: [
@@ -417,7 +417,7 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
                         color: Colors.white),
                   ),
                   items: [
-                    const GlassMenuLabel(child: Text('PRIMARY ACTIONS')),
+                    const GlassMenuLabel(title: 'PRIMARY ACTIONS'),
                     GlassMenuItem(
                       title: 'New Project',
                       subtitle: 'Create from template',
@@ -431,14 +431,14 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
                       onTap: () {},
                     ),
                     const GlassMenuDivider(),
-                    const GlassMenuLabel(child: Text('MANAGEMENT')),
+                    const GlassMenuLabel(title: 'MANAGEMENT'),
                     GlassMenuItem(
                       title: 'Settings',
                       icon: const Icon(CupertinoIcons.settings),
                       onTap: () {},
                     ),
                     const GlassMenuDivider(),
-                    const GlassMenuLabel(child: Text('DANGER ZONE')),
+                    const GlassMenuLabel(title: 'DANGER ZONE'),
                     GlassMenuItem(
                       title: 'Delete Forever',
                       isDestructive: true,

--- a/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
+++ b/example/lib/modal_sheet_showcase/modal_sheet_showcase.dart
@@ -367,7 +367,6 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
                     saturation: 1.2,
                   ),
                   enableInteractionGlow: true,
-                  glowOnTapOnly: true,
                   glowRadius: 0.6,
                   interactionScale: 1.00,
                   triggerBuilder: (context, toggleMenu) => GlassButton(
@@ -466,7 +465,7 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
                     refractiveIndex: 1.2,
                     saturation: 1.2,
                   ),
-                  enableInteractionGlow: false,
+                  enableInteractionGlow: true,
                   glowRadius: 0.6,
                   interactionScale: 1.00,
                   triggerBuilder: (context, toggleMenu) => GlassButton(

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/physics.dart';
+import 'package:flutter/physics.dart'; // Required for SpringSimulation
 import '../../src/renderer/liquid_glass_renderer.dart';
 
 import '../../constants/glass_defaults.dart';
@@ -21,41 +21,52 @@ part 'shared/glass_menu_internal.dart';
 ///
 /// ## Features
 /// - **True morphing**: Button transforms into menu (not overlay)
-/// - **Smooth spring physics**: Gentle settle (stiffness: 300, damping: 24)
-/// - **Liquid swoop**: Subtle 5px parabolic arc during morph
-/// - **Elastic stretch**: [LiquidStretch] wrapping for physics-driven drag
-/// - **Scroll-aware selection pill**: Slides to highlight the hovered item;
-///   automatically hidden during scrolling to prevent visual noise
-/// - **Heterogeneous items**: Mix [GlassMenuItem], [GlassMenuDivider], and
-///   [GlassMenuLabel] in a single menu
-/// - **glowOnTapOnly**: Momentary glare that disappears on drag/scroll
+/// - **Smooth spring physics**: Gentle settle with no harsh bounces (stiffness: 300, damping: 24)
+/// - **Liquid swoop**: Subtle 5px parabolic arc for seamless down-and-up motion
+/// - **Seamless crossfade**: Button only appears at final 5% to preserve morph illusion
+/// - **Dimension interpolation**: Width, height, and border radius morph smoothly
+/// - **Position aware**: Menu expands from button position
+/// - **Settings inheritance**: Inherits parent layer settings like GlassCard (thin rim by default)
+/// - **No button animation**: Trigger button remains static, only shape morphs
 class GlassMenu extends StatefulWidget {
   /// The widget that triggers the menu.
   ///
-  /// If provided, this widget will be wrapped in a [GestureDetector].
-  /// For interactive triggers (e.g. [GlassButton]), use [triggerBuilder].
+  /// If provided, this widget will be wrapped in a [GestureDetector] to handle
+  /// taps. Use this for simple, non-interactive triggers like Icons or Text.
+  ///
+  /// If your trigger is interactive (like a [GlassButton]), use [triggerBuilder]
+  /// instead to manually handle the tap event.
   final Widget? trigger;
 
-  /// A builder for the trigger widget that exposes the menu toggle callback.
+  /// A builder for the trigger widget that provides access to the menu toggle callback.
+  ///
+  /// Use this when your trigger widget handles its own interactions (e.g., a [GlassButton]
+  /// or [IconButton]).
+  ///
+  /// Example:
+  /// ```dart
+  /// GlassMenu(
+  ///   triggerBuilder: (context, toggle) => GlassButton(
+  ///     onTap: toggle,
+  ///     child: Text('Open'),
+  ///   ),
+  ///   ...
+  /// )
+  /// ```
   final Widget Function(BuildContext context, VoidCallback toggleMenu)?
       triggerBuilder;
 
   /// The list of items to display in the menu.
   ///
-  /// Accepts any widget — typically [GlassMenuItem], [GlassMenuDivider],
-  /// or [GlassMenuLabel].
+  /// Typically contains [GlassMenuItem] and [GlassMenuDivider].
   final List<Widget> items;
 
-  /// Width of the expanded menu. Defaults to 200.
+  /// Width of the expanded menu.
   final double menuWidth;
 
-  /// Fixed height for the menu content area.
+  /// Border radius of the expanded menu.
   ///
-  /// When set, the menu becomes scrollable and this height is used as the
-  /// maximum content height. When null, the menu sizes to fit its children.
-  final double? menuHeight;
-
-  /// Border radius of the expanded menu. Defaults to 16.0.
+  /// Defaults to 28.0 for a modern rounded look.
   final double menuBorderRadius;
 
   /// Custom glass settings for the menu container.
@@ -64,62 +75,59 @@ class GlassMenu extends StatefulWidget {
   /// Rendering quality for the glass effect.
   final GlassQuality? quality;
 
-  // ---------------------------------------------------------------------------
-  // Elastic Stretch (LiquidStretch)
-  // ---------------------------------------------------------------------------
-
-  /// Scale factor applied during interaction for tactile feedback.
-  /// Defaults to 1.05.
-  final double interactionScale;
-
-  /// Stretch multiplier applied to drag offset. Defaults to 0.5.
+  /// Liquid stretch factor. Default: 0.5.
   final double stretch;
 
-  /// Resistance factor for the elastic drag. Defaults to 0.08.
+  /// Scale factor applied on touch. Default: 1.02.
+  final double interactionScale;
+
+  /// The resistance factor to apply to the drag offset.
+  /// Higher values make the drag feel "stickier". Default: 0.08.
   final double stretchResistance;
 
-  /// Axis to constrain the stretch to. When null, stretches in both axes.
+  /// The axis to constrain the stretch to. If null, stretches in both axes.
   final Axis? stretchAxis;
 
-  /// Allow stretch in the positive X direction (right). Defaults to true.
-  final bool? allowPositiveX;
+  /// Whether to allow stretch in the positive X direction (Right).
+  /// If null, automatically determined by menu position.
+  final bool? allowPositiveXStretch;
 
-  /// Allow stretch in the negative X direction (left). Defaults to true.
-  final bool? allowNegativeX;
+  /// Whether to allow stretch in the negative X direction (Left).
+  /// If null, automatically determined by menu position.
+  final bool? allowNegativeXStretch;
 
-  /// Allow stretch in the positive Y direction (down). Defaults to true.
-  final bool? allowPositiveY;
+  /// Whether to allow stretch in the positive Y direction (Down).
+  /// If null, automatically determined by menu position.
+  final bool? allowPositiveYStretch;
 
-  /// Allow stretch in the negative Y direction (up). Defaults to true.
-  final bool? allowNegativeY;
+  /// Whether to allow stretch in the negative Y direction (Up).
+  /// If null, automatically determined by menu position.
+  final bool? allowNegativeYStretch;
 
-  // ---------------------------------------------------------------------------
-  // Selection Pill
-  // ---------------------------------------------------------------------------
-
-  /// Background color of the sliding selection pill.
-  ///
-  /// Defaults to white at 12% opacity.
-  final Color? selectionColor;
-
-  // ---------------------------------------------------------------------------
-  // GlassGlow
-  // ---------------------------------------------------------------------------
-
-  /// Whether to show a finger-following glare on the menu surface.
-  /// Defaults to true.
+  /// Whether to show glow/glare on touch for tactile feedback. Default: true.
   final bool enableInteractionGlow;
 
-  /// When true, the glow appears on touch-down but is suppressed after a
-  /// >10px drag, preventing a "stuck glow" during scrolling.
+  /// Whether the glow should act as a momentary tap indicator.
+  ///
+  /// If true, the glow will appear on tap but will automatically fade out
+  /// if the user starts dragging. It will not reappear until a new tap starts.
+  /// Default: false.
   final bool glowOnTapOnly;
 
-  /// Color of the interaction glow. Defaults to white at 15% opacity.
+  /// Custom color for the touch interaction glow.
   final Color? glowColor;
 
-  /// Radius of the interaction glow relative to the surface's shortest side.
-  /// Defaults to 1.0.
+  /// Radius of the touch interaction glow. Default: 0.6.
   final double glowRadius;
+
+  /// Custom color for the menu selection background.
+  final Color selectionColor;
+
+  /// Optional fixed height for the menu.
+  ///
+  /// If null, the menu will size itself to fit its items.
+  /// If provided, the menu will have a fixed height and internal scrolling.
+  final double? menuHeight;
 
   /// Creates a liquid glass menu.
   const GlassMenu({
@@ -128,27 +136,25 @@ class GlassMenu extends StatefulWidget {
     this.triggerBuilder,
     required this.items,
     this.menuWidth = 200,
-    this.menuHeight,
-    this.menuBorderRadius = 16.0,
+    this.menuBorderRadius = 32.0,
     this.glassSettings,
     this.quality,
-    this.interactionScale = 1.05,
     this.stretch = 0.5,
+    this.interactionScale = 1.02,
     this.stretchResistance = 0.08,
     this.stretchAxis,
-    this.allowPositiveX,
-    this.allowNegativeX,
-    this.allowPositiveY,
-    this.allowNegativeY,
-    this.selectionColor,
+    this.allowPositiveXStretch,
+    this.allowNegativeXStretch,
+    this.allowPositiveYStretch,
+    this.allowNegativeYStretch,
+    this.menuHeight,
+    this.selectionColor = const Color(0x3DFFFFFF),
     this.enableInteractionGlow = true,
-    this.glowOnTapOnly = true,
+    this.glowOnTapOnly = false,
     this.glowColor,
-    this.glowRadius = 1.0,
-  }) : assert(
-          trigger != null || triggerBuilder != null,
-          'Either trigger or triggerBuilder must be provided',
-        );
+    this.glowRadius = 0.6,
+  }) : assert(trigger != null || triggerBuilder != null,
+            'Either trigger or triggerBuilder must be provided');
 
   @override
   State<GlassMenu> createState() => _GlassMenuState();

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -90,19 +90,19 @@ class GlassMenu extends StatefulWidget {
 
   /// Whether to allow stretch in the positive X direction (Right).
   /// If null, automatically determined by menu position.
-  final bool? allowPositiveXStretch;
+  final bool? allowPositiveX;
 
   /// Whether to allow stretch in the negative X direction (Left).
   /// If null, automatically determined by menu position.
-  final bool? allowNegativeXStretch;
+  final bool? allowNegativeX;
 
   /// Whether to allow stretch in the positive Y direction (Down).
   /// If null, automatically determined by menu position.
-  final bool? allowPositiveYStretch;
+  final bool? allowPositiveY;
 
   /// Whether to allow stretch in the negative Y direction (Up).
   /// If null, automatically determined by menu position.
-  final bool? allowNegativeYStretch;
+  final bool? allowNegativeY;
 
   /// Whether to show glow/glare on touch for tactile feedback. Default: true.
   final bool enableInteractionGlow;
@@ -111,7 +111,7 @@ class GlassMenu extends StatefulWidget {
   ///
   /// If true, the glow will appear on tap but will automatically fade out
   /// if the user starts dragging. It will not reappear until a new tap starts.
-  /// Default: false.
+  /// Default: true.
   final bool glowOnTapOnly;
 
   /// Custom color for the touch interaction glow.
@@ -119,6 +119,11 @@ class GlassMenu extends StatefulWidget {
 
   /// Radius of the touch interaction glow. Default: 0.6.
   final double glowRadius;
+
+  /// The intensity of the interactive glow.
+  ///
+  /// Defaults to 0.0.
+  final double glowIntensity;
 
   /// Custom color for the menu selection background.
   final Color selectionColor;
@@ -143,16 +148,17 @@ class GlassMenu extends StatefulWidget {
     this.interactionScale = 1.02,
     this.stretchResistance = 0.08,
     this.stretchAxis,
-    this.allowPositiveXStretch,
-    this.allowNegativeXStretch,
-    this.allowPositiveYStretch,
-    this.allowNegativeYStretch,
+    this.allowPositiveX,
+    this.allowNegativeX,
+    this.allowPositiveY,
+    this.allowNegativeY,
     this.menuHeight,
     this.selectionColor = const Color(0x3DFFFFFF),
     this.enableInteractionGlow = true,
-    this.glowOnTapOnly = false,
+    this.glowOnTapOnly = true,
     this.glowColor,
     this.glowRadius = 0.6,
+    this.glowIntensity = 0.0,
   }) : assert(trigger != null || triggerBuilder != null,
             'Either trigger or triggerBuilder must be provided');
 

--- a/lib/widgets/overlays/glass_menu_item.dart
+++ b/lib/widgets/overlays/glass_menu_item.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 /// A menu item for use within a [GlassMenu].
 ///
 /// [GlassMenuItem] provides a standard layout for menu options, including
-/// support for icons, labels, subtitles, and "destructive" styling.
+/// support for icons, labels, and "destructive" styling. It handles its own
+/// hover and tap interactions with liquid glass effects.
 class GlassMenuItem extends StatefulWidget {
   /// Creates a glass menu item.
   const GlassMenuItem({
@@ -15,6 +16,8 @@ class GlassMenuItem extends StatefulWidget {
     this.trailing,
     this.height = 44.0,
     this.subtitle,
+    this.isPressed,
+    this.isSelected = false,
     this.enabled = true,
     this.titleStyle,
     this.subtitleStyle,
@@ -25,11 +28,11 @@ class GlassMenuItem extends StatefulWidget {
   /// The primary text of the item.
   final String title;
 
-  /// Optional secondary text shown below [title].
-  final String? subtitle;
-
   /// The icon widget displayed before the title.
   final Widget? icon;
+
+  /// Optional subtitle text displayed below the title.
+  final String? subtitle;
 
   /// Callback when the item is tapped.
   final VoidCallback onTap;
@@ -39,12 +42,6 @@ class GlassMenuItem extends StatefulWidget {
   /// Renders with red text and distinct hover effect.
   final bool isDestructive;
 
-  /// Whether this item is enabled and interactive.
-  ///
-  /// When false, the item is rendered at reduced opacity and tap gestures
-  /// are ignored. Defaults to true.
-  final bool enabled;
-
   /// A widget to display after the title (e.g., shortcut key).
   final Widget? trailing;
 
@@ -53,30 +50,117 @@ class GlassMenuItem extends StatefulWidget {
   /// Defaults to 44.0 (standard iOS touch target).
   final double height;
 
-  /// Custom text style for the title. When null, uses the default style
-  /// derived from [isDestructive].
+  /// External override for the pressed state.
+  final bool? isPressed;
+
+  /// Whether the item is currently selected (e.g. by a sliding pill).
+  final bool isSelected;
+
+  /// Whether the item should handle its own interactions.
+  final bool enabled;
+
+  /// Custom text style for the title.
   final TextStyle? titleStyle;
 
-  /// Custom text style for the subtitle. When null, uses a muted default.
+  /// Custom text style for the subtitle.
   final TextStyle? subtitleStyle;
 
-  /// Override for the icon foreground color. Falls back to the computed
-  /// color from [isDestructive] when null.
+  /// Custom color for the icon.
   final Color? iconColor;
 
-  /// Size of the icon. Defaults to 20.0.
+  /// Custom size for the icon.
   final double iconSize;
 
   @override
   State<GlassMenuItem> createState() => _GlassMenuItemState();
 }
 
+/// A separator line for use within a [GlassMenu].
+class GlassMenuDivider extends StatelessWidget {
+  /// The height of the divider area (line + spacing).
+  final double height;
+
+  /// Custom color for the divider line.
+  final Color? color;
+
+  /// Horizontal padding for the divider line.
+  final double indent;
+
+  /// Creates a glass menu divider.
+  const GlassMenuDivider({
+    super.key,
+    this.height = 12.0,
+    this.color,
+    this.indent = 8.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      child: Center(
+        child: Container(
+          height: 0.5,
+          margin: EdgeInsets.symmetric(horizontal: indent),
+          color: color ?? const Color(0x26FFFFFF), // 15% white line default
+        ),
+      ),
+    );
+  }
+}
+
+/// A non-interactive label or content item for use within a [GlassMenu].
+///
+/// Use this for headers, section labels, or purely decorative content.
+/// It does not respond to hover/press and is ignored by the selection pill.
+class GlassMenuLabel extends StatelessWidget {
+  /// The content to display.
+  final Widget child;
+
+  /// The height of the item.
+  ///
+  /// Defaults to 32.0 (slightly shorter than a standard menu item).
+  final double height;
+
+  /// Horizontal padding for the content.
+  final double horizontalPadding;
+
+  /// Creates a glass menu label.
+  const GlassMenuLabel({
+    required this.child,
+    super.key,
+    this.height = 32.0,
+    this.horizontalPadding = 16.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+      alignment: Alignment.centerLeft,
+      child: DefaultTextStyle(
+        style: const TextStyle(
+          color: Color(0x99FFFFFF), // 60% white default
+          fontSize: 13,
+          fontWeight: FontWeight.w500,
+          letterSpacing: -0.1,
+        ),
+        child: IconTheme(
+          data: const IconThemeData(
+            color: Color(0x99FFFFFF),
+            size: 16,
+          ),
+          child: child,
+        ),
+      ),
+    );
+  }
+}
+
 class _GlassMenuItemState extends State<GlassMenuItem> {
   bool _isHovered = false;
   bool _isPressed = false;
-
-  // QUALITY 1 FIX: Clear hover flag on dispose so it cannot leak when the
-  // overlay closes while the desktop cursor is still positioned over this item.
   @override
   void dispose() {
     _isHovered = false;
@@ -85,32 +169,45 @@ class _GlassMenuItemState extends State<GlassMenuItem> {
 
   @override
   Widget build(BuildContext context) {
-    // Smart color inheritance: iconColor → titleStyle.color → destructive → white
-    final Color defaultTextColor = widget.isDestructive
-        ? const Color(0xFFEF5350)
-        : const Color(0xE6FFFFFF);
-    final Color defaultIconColor = widget.iconColor ??
+    // Performance: Cache static colors to avoid recalculation on every build
+    // Determine the base color of the item (inheritance logic)
+    // Priority: iconColor > titleStyle.color > destructiveRed > white
+    final Color baseColor = widget.iconColor ??
         widget.titleStyle?.color ??
         (widget.isDestructive
-            ? const Color(0xFFEF5350)
-            : const Color(0xB3FFFFFF));
+            ? const Color(0xFFEF5350) // Colors.red.shade400
+            : Colors.white);
 
-    final Color textColor = widget.titleStyle?.color ?? defaultTextColor;
+    // Apply specific opacities based on original design specs:
+    // Icon: 100% (enabled), 50% (disabled)
+    // Text: 90% (static for enabled/disabled)
+    final Color iconColor = widget.iconColor ??
+        (widget.isDestructive
+            ? Colors.redAccent
+            : baseColor.withValues(alpha: widget.enabled ? 1.0 : 0.5));
 
-    final Color backgroundColor = _isPressed
-        ? const Color(0x26FFFFFF)
-        : _isHovered
-            ? const Color(0x1AFFFFFF)
-            : Colors.transparent;
+    final Color textColor = widget.titleStyle?.color ??
+        (widget.isDestructive
+            ? const Color(0xFFEF5350) // Colors.red.shade400
+            : baseColor.withValues(alpha: 0.9));
+    // Dynamic background for hover/press states
+    // We use a subtle white overlay to "brighten" the glass
+    final bool effectivePressed = widget.isPressed ?? _isPressed;
+    final bool effectiveSelected = widget.isSelected;
 
-    final double scale = _isPressed ? 0.98 : 1.0;
-    final bool hasSubtitle = widget.subtitle != null;
+    final Color backgroundColor = effectiveSelected
+        ? Colors.transparent // Parent renders the sliding pill
+        : effectivePressed
+            ? const Color(0x26FFFFFF) // Standalone press
+            : _isHovered
+                ? const Color(0x1AFFFFFF)
+                : Colors.transparent;
 
-    // Increase height when subtitle is present if no explicit height override.
-    final double effectiveHeight =
-        hasSubtitle && widget.height == 44.0 ? 58.0 : widget.height;
+    // Scale effect on press (subtle squash like iOS buttons)
+    final double scale = effectivePressed ? 0.98 : 1.0;
 
-    final Widget content = GestureDetector(
+    // Build the item content
+    return GestureDetector(
       onTapDown:
           widget.enabled ? (_) => setState(() => _isPressed = true) : null,
       onTapUp:
@@ -122,67 +219,46 @@ class _GlassMenuItemState extends State<GlassMenuItem> {
         onEnter: (_) => setState(() => _isHovered = true),
         onExit: (_) => setState(() => _isHovered = false),
         child: SizedBox(
-          height: effectiveHeight,
-          // SizedBox fixes the layout footprint so AnimatedScale's
-          // RenderTransform cannot overflow its parent (Stack or Column).
-          // Transform-based widgets retain the pre-scale layout size, which
-          // causes the overflow banner during press (scale=0.98) inside the
-          // menu's bounded Positioned.fill.
+          height: widget.height,
           child: AnimatedScale(
             scale: scale,
             duration: const Duration(milliseconds: 150),
             curve: Curves.easeOutCubic,
             child: AnimatedContainer(
-              duration: const Duration(milliseconds: 150),
+              duration: effectiveSelected
+                  ? Duration.zero
+                  : const Duration(milliseconds: 150),
               curve: Curves.easeOutCubic,
-              height: effectiveHeight,
+              height: widget.height,
               padding: const EdgeInsets.symmetric(horizontal: 16),
               decoration: BoxDecoration(
                 color: backgroundColor,
-                borderRadius: BorderRadius.circular(10),
+                borderRadius: BorderRadius.circular(24),
               ),
-              child: Row(
-                children: [
-                  // Icon
-                  if (widget.icon != null) ...[
-                    IconTheme(
-                      data: IconThemeData(
-                          color: defaultIconColor, size: widget.iconSize),
-                      child: widget.icon!,
-                    ),
-                    const SizedBox(width: 12),
-                  ],
+                child: Row(
+                  children: [
+                    // Icon
+                    if (widget.icon != null) ...[
+                      IconTheme(
+                        data: IconThemeData(
+                          color: iconColor,
+                          size: widget.iconSize,
+                        ),
+                        child: widget.icon!,
+                      ),
+                      const SizedBox(width: 12),
+                    ],
 
-                  // Title (+ optional subtitle)
-                  Expanded(
-                    child: hasSubtitle
-                        ? Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                widget.title,
-                                style: widget.titleStyle ??
-                                    TextStyle(
-                                      color: textColor,
-                                      fontSize: 17,
-                                      fontWeight: FontWeight.w400,
-                                    ),
-                              ),
-                              Text(
-                                widget.subtitle!,
-                                style: widget.subtitleStyle ??
-                                    TextStyle(
-                                      color:
-                                          Colors.white.withValues(alpha: 0.5),
-                                      fontSize: 12,
-                                      fontWeight: FontWeight.w400,
-                                    ),
-                              ),
-                            ],
-                          )
-                        : Text(
+                    // Text Content (Title & Subtitle)
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
                             widget.title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                             style: widget.titleStyle ??
                                 TextStyle(
                                   color: textColor,
@@ -190,85 +266,29 @@ class _GlassMenuItemState extends State<GlassMenuItem> {
                                   fontWeight: FontWeight.w400,
                                 ),
                           ),
-                  ),
+                          if (widget.subtitle != null)
+                            Text(
+                              widget.subtitle!,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: widget.subtitleStyle ??
+                                  TextStyle(
+                                    color: textColor.withValues(alpha: 0.6),
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w400,
+                                  ),
+                            ),
+                        ],
+                      ),
+                    ),
 
-                  // Trailing
-                  if (widget.trailing != null) widget.trailing!,
-                ],
+                    // Trailing
+                    if (widget.trailing != null) widget.trailing!,
+                  ],
+                ),
               ),
             ),
           ),
-        ),
-      ),
-    );
-
-    return widget.enabled ? content : Opacity(opacity: 0.4, child: content);
-  }
-}
-
-/// A subtle hairline separator for use within a [GlassMenu].
-///
-/// Place between [GlassMenuItem] instances to create visual groupings.
-/// Renders as a thin semi-transparent horizontal line.
-class GlassMenuDivider extends StatelessWidget {
-  /// Creates a glass menu divider.
-  const GlassMenuDivider({super.key, this.height = 1.0, this.color});
-
-  /// Height of the divider line. Defaults to 1.0.
-  final double height;
-
-  /// Color of the divider. Defaults to white at 15% opacity.
-  final Color? color;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      height: height,
-      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      color: color ?? Colors.white.withValues(alpha: 0.15),
-    );
-  }
-}
-
-/// A non-interactive section label for use within a [GlassMenu].
-///
-/// Use to add named groupings above related [GlassMenuItem]s.
-/// Renders in a small, muted caption style.
-class GlassMenuLabel extends StatelessWidget {
-  /// Creates a glass menu section label.
-  const GlassMenuLabel({
-    required this.title,
-    super.key,
-    this.style,
-    // QUALITY 3 FIX: Explicit height so _getItemHeight() in the menu state
-    // uses this value rather than a hardcoded 30.0, preventing pill-position
-    // drift when a custom style has a non-default fontSize.
-    this.height = 30.0,
-  });
-
-  /// The label text.
-  final String title;
-
-  /// Override for the default caption text style.
-  final TextStyle? style;
-
-  /// Height of this label row, used by [GlassMenu] to compute the selection
-  /// pill position. Defaults to 30.0 — increase if using a large [style].
-  final double height;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 16, right: 16, top: 8, bottom: 2),
-      child: Text(
-        title.toUpperCase(),
-        style: style ??
-            TextStyle(
-              color: Colors.white.withValues(alpha: 0.45),
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0.8,
-            ),
       ),
     );
   }

--- a/lib/widgets/overlays/glass_menu_item.dart
+++ b/lib/widgets/overlays/glass_menu_item.dart
@@ -235,56 +235,59 @@ class _GlassMenuItemState extends State<GlassMenuItem> {
                 color: backgroundColor,
                 borderRadius: BorderRadius.circular(24),
               ),
-                child: Row(
-                  children: [
-                    // Icon
-                    if (widget.icon != null) ...[
-                      IconTheme(
-                        data: IconThemeData(
-                          color: iconColor,
-                          size: widget.iconSize,
-                        ),
-                        child: widget.icon!,
-                      ),
-                      const SizedBox(width: 12),
-                    ],
-
-                    // Text Content (Title & Subtitle)
-                    Expanded(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            widget.title,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: widget.titleStyle ??
-                                TextStyle(
-                                  color: textColor,
-                                  fontSize: 17,
-                                  fontWeight: FontWeight.w400,
-                                ),
+                child: Opacity(
+                  opacity: widget.enabled ? 1.0 : 0.4,
+                  child: Row(
+                    children: [
+                      // Icon
+                      if (widget.icon != null) ...[
+                        IconTheme(
+                          data: IconThemeData(
+                            color: iconColor,
+                            size: widget.iconSize,
                           ),
-                          if (widget.subtitle != null)
+                          child: widget.icon!,
+                        ),
+                        const SizedBox(width: 12),
+                      ],
+  
+                      // Text Content (Title & Subtitle)
+                      Expanded(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
                             Text(
-                              widget.subtitle!,
+                              widget.title,
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
-                              style: widget.subtitleStyle ??
+                              style: widget.titleStyle ??
                                   TextStyle(
-                                    color: textColor.withValues(alpha: 0.6),
-                                    fontSize: 13,
+                                    color: textColor,
+                                    fontSize: 17,
                                     fontWeight: FontWeight.w400,
                                   ),
                             ),
-                        ],
+                            if (widget.subtitle != null)
+                              Text(
+                                widget.subtitle!,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: widget.subtitleStyle ??
+                                    TextStyle(
+                                      color: textColor.withValues(alpha: 0.6),
+                                      fontSize: 13,
+                                      fontWeight: FontWeight.w400,
+                                    ),
+                              ),
+                          ],
+                        ),
                       ),
-                    ),
-
-                    // Trailing
-                    if (widget.trailing != null) widget.trailing!,
-                  ],
+  
+                      // Trailing
+                      if (widget.trailing != null) widget.trailing!,
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/widgets/overlays/glass_menu_item.dart
+++ b/lib/widgets/overlays/glass_menu_item.dart
@@ -114,24 +114,33 @@ class GlassMenuDivider extends StatelessWidget {
 /// Use this for headers, section labels, or purely decorative content.
 /// It does not respond to hover/press and is ignored by the selection pill.
 class GlassMenuLabel extends StatelessWidget {
-  /// The content to display.
-  final Widget child;
+  /// The label text. If provided, renders stylized uppercase text.
+  final String? title;
+
+  /// The custom widget to display. Use this if [title] is null.
+  final Widget? child;
 
   /// The height of the item.
   ///
-  /// Defaults to 32.0 (slightly shorter than a standard menu item).
+  /// Defaults to 30.0 (aligned with author's fix to prevent pill-position drift).
   final double height;
 
-  /// Horizontal padding for the content.
+  /// Override for the default caption text style. Only used if [title] is provided.
+  final TextStyle? style;
+
+  /// Horizontal padding for the content. Only used if [child] is provided.
   final double horizontalPadding;
 
   /// Creates a glass menu label.
   const GlassMenuLabel({
-    required this.child,
-    super.key,
-    this.height = 32.0,
+    this.title,
+    this.child,
+    this.style,
+    this.height = 30.0,
     this.horizontalPadding = 16.0,
-  });
+    super.key,
+  }) : assert(title != null || child != null,
+            'Either title or child must be provided');
 
   @override
   Widget build(BuildContext context) {
@@ -139,21 +148,17 @@ class GlassMenuLabel extends StatelessWidget {
       height: height,
       padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
       alignment: Alignment.centerLeft,
-      child: DefaultTextStyle(
-        style: const TextStyle(
-          color: Color(0x99FFFFFF), // 60% white default
-          fontSize: 13,
-          fontWeight: FontWeight.w500,
-          letterSpacing: -0.1,
-        ),
-        child: IconTheme(
-          data: const IconThemeData(
-            color: Color(0x99FFFFFF),
-            size: 16,
+      child: child ??
+          Text(
+            title!.toUpperCase(),
+            style: style ??
+                TextStyle(
+                  color: Colors.white.withValues(alpha: 0.45),
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0.8,
+                ),
           ),
-          child: child,
-        ),
-      ),
     );
   }
 }
@@ -235,63 +240,63 @@ class _GlassMenuItemState extends State<GlassMenuItem> {
                 color: backgroundColor,
                 borderRadius: BorderRadius.circular(24),
               ),
-                child: Opacity(
-                  opacity: widget.enabled ? 1.0 : 0.4,
-                  child: Row(
-                    children: [
-                      // Icon
-                      if (widget.icon != null) ...[
-                        IconTheme(
-                          data: IconThemeData(
-                            color: iconColor,
-                            size: widget.iconSize,
-                          ),
-                          child: widget.icon!,
+              child: Opacity(
+                opacity: widget.enabled ? 1.0 : 0.4,
+                child: Row(
+                  children: [
+                    // Icon
+                    if (widget.icon != null) ...[
+                      IconTheme(
+                        data: IconThemeData(
+                          color: iconColor,
+                          size: widget.iconSize,
                         ),
-                        const SizedBox(width: 12),
-                      ],
-  
-                      // Text Content (Title & Subtitle)
-                      Expanded(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
+                        child: widget.icon!,
+                      ),
+                      const SizedBox(width: 12),
+                    ],
+
+                    // Text Content (Title & Subtitle)
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            widget.title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: widget.titleStyle ??
+                                TextStyle(
+                                  color: textColor,
+                                  fontSize: 17,
+                                  fontWeight: FontWeight.w400,
+                                ),
+                          ),
+                          if (widget.subtitle != null)
                             Text(
-                              widget.title,
+                              widget.subtitle!,
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
-                              style: widget.titleStyle ??
+                              style: widget.subtitleStyle ??
                                   TextStyle(
-                                    color: textColor,
-                                    fontSize: 17,
+                                    color: textColor.withValues(alpha: 0.6),
+                                    fontSize: 13,
                                     fontWeight: FontWeight.w400,
                                   ),
                             ),
-                            if (widget.subtitle != null)
-                              Text(
-                                widget.subtitle!,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: widget.subtitleStyle ??
-                                    TextStyle(
-                                      color: textColor.withValues(alpha: 0.6),
-                                      fontSize: 13,
-                                      fontWeight: FontWeight.w400,
-                                    ),
-                              ),
-                          ],
-                        ),
+                        ],
                       ),
-  
-                      // Trailing
-                      if (widget.trailing != null) widget.trailing!,
-                    ],
-                  ),
+                    ),
+
+                    // Trailing
+                    if (widget.trailing != null) widget.trailing!,
+                  ],
                 ),
               ),
             ),
           ),
+        ),
       ),
     );
   }

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -27,6 +27,13 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     super.didUpdateWidget(oldWidget);
     if (!identical(widget.items, oldWidget.items)) {
       _cachedWrappedItems = null;
+      // BUG 12 FIX: Clear hover state if items shrink while menu is open
+      // to prevent RangeError when the selection pill tries to measure
+      // a now-deleted index.
+      if (widget.items.length < oldWidget.items.length) {
+        _hoveredIndex = null;
+        _hoveredIndexNotifier.value = null;
+      }
     }
   }
 
@@ -367,8 +374,9 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
                       ValueListenableBuilder<int?>(
                         valueListenable: _hoveredIndexNotifier,
                         builder: (context, hoveredIndex, _) {
-                          if (hoveredIndex == null)
+                          if (hoveredIndex == null) {
                             return const SizedBox.shrink();
+                          }
                           return AnimatedPositioned(
                             duration: const Duration(milliseconds: 150),
                             curve: Curves.easeOutCubic,

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -1,270 +1,81 @@
 part of '../glass_menu.dart';
 
-class _GlassMenuState extends State<GlassMenu>
-    with SingleTickerProviderStateMixin {
+class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
   final LayerLink _layerLink = LayerLink();
   final OverlayPortalController _overlayController = OverlayPortalController();
 
   late final AnimationController _animationController;
   late final ScrollController _scrollController;
-
   Size? _triggerSize;
   double? _triggerBorderRadius;
-  Alignment _morphAlignment = Alignment.topLeft;
-
-  final _springDescription = const SpringDescription(
-    mass: 1.0,
-    stiffness: 300.0,
-    damping: 24.0,
-  );
-
-  // --- Selection Pill ---
   int? _hoveredIndex;
-  Offset? _pointerDownPos;
-  bool _isScrolling = false;
-  double _scrollOffset = 0.0;
+  bool _isDragging = false;
+  bool _hasStretched =
+      false; // Prevents closing if we moved into stretch territory
+  double _initialScrollOffset = 0.0;
+  Offset _initialLocalPosition = Offset.zero;
 
-  // --- Wrapped-items cache (BUG 5: prevents GlassMenuItem remount per setState) ---
+  // --- Granular Update System (Performance + No flicker) ---
+  // We cache the outer list but use notifiers to update selection state
+  // without rebuilding the entire menu tree.
+  late final ValueNotifier<int?> _hoveredIndexNotifier;
+  late final ValueNotifier<bool> _isDraggingNotifier;
   List<Widget>? _cachedWrappedItems;
 
-  // ---------------------------------------------------------------------------
-  // Lifecycle
-  // ---------------------------------------------------------------------------
+  @override
+  void didUpdateWidget(GlassMenu oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(widget.items, oldWidget.items)) {
+      _cachedWrappedItems = null;
+    }
+  }
+
+  // iOS 26 Liquid Glass smooth spring physics
+  // Gentle, fluid motion with subtle overshoot - NOT harsh bounces
+  //
+  // Response: ~0.35s (smooth, not too fast)
+  // DampingFraction: 0.7 (slightly underdamped = gentle settle, no harsh bounce)
+  // Result: Seamless liquid feel that complements the swoop curve
+  //
+  // Conversion to Flutter SpringSimulation:
+  // - stiffness: 300 (smooth, not too snappy)
+  // - damping: 2 * 0.7 * sqrt(300) ≈ 24.2
+  final _springDescription = const SpringDescription(
+    mass: 1.0,
+    stiffness: 300.0, // Smooth motion (not too fast)
+    damping: 24.0, // Gentle settle (no harsh bounce)
+  );
+
+  Alignment _morphAlignment = Alignment.topLeft;
 
   @override
   void initState() {
     super.initState();
-    _scrollController = ScrollController()
-      ..addListener(() {
-        if (mounted) setState(() => _scrollOffset = _scrollController.offset);
-      });
-
     _animationController = AnimationController.unbounded(vsync: this);
     _animationController.addListener(() {
+      // Rebuild on each spring physics tick
       if (mounted) setState(() {});
+
+      // Auto-hide when spring settles back to closed state
       if (_overlayController.isShowing &&
           _animationController.value <= 0.001 &&
           _animationController.status != AnimationStatus.forward) {
         _overlayController.hide();
       }
     });
-  }
-
-  @override
-  void didUpdateWidget(GlassMenu oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    // BUG 5: Invalidate wrapped-items cache when items list changes.
-    if (!identical(widget.items, oldWidget.items)) {
-      _cachedWrappedItems = null;
-    }
-    // BUG 4: Guard _hoveredIndex against RangeError when items are mutated.
-    if (widget.items.length != oldWidget.items.length &&
-        _hoveredIndex != null &&
-        _hoveredIndex! >= widget.items.length) {
-      _hoveredIndex = null;
-    }
+    _scrollController = ScrollController();
+    _hoveredIndexNotifier = ValueNotifier(null);
+    _isDraggingNotifier = ValueNotifier(false);
   }
 
   @override
   void dispose() {
     _animationController.dispose();
     _scrollController.dispose();
+    _hoveredIndexNotifier.dispose();
+    _isDraggingNotifier.dispose();
     super.dispose();
   }
-
-  // ---------------------------------------------------------------------------
-  // Menu Control
-  // ---------------------------------------------------------------------------
-
-  void _runSpring(double target) {
-    _animationController.animateWith(
-      SpringSimulation(
-          _springDescription, _animationController.value, target, 0.0),
-    );
-  }
-
-  void _toggleMenu() {
-    if (_overlayController.isShowing && _animationController.value > 0.1) {
-      _closeMenu();
-    } else {
-      _openMenu();
-    }
-  }
-
-  void _openMenu() {
-    final renderBox = context.findRenderObject() as RenderBox?;
-    if (renderBox == null || !renderBox.hasSize) return;
-
-    _triggerSize = renderBox.size;
-    _triggerBorderRadius = _triggerSize!.height / 2;
-
-    final position = renderBox.localToGlobal(Offset.zero);
-    final mq = MediaQuery.maybeOf(context);
-    final screenWidth = mq?.size.width ?? double.infinity;
-    final screenHeight = mq?.size.height ?? double.infinity;
-    final menuH = _calculateMenuHeight();
-
-    final isRightHalf = screenWidth.isFinite && position.dx > screenWidth / 2;
-    final spaceBelow = screenHeight.isFinite
-        ? screenHeight - (position.dy + _triggerSize!.height)
-        : double.infinity;
-    final spaceAbove = screenHeight.isFinite ? position.dy : double.infinity;
-
-    _morphAlignment = (spaceBelow < menuH && spaceAbove > menuH)
-        ? (isRightHalf ? Alignment.bottomRight : Alignment.bottomLeft)
-        : (isRightHalf ? Alignment.topRight : Alignment.topLeft);
-
-    if (_scrollController.hasClients) _scrollController.jumpTo(0);
-    setState(() {
-      _hoveredIndex = null;
-      _isScrolling = false;
-      _scrollOffset = 0.0;
-    });
-
-    _overlayController.show();
-    _runSpring(1.0);
-  }
-
-  void _closeMenu() {
-    setState(() => _hoveredIndex = null);
-    _runSpring(0.0);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Height / Layout Helpers
-  // ---------------------------------------------------------------------------
-
-  double _getItemHeight(Widget item) {
-    if (item is GlassMenuItem) {
-      return (item.subtitle != null && item.height == 44.0)
-          ? 58.0
-          : item.height;
-    }
-    // QUALITY 3: GlassMenuLabel now exposes .height so custom fonts work.
-    if (item is GlassMenuDivider) return item.height + 8.0;
-    if (item is GlassMenuLabel) return item.height;
-    return 44.0;
-  }
-
-  double _calculateMenuHeight() {
-    if (widget.menuHeight != null) return widget.menuHeight! + 16.0;
-    return widget.items.fold<double>(0.0, (s, i) => s + _getItemHeight(i)) +
-        16.0;
-  }
-
-  double _calculateSwoopOffset(double t) =>
-      (1.0 - 4.0 * (t - 0.5) * (t - 0.5)) * 5.0;
-
-  // ---------------------------------------------------------------------------
-  // Wrapped Items Cache (BUG 5)
-  // ---------------------------------------------------------------------------
-
-  /// Returns [GlassMenuItem] instances with [_closeMenu] wired in.
-  ///
-  /// Cached so that element identity is stable across the frequent [setState]
-  /// calls driven by the spring animation ticker, preventing [_GlassMenuItemState]
-  /// from remounting (which resets its pressed/hover state on every frame).
-  List<Widget> _buildWrappedItems() {
-    return _cachedWrappedItems ??= widget.items.map((item) {
-      if (item is GlassMenuItem) {
-        return GlassMenuItem(
-          // Stable key prevents element reconciliation confusion.
-          key: item.key ?? ValueKey(item.title),
-          title: item.title,
-          subtitle: item.subtitle,
-          icon: item.icon,
-          isDestructive: item.isDestructive,
-          enabled: item.enabled,
-          trailing: item.trailing,
-          height: item.height,
-          titleStyle: item.titleStyle,
-          subtitleStyle: item.subtitleStyle,
-          iconColor: item.iconColor,
-          iconSize: item.iconSize,
-          onTap: () {
-            item.onTap();
-            _closeMenu();
-          },
-        );
-      }
-      return item;
-    }).toList();
-  }
-
-  // ---------------------------------------------------------------------------
-  // Selection Pill Helpers
-  // ---------------------------------------------------------------------------
-
-  /// Y-start of each item in the full (unscrolled) content column.
-  List<double> _computeItemTops() {
-    double y = 0.0;
-    return widget.items.map((item) {
-      final top = y;
-      y += _getItemHeight(item);
-      return top;
-    }).toList();
-  }
-
-  /// [widget.items] index of the enabled [GlassMenuItem] under [contentY],
-  /// adjusted for the current scroll offset.
-  int? _indexAtContentY(double contentY) {
-    final scrolledY = contentY + _scrollOffset;
-    double y = 0.0;
-    for (int i = 0; i < widget.items.length; i++) {
-      final h = _getItemHeight(widget.items[i]);
-      if (scrolledY >= y && scrolledY < y + h) {
-        final item = widget.items[i];
-        if (item is GlassMenuItem && item.enabled) return i;
-        return null;
-      }
-      y += h;
-    }
-    return null;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Pointer Handlers
-  // ---------------------------------------------------------------------------
-
-  void _onMenuPointerDown(PointerDownEvent e) {
-    _pointerDownPos = e.localPosition;
-    _isScrolling = false;
-    setState(() => _hoveredIndex = _indexAtContentY(e.localPosition.dy - 8));
-  }
-
-  void _onMenuPointerMove(PointerMoveEvent e) {
-    if (_isScrolling) return;
-    final dist = (e.localPosition - (_pointerDownPos ?? Offset.zero)).distance;
-    if (dist > 10.0) {
-      setState(() => _hoveredIndex = null);
-      return;
-    }
-    setState(() => _hoveredIndex = _indexAtContentY(e.localPosition.dy - 8));
-  }
-
-  void _onMenuPointerUp(PointerUpEvent e) {
-    _pointerDownPos = null;
-    setState(() => _hoveredIndex = null);
-  }
-
-  void _onMenuPointerCancel(PointerCancelEvent e) {
-    _pointerDownPos = null;
-    setState(() => _hoveredIndex = null);
-  }
-
-  bool _onScrollNotification(ScrollNotification notification) {
-    if (notification is ScrollStartNotification) {
-      _isScrolling = true;
-      setState(() => _hoveredIndex = null);
-    } else if (notification is ScrollEndNotification) {
-      _isScrolling = false;
-    }
-    return false;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Build
-  // ---------------------------------------------------------------------------
 
   @override
   Widget build(BuildContext context) {
@@ -275,6 +86,7 @@ class _GlassMenuState extends State<GlassMenu>
       link: _layerLink,
       child: Stack(
         children: [
+          // Original trigger button (hidden when menu is morphing)
           Opacity(
             opacity: isMenuOpen ? 0.0 : 1.0,
             child: IgnorePointer(
@@ -287,6 +99,8 @@ class _GlassMenuState extends State<GlassMenu>
                     ),
             ),
           ),
+
+          // Overlay portal for morphing animation
           OverlayPortal(
             controller: _overlayController,
             overlayChildBuilder: _buildMorphingOverlay,
@@ -296,71 +110,199 @@ class _GlassMenuState extends State<GlassMenu>
     );
   }
 
+  void _runSpring(double target) {
+    final simulation = SpringSimulation(
+      _springDescription,
+      _animationController.value,
+      target,
+      0.0, // Initial velocity (could add velocity for swipe gestures)
+    );
+    _animationController.animateWith(simulation);
+  }
+
+  void _toggleMenu() {
+    if (_overlayController.isShowing && _animationController.value > 0.1) {
+      _closeMenu();
+    } else {
+      _openMenu();
+    }
+  }
+
+  void _openMenu() {
+    // Capture geometry and screen position for morphing
+    final renderBox = context.findRenderObject() as RenderBox?;
+    if (renderBox == null || !renderBox.hasSize) {
+      // Safety: Cannot open menu if render box is not ready
+      return;
+    }
+
+    _triggerSize = renderBox.size;
+    _triggerBorderRadius = _triggerSize!.height / 2;
+
+    // Determine alignment based on screen position
+    // This ensures menu doesn't overflow screen edges
+    final position = renderBox.localToGlobal(Offset.zero);
+    final mediaQuery = MediaQuery.maybeOf(context);
+    final screenWidth = mediaQuery?.size.width ?? double.infinity;
+    final screenHeight = mediaQuery?.size.height ?? double.infinity;
+
+    // Calculate menu height for vertical boundary check
+    final menuHeight = _calculateMenuHeight();
+
+    // Horizontal alignment: left vs right half
+    final isRightHalf = screenWidth.isFinite && position.dx > screenWidth / 2;
+
+    // Vertical alignment: check if menu would overflow bottom
+    final spaceBelow = screenHeight.isFinite
+        ? screenHeight - (position.dy + _triggerSize!.height)
+        : double.infinity;
+    final spaceAbove = screenHeight.isFinite ? position.dy : double.infinity;
+
+    // Prefer downward opening unless insufficient space
+    final shouldFlipVertical =
+        spaceBelow < menuHeight && spaceAbove > menuHeight;
+
+    // Determine final alignment based on both axes
+    if (shouldFlipVertical) {
+      _morphAlignment =
+          isRightHalf ? Alignment.bottomRight : Alignment.bottomLeft;
+    } else {
+      _morphAlignment = isRightHalf ? Alignment.topRight : Alignment.topLeft;
+    }
+
+    _overlayController.show();
+    _runSpring(1.0);
+  }
+
+  void _closeMenu() {
+    setState(() {
+      _hoveredIndex = null;
+      _isDragging = false;
+    });
+    _runSpring(0.0);
+  }
+
   Widget _buildMorphingOverlay(BuildContext context) {
     if (_triggerSize == null) return const SizedBox.shrink();
+
+    // Clamp animation value to prevent overshoot artifacts
     final value = _animationController.value.clamp(0.0, 1.0);
 
     return Stack(
       children: [
+        // Backdrop barrier (only active when menu is significantly open)
         if (value > 0.3)
           Positioned.fill(
             child: GestureDetector(
               behavior: HitTestBehavior.translucent,
               onTap: _closeMenu,
-              child: const ColoredBox(color: Colors.transparent),
+              child: Container(
+                color: Colors.black
+                    .withValues(alpha: 0.0), // Invisible but tappable
+              ),
             ),
           ),
+
+        // Morphing glass container
         CompositedTransformFollower(
           link: _layerLink,
           showWhenUnlinked: false,
+          // anchor based on calculated alignment
           targetAnchor: _morphAlignment,
           followerAnchor: _morphAlignment,
+          // iOS 26 "liquid swoop" offset:
+          // - Parabolic curve creates smooth, gravity-like arc
+          // - Subtle 5px vertical displacement at peak (t=0.5)
+          // - Seamless in both directions (opening and closing)
           offset: Offset(0, _calculateSwoopOffset(value)),
-          child: LiquidStretch(
-            interactionScale: widget.interactionScale,
-            stretch: widget.stretch,
-            resistance: widget.stretchResistance,
-            axis: widget.stretchAxis,
-            allowPositiveX: widget.allowPositiveX,
-            allowNegativeX: widget.allowNegativeX,
-            allowPositiveY: widget.allowPositiveY,
-            allowNegativeY: widget.allowNegativeY,
-            hitTestBehavior: HitTestBehavior.translucent,
-            child: _buildMorphingContainer(value),
-          ),
+          child: _buildMorphingContainer(value),
         ),
       ],
     );
   }
 
+  /// Calculates the vertical "swoop" offset for liquid glass morphing.
+  ///
+  /// iOS 26 uses a gentle parabolic curve that creates a subtle "liquid droop"
+  /// effect during morphing. This is NOT a bounce - it's a smooth arc that
+  /// complements the spring physics for a seamless feel.
+  ///
+  /// The curve peaks at mid-animation (t=0.5) and smoothly returns to zero
+  /// at both ends, creating a natural "swoop down and up" motion.
+  double _calculateSwoopOffset(double t) {
+    // Parabolic curve: peaks at t=0.5, zero at t=0 and t=1
+    // This creates a smooth down-and-up arc without harsh direction changes
+    // Formula: -4 * (t - 0.5)² + 1, scaled by amplitude
+    final parabola = 1.0 - 4.0 * (t - 0.5) * (t - 0.5);
+
+    // Gentle 5px peak displacement for subtle liquid feel
+    // Opening: swoops down then up (parabola is always positive)
+    // Closing: same smooth curve in reverse (no jarring direction change)
+    return parabola * 5.0;
+  }
+
+  /// Calculates the total height of the menu content.
+  ///
+  /// Sums up all menu item heights plus padding to determine the target height
+  /// for the morphing animation.
+  double _calculateMenuHeight() {
+    // Sum all menu item heights (each defaults to 44.0)
+    final itemHeights = widget.items.fold<double>(
+      0.0,
+      (sum, item) => sum + _getItemHeight(item),
+    );
+
+    // Add vertical padding (12px top + 12px bottom = 24px total)
+    // plus vertical gaps between items (2px each)
+    final gaps = (widget.items.length - 1) * 2.0;
+    return itemHeights + 24.0 + gaps;
+  }
+
   Widget _buildMorphingContainer(double value) {
+    // Inherit quality from parent layer if not explicitly set
     final effectiveQuality = GlassThemeHelpers.resolveQuality(
       context,
       widgetQuality: widget.quality,
     );
 
+    // Calculate menu height by measuring its natural size
+    // This is necessary for proper height interpolation during morph
     final menuHeight = _calculateMenuHeight();
+
+    // iOS 26: Width always interpolates smoothly throughout animation
+    // Height goes natural at 85% to prevent any overflow from content
     final currentWidth =
         lerpDouble(_triggerSize!.width, widget.menuWidth, value)!;
+
+    final targetHeight = widget.menuHeight ?? menuHeight;
     final currentHeight = value < 0.85
-        ? lerpDouble(_triggerSize!.height, menuHeight, value)!
-        : null;
+        ? lerpDouble(_triggerSize!.height, targetHeight, value)!
+        : widget.menuHeight; // Natural height (null) or fixed height
+
+    // Interpolate border radius: circular button -> rounded menu
     final currentBorderRadius = lerpDouble(
       _triggerBorderRadius ?? 16.0,
       widget.menuBorderRadius,
       value,
     )!;
 
-    // Content fade-in starts only once the container has reached its natural
-    // (unconstrained) height at value >= 0.85. Showing content earlier caused
-    // a tight-height cascade: GlassContainer(height: currentHeight) constrained
-    // its subtree tightly, the Column inside Positioned.fill received that
-    // tight height, and overflowed its items by ~18px.
-    // By waiting until currentHeight == null the container wraps its content
-    // naturally and no overflow is possible.
-    final menuOpacity = ((value - 0.85) / 0.15).clamp(0.0, 1.0);
+    // iOS 26 Crossfade Timing + Material Fade
+    // Problem: Empty morphing container still visible (glowing blob) during closing
+    // Solution: Fade glass material opacity as container shrinks
+    //
+    // Menu content: Fades in 0.7→1.0 opening, exits cleanly when closing
+    final menuOpacity = ((value - 0.7) / 0.3).clamp(0.0, 1.0);
+
+    // Glass container opacity: Fully visible when menu open, fades during closing
+    // - value > 0.3: Fully visible (1.0)
+    // - value 0.3→0: Fades out to transparent
+    // - Result: No "empty glowing blob" - seamless fade to real button
     final containerOpacity = (value / 0.3).clamp(0.0, 1.0);
 
+    // Inherit settings from context (like GlassCard/GlassContainer)
+    // If user provides custom settings, use those. Otherwise, check for inherited
+    // settings from parent layer. If none, use subtle overlay defaults.
+    // This matches the pattern used by all other glass widgets.
     final inheritedSettings = InheritedLiquidGlass.of(context);
     final effectiveSettings = widget.glassSettings ??
         inheritedSettings ??
@@ -368,173 +310,323 @@ class _GlassMenuState extends State<GlassMenu>
           blur: 10,
           thickness: 10,
           glassColor: Color.fromRGBO(255, 255, 255, 0.12),
-          lightAngle: GlassDefaults.lightAngle,
+          lightAngle: GlassDefaults.lightAngle, // Apple iOS 26 standard
           lightIntensity: 0.7,
           ambientStrength: 0.4,
           saturation: 1.2,
-          refractiveIndex: 0.7,
+          refractiveIndex: 0.7, // Thin rim - iOS 26 delicate aesthetic
           chromaticAberration: 0.0,
         );
 
-    // BUG 1 FIX: GlassContainer already applies BackdropFilter internally via
-    // LightweightLiquidGlass. Adding a second BackdropFilter here doubled the
-    // blur sigma, producing a visually incorrect "over-frosted ring" around the
-    // menu inconsistent with all other glass surfaces in the package.
-    //
-    // DETACHED-LAYER FIX: The outer RepaintBoundary was removed. When
-    // GlassContainer(useOwnLayer: true) creates a BackdropFilter layer, it
-    // forces compositing on the entire subtree. A wrapping RepaintBoundary
-    // would fight the compositor for layer ownership, leaving its OffsetLayer
-    // DETACHED from the scene — causing GlassMenuItem RepaintBoundary nodes to
-    // be painted but never wired into the render tree. GlassGlow and
-    // GlassContainer already own their compositing layers; no extra boundary
-    // is needed.
-    //
-    // Also avoid instantiating an Opacity widget when fully opaque — an Opacity
-    // at 1.0 still creates an OpacityLayer when compositing is forced by a
-    // BackdropFilter descendant, which is wasteful and can mis-sequence layers.
-    // GLOW CLIP FIX: GlassGlow must sit INSIDE GlassContainer's clip so the
-    // radial gradient is confined to the menu's glass shape. When GlassGlow
-    // wrapped GlassContainer from the outside, _RenderGlassGlowLayer.paint()
-    // drew canvas.drawCircle() over the full overlay canvas with no shape
-    // boundary, causing the glow to bleed onto the background behind the menu.
-    // GlassButton avoids this by keeping GlassGlow inside AdaptiveGlass's clip.
-    final glassContent = GlassContainer(
-      useOwnLayer: true,
-      settings: effectiveSettings,
-      quality: effectiveQuality,
-      allowElevation: false,
-      width: currentWidth,
-      height: currentHeight,
-      shape: LiquidRoundedSuperellipse(borderRadius: currentBorderRadius),
-      clipBehavior: Clip.antiAlias,
-      child: GlassGlow(
-        enabled: widget.enableInteractionGlow,
-        glowOnTapOnly: widget.glowOnTapOnly,
-        glowColor: widget.glowColor ?? Colors.white.withValues(alpha: 0.15),
-        glowRadius: widget.glowRadius,
-        hitTestBehavior: HitTestBehavior.translucent,
-        child: Stack(
-          alignment: _morphAlignment,
-          clipBehavior: Clip.antiAlias,
-          children: [
-            // Render content only when value >= 0.85 — at that point
-            // currentHeight is null and GlassContainer sizes naturally,
-            // so the Column never fights a tight height constraint.
-            if (value >= 0.85)
-              menuOpacity >= 1.0
-                  ? SizedBox(
-                      width: currentWidth,
-                      child: _buildMenuContent(currentBorderRadius),
-                    )
-                  : Opacity(
-                      opacity: menuOpacity,
-                      child: SizedBox(
-                        width: currentWidth,
-                        child: _buildMenuContent(currentBorderRadius),
+    final glassContent = LiquidStretch(
+      stretch: widget.stretch,
+      interactionScale: widget.interactionScale,
+      resistance: widget.stretchResistance,
+      axis: widget.stretchAxis,
+      suppressInteractionOnChildren: false,
+      // Constrain stretch to 'Down' and 'Away from screen edge' by default,
+      // but allow explicit user overrides.
+      allowPositiveX: widget.allowPositiveXStretch ?? (_morphAlignment.x < 0),
+      allowNegativeX: widget.allowNegativeXStretch ?? (_morphAlignment.x > 0),
+      allowPositiveY: widget.allowPositiveYStretch ?? (_morphAlignment.y < 0),
+      allowNegativeY: widget.allowNegativeYStretch ?? (_morphAlignment.y > 0),
+      child: GlassContainer(
+        useOwnLayer: true,
+        settings: effectiveSettings,
+        quality: effectiveQuality,
+        allowElevation:
+            false, // Menu is overlay - don't darken when outside parent
+        width: currentWidth,
+        height: currentHeight, // Constrained during morph, natural when open
+        shape: LiquidRoundedSuperellipse(borderRadius: currentBorderRadius),
+        clipBehavior:
+            Clip.antiAlias, // Clip items at the edges for edge-to-edge feel
+        child: GlassGlow(
+          enabled: widget.enableInteractionGlow,
+          glowOnTapOnly: widget.glowOnTapOnly,
+          glowColor: widget.glowColor ?? Colors.white.withValues(alpha: 0.15),
+          glowRadius: widget.glowRadius,
+          glowBlurRadius: 40,
+          clipper: ShapeBorderClipper(
+            shape: LiquidRoundedSuperellipse(borderRadius: currentBorderRadius),
+          ),
+          child: Stack(
+            alignment: _morphAlignment, // Align internal stack content
+            clipBehavior:
+                Clip.none, // Prevent double-clip artifacts during stretch
+            children: [
+              // Menu content - waits for container to be nearly full width
+              if (value > 0.65)
+                Opacity(
+                  opacity: menuOpacity,
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      // Sliding selection pill (background)
+                      ValueListenableBuilder<int?>(
+                        valueListenable: _hoveredIndexNotifier,
+                        builder: (context, hoveredIndex, _) {
+                          if (hoveredIndex == null) return const SizedBox.shrink();
+                          return AnimatedPositioned(
+                            duration: const Duration(milliseconds: 150),
+                            curve: Curves.easeOutCubic,
+                            left: 12,
+                            right: 12,
+                            top: _getItemOffset(hoveredIndex) -
+                                (_scrollController.hasClients
+                                    ? _scrollController.offset
+                                    : 0.0),
+                            height: _getItemHeight(widget.items[hoveredIndex]),
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: widget.selectionColor,
+                                borderRadius: BorderRadius.circular(24),
+                                border: Border.all(
+                                  color: const Color(
+                                      0x0DFFFFFF), // 5% white border
+                                  width: 0.5,
+                                ),
+                              ),
+                            ),
+                          );
+                        },
                       ),
-                    ),
-          ],
+                      Listener(
+                        onPointerDown: (event) {
+                          _isDragging = true;
+                          _isDraggingNotifier.value = true;
+                          _hasStretched = false;
+                          _initialLocalPosition = event.localPosition;
+                          _initialScrollOffset = _scrollController.hasClients
+                              ? _scrollController.offset
+                              : 0.0;
+                          _updateHoveredIndex(event.localPosition);
+                        },
+                        onPointerMove: (event) {
+                          if (_isDragging) {
+                            _updateHoveredIndex(event.localPosition);
+                          }
+                        },
+                        onPointerUp: (event) {
+                          if (_isDragging) {
+                            if (_hoveredIndex != null) {
+                              // Only trigger tap if we didn't scroll or drag much (prevents selection during stretching)
+                              final currentOffset = _scrollController.hasClients
+                                  ? _scrollController.offset
+                                  : 0.0;
+                              final scrollDisplacement =
+                                  (currentOffset - _initialScrollOffset).abs();
+                              final dragDisplacement =
+                                  (event.localPosition - _initialLocalPosition)
+                                      .distance;
+
+                              if (scrollDisplacement < 10 &&
+                                  dragDisplacement < 10) {
+                                final item = widget.items[_hoveredIndex!];
+                                if (item is GlassMenuItem) {
+                                  item.onTap();
+                                }
+                                _closeMenu();
+                              }
+                            }
+                            _isDragging = false;
+                            _isDraggingNotifier.value = false;
+                            _hoveredIndex = null;
+                            _hoveredIndexNotifier.value = null;
+                            _hasStretched = false;
+                          }
+                        },
+                        onPointerCancel: (_) {
+                          _isDragging = false;
+                          _isDraggingNotifier.value = false;
+                          _hoveredIndex = null;
+                          _hoveredIndexNotifier.value = null;
+                        },
+                        child: SizedBox(
+                          width: currentWidth,
+                          height: widget.menuHeight, // Apply fixed height
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 12),
+                            child: SingleChildScrollView(
+                              controller: _scrollController,
+                              physics:
+                                  const ClampingScrollPhysics(), // iOS-style scrolling
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                crossAxisAlignment: CrossAxisAlignment.stretch,
+                                children: [
+                                  const SizedBox(
+                                      height: 12), // Inner top padding
+                                  ..._buildWrappedItems()
+                                      .asMap()
+                                      .entries
+                                      .expand((entry) => [
+                                            entry.value,
+                                            if (entry.key <
+                                                widget.items.length - 1)
+                                              const SizedBox(height: 2),
+                                          ]),
+                                  const SizedBox(
+                                      height: 12), // Inner bottom padding
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
     );
 
-    // Only wrap in Opacity during the fade-in phase; once fully opaque skip
-    // the widget entirely so no OpacityLayer is inserted into the layer tree.
     return containerOpacity >= 1.0
         ? glassContent
         : Opacity(opacity: containerOpacity, child: glassContent);
   }
 
-  Widget _buildMenuContent(double borderRadius) {
-    final pillRadius = (borderRadius - 8).clamp(4.0, double.infinity);
-    final selectionColor =
-        widget.selectionColor ?? Colors.white.withValues(alpha: 0.12);
+  List<Widget> _buildWrappedItems() {
+    return _cachedWrappedItems ??= widget.items.asMap().entries.map((entry) {
+      final item = entry.value;
 
-    final wrappedItems = _buildWrappedItems();
-    final tops = _computeItemTops();
+      if (item is GlassMenuItem) {
+        return _SelectionItemWrapper(
+          index: entry.key,
+          hoverNotifier: _hoveredIndexNotifier,
+          dragNotifier: _isDraggingNotifier,
+          builder: (context, isSelected, isPressed) {
+            return GlassMenuItem(
+              key: item.key ?? ValueKey(item.title),
+              title: item.title,
+              subtitle: item.subtitle,
+              icon: item.icon,
+              isDestructive: item.isDestructive,
+              enabled: item.enabled,
+              trailing: item.trailing,
+              height: item.height,
+              titleStyle: item.titleStyle,
+              subtitleStyle: item.subtitleStyle,
+              iconColor: item.iconColor,
+              iconSize: item.iconSize,
+              isSelected: isSelected,
+              isPressed: isPressed,
+              onTap: () {
+                item.onTap();
+                _closeMenu();
+              },
+            );
+          },
+        );
+      }
+      return item;
+    }).toList();
+  }
 
-    // Total unscrolled content height — needed to give the Stack a fixed size
-    // so AnimatedPositioned has a bounded parent (BUG 2 FIX).
-    final totalH =
-        widget.items.fold<double>(0.0, (s, i) => s + _getItemHeight(i));
+  double _getItemHeight(Widget item) {
+    if (item is GlassMenuItem) return item.height;
+    if (item is GlassMenuDivider) return item.height;
+    if (item is GlassMenuLabel) return item.height;
+    return 44.0;
+  }
 
-    // BUG 2 FIX: AnimatedPositioned requires a bounded Stack. We give the Stack
-    // an explicit height via SizedBox(height: totalH). This also ensures the
-    // pill position (tops[i]) is always within [0, totalH), preventing overflow.
-    // The pill and items are siblings in the same Stack, so they scroll together
-    // when inside SingleChildScrollView — NO _scrollOffset subtraction needed.
-    Widget content = SizedBox(
-      height: totalH,
-      child: Stack(
-        // OVERFLOW FIX: Clip the items stack so that during the wide→menu morph
-        // transition the Column children (and any AnimatedScale transforms that
-        // retain their pre-scale layout size) cannot report overflow to the
-        // framework. The outer GlassContainer already clips visually; this just
-        // suppresses the spurious debug overflow banner during resize.
-        clipBehavior: Clip.hardEdge,
-        children: [
-          // Selection pill is drawn first so it sits BEHIND the items.
-          // BUG 4 FIX: bounds-check _hoveredIndex before indexing.
-          if (_hoveredIndex != null &&
-              !_isScrolling &&
-              _hoveredIndex! < widget.items.length)
-            AnimatedPositioned(
-              duration: const Duration(milliseconds: 100),
-              curve: Curves.easeOutCubic,
-              top: tops[_hoveredIndex!].clamp(
-                0.0,
-                (totalH - _getItemHeight(widget.items[_hoveredIndex!]))
-                    .clamp(0.0, double.infinity),
-              ),
-              left: 0,
-              right: 0,
-              height: _getItemHeight(widget.items[_hoveredIndex!]),
-              child: Container(
-                decoration: BoxDecoration(
-                  color: selectionColor,
-                  borderRadius: BorderRadius.circular(pillRadius),
-                ),
-              ),
-            ),
-          // Items drawn on top of the pill.
-          Positioned.fill(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: wrappedItems,
-            ),
-          ),
-        ],
-      ),
-    );
+  double _getItemOffset(int index) {
+    double offset = 12.0; // Top padding
+    for (int i = 0; i < index; i++) {
+      offset += _getItemHeight(widget.items[i]) + 2.0; // height + 2px gap
+    }
+    return offset;
+  }
 
-    // Wrap in scrollable when menuHeight is set.
-    if (widget.menuHeight != null) {
-      content = SizedBox(
-        height: widget.menuHeight! - 16,
-        child: ClipRect(
-          child: NotificationListener<ScrollNotification>(
-            onNotification: _onScrollNotification,
-            child: SingleChildScrollView(
-              controller: _scrollController,
-              physics: const ClampingScrollPhysics(),
-              child: content,
-            ),
-          ),
-        ),
-      );
+  void _updateHoveredIndex(Offset localPosition) {
+    // Detect if we've moved into "stretch territory" (outside visible menu bounds)
+    // We use the visible container height if fixed, otherwise the natural height.
+    final visibleHeight = widget.menuHeight ?? _calculateMenuHeight();
+    final x = localPosition.dx;
+    final dy = localPosition.dy;
+
+    // We add a 100px buffer to allow for intense liquid stretching without accidental closure.
+    // We also allow cancelling the stretch if the user moves their finger back.
+    final outsideBounds = dy < -100 ||
+        dy > visibleHeight + 100 ||
+        x < -100 ||
+        x > widget.menuWidth + 100;
+
+    if (_hasStretched != outsideBounds) {
+      setState(() => _hasStretched = outsideBounds);
+    }
+    final y =
+        dy + (_scrollController.hasClients ? _scrollController.offset : 0.0);
+
+    double currentOffset = 12.0;
+    int? detectedIndex;
+
+    // Only allow selecting items if we are within a small "active" buffer (20px)
+    // This prevents triggering items while intentionally stretching the menu.
+    final isWithinActiveZone = x > -20 &&
+        x < widget.menuWidth + 20 &&
+        dy > -20 &&
+        dy < visibleHeight + 20;
+
+    if (isWithinActiveZone) {
+      // In scrollable menus, we disable pill tracking during significant movement
+      // to prevent visual noise and overlapping highlights during scrolling.
+      final isScrollable = widget.menuHeight != null;
+      final hasMoved =
+          _isDragging && (localPosition - _initialLocalPosition).distance > 10;
+
+      if (!isScrollable || !hasMoved) {
+        for (int i = 0; i < widget.items.length; i++) {
+          final item = widget.items[i];
+          final itemHeight = _getItemHeight(item);
+
+          if (y >= currentOffset && y <= currentOffset + itemHeight) {
+            // Only select interactive items
+            if (item is GlassMenuItem) {
+              detectedIndex = i;
+            }
+            break;
+          }
+          currentOffset += itemHeight + 2.0; // height + 2px gap
+        }
+      }
     }
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
-      child: Listener(
-        onPointerDown: _onMenuPointerDown,
-        onPointerMove: _onMenuPointerMove,
-        onPointerUp: _onMenuPointerUp,
-        onPointerCancel: _onMenuPointerCancel,
-        child: content,
-      ),
+    _hoveredIndex = detectedIndex;
+    _hoveredIndexNotifier.value = detectedIndex;
+  }
+}
+
+/// Internal helper to update selection state for cached items.
+class _SelectionItemWrapper extends StatelessWidget {
+  final int index;
+  final ValueNotifier<int?> hoverNotifier;
+  final ValueNotifier<bool> dragNotifier;
+  final Widget Function(BuildContext context, bool isSelected, bool isPressed)
+      builder;
+
+  const _SelectionItemWrapper({
+    required this.index,
+    required this.hoverNotifier,
+    required this.dragNotifier,
+    required this.builder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<int?>(
+      valueListenable: hoverNotifier,
+      builder: (context, hoveredIndex, _) {
+        final isSelected = hoveredIndex == index;
+        return ValueListenableBuilder<bool>(
+          valueListenable: dragNotifier,
+          builder: (context, isDragging, _) {
+            return builder(context, isSelected, isDragging && isSelected);
+          },
+        );
+      },
     );
   }
 }

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -424,9 +424,15 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
                                   dragDisplacement < 10) {
                                 final item = widget.items[_hoveredIndex!];
                                 if (item is GlassMenuItem) {
-                                  item.onTap();
+                                  if (item.enabled) {
+                                    item.onTap();
+                                    _closeMenu();
+                                  }
+                                } else {
+                                  // For non-GlassMenuItem (labels, dividers),
+                                  // we might want to close if it's a generic item,
+                                  // but usually only menu items close on tap.
                                 }
-                                _closeMenu();
                               }
                             }
                             _isDragging = false;
@@ -513,10 +519,7 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
               iconSize: item.iconSize,
               isSelected: isSelected,
               isPressed: isPressed,
-              onTap: () {
-                item.onTap();
-                _closeMenu();
-              },
+              onTap: () {}, // Provide empty callback to enable GestureDetector feedback
             );
           },
         );
@@ -584,7 +587,7 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
 
           if (y >= currentOffset && y <= currentOffset + itemHeight) {
             // Only select interactive items
-            if (item is GlassMenuItem) {
+            if (item is GlassMenuItem && item.enabled) {
               detectedIndex = i;
             }
             break;

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -326,10 +326,10 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
       suppressInteractionOnChildren: false,
       // Constrain stretch to 'Down' and 'Away from screen edge' by default,
       // but allow explicit user overrides.
-      allowPositiveX: widget.allowPositiveXStretch ?? (_morphAlignment.x < 0),
-      allowNegativeX: widget.allowNegativeXStretch ?? (_morphAlignment.x > 0),
-      allowPositiveY: widget.allowPositiveYStretch ?? (_morphAlignment.y < 0),
-      allowNegativeY: widget.allowNegativeYStretch ?? (_morphAlignment.y > 0),
+      allowPositiveX: widget.allowPositiveX ?? (_morphAlignment.x < 0),
+      allowNegativeX: widget.allowNegativeX ?? (_morphAlignment.x > 0),
+      allowPositiveY: widget.allowPositiveY ?? (_morphAlignment.y < 0),
+      allowNegativeY: widget.allowNegativeY ?? (_morphAlignment.y > 0),
       child: GlassContainer(
         useOwnLayer: true,
         settings: effectiveSettings,
@@ -341,6 +341,7 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
         shape: LiquidRoundedSuperellipse(borderRadius: currentBorderRadius),
         clipBehavior:
             Clip.antiAlias, // Clip items at the edges for edge-to-edge feel
+        glowIntensity: widget.glowIntensity,
         child: GlassGlow(
           enabled: widget.enableInteractionGlow,
           glowOnTapOnly: widget.glowOnTapOnly,

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -357,7 +357,7 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
                 Clip.none, // Prevent double-clip artifacts during stretch
             children: [
               // Menu content - waits for container to be nearly full width
-              if (value > 0.65)
+              if (value > 0.85)
                 Opacity(
                   opacity: menuOpacity,
                   child: Stack(
@@ -367,7 +367,8 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
                       ValueListenableBuilder<int?>(
                         valueListenable: _hoveredIndexNotifier,
                         builder: (context, hoveredIndex, _) {
-                          if (hoveredIndex == null) return const SizedBox.shrink();
+                          if (hoveredIndex == null)
+                            return const SizedBox.shrink();
                           return AnimatedPositioned(
                             duration: const Duration(milliseconds: 150),
                             curve: Curves.easeOutCubic,
@@ -520,7 +521,8 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
               iconSize: item.iconSize,
               isSelected: isSelected,
               isPressed: isPressed,
-              onTap: () {}, // Provide empty callback to enable GestureDetector feedback
+              onTap:
+                  () {}, // Provide empty callback to enable GestureDetector feedback
             );
           },
         );

--- a/test/widgets/overlays/glass_menu_primitives_test.dart
+++ b/test/widgets/overlays/glass_menu_primitives_test.dart
@@ -34,9 +34,14 @@ void main() {
   // GlassMenuLabel
   // ==========================================================================
   group('GlassMenuLabel', () {
-    testWidgets('uppercases title', (tester) async {
-      await tester.pumpWidget(_app(const GlassMenuLabel(child: Text('SECTION'))));
+    testWidgets('uppercases title when using title param', (tester) async {
+      await tester.pumpWidget(_app(const GlassMenuLabel(title: 'section')));
       expect(find.text('SECTION'), findsOneWidget);
+    });
+
+    testWidgets('renders child when provided', (tester) async {
+      await tester.pumpWidget(_app(const GlassMenuLabel(child: Text('CUSTOM'))));
+      expect(find.text('CUSTOM'), findsOneWidget);
     });
 
     testWidgets('applies custom style', (tester) async {
@@ -52,10 +57,10 @@ void main() {
     });
 
     // QUALITY 3: height param is accepted and has correct default.
-    testWidgets('exposes height param with default 32.0', (tester) async {
-      const label = GlassMenuLabel(child: Text('test'));
-      expect(label.height, 32.0);
-      const custom = GlassMenuLabel(height: 48.0, child: Text('big'));
+    testWidgets('exposes height param with default 30.0', (tester) async {
+      const label = GlassMenuLabel(title: 'test');
+      expect(label.height, 30.0);
+      const custom = GlassMenuLabel(height: 48.0, title: 'big');
       expect(custom.height, 48.0);
     });
   });

--- a/test/widgets/overlays/glass_menu_primitives_test.dart
+++ b/test/widgets/overlays/glass_menu_primitives_test.dart
@@ -326,13 +326,15 @@ void main() {
           outerSetState = setState;
           return MaterialApp(
             home: Scaffold(
-              body: GlassMenu(
-                trigger:
-                    const SizedBox(width: 60, height: 40, child: Text('Open')),
-                items: [
-                  GlassMenuItem(title: 'A', onTap: () {}),
-                  if (showExtra) GlassMenuItem(title: 'B', onTap: () {}),
-                ],
+              body: Center(
+                child: GlassMenu(
+                  trigger:
+                      const SizedBox(width: 60, height: 40, child: Text('Open')),
+                  items: [
+                    GlassMenuItem(title: 'A', onTap: () {}),
+                    if (showExtra) GlassMenuItem(title: 'B', onTap: () {}),
+                  ],
+                ),
               ),
             ),
           );
@@ -476,17 +478,21 @@ void main() {
       await tester.pumpWidget(StatefulBuilder(
         builder: (context, setState) => MaterialApp(
           home: Scaffold(
-            body: Column(
-              children: [
-                GlassGlow(
-                  glowOnTapOnly: tapOnly,
-                  child: const SizedBox(width: 200, height: 200),
-                ),
-                ElevatedButton(
-                  onPressed: () => setState(() => tapOnly = false),
-                  child: const Text('Toggle'),
-                ),
-              ],
+            body: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  GlassGlow(
+                    glowOnTapOnly: tapOnly,
+                    child: const SizedBox(width: 200, height: 200),
+                  ),
+                  const SizedBox(height: 20),
+                  ElevatedButton(
+                    onPressed: () => setState(() => tapOnly = false),
+                    child: const Text('Toggle'),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/test/widgets/overlays/glass_menu_primitives_test.dart
+++ b/test/widgets/overlays/glass_menu_primitives_test.dart
@@ -35,14 +35,16 @@ void main() {
   // ==========================================================================
   group('GlassMenuLabel', () {
     testWidgets('uppercases title', (tester) async {
-      await tester.pumpWidget(_app(const GlassMenuLabel(title: 'section')));
+      await tester.pumpWidget(_app(const GlassMenuLabel(child: Text('SECTION'))));
       expect(find.text('SECTION'), findsOneWidget);
     });
 
     testWidgets('applies custom style', (tester) async {
       await tester.pumpWidget(_app(const GlassMenuLabel(
-        title: 'actions',
-        style: TextStyle(color: Colors.amber, fontSize: 14),
+        child: Text(
+          'ACTIONS',
+          style: TextStyle(color: Colors.amber, fontSize: 14),
+        ),
       )));
       expect(find.text('ACTIONS'), findsOneWidget);
       final text = tester.widget<Text>(find.text('ACTIONS'));
@@ -50,10 +52,10 @@ void main() {
     });
 
     // QUALITY 3: height param is accepted and has correct default.
-    testWidgets('exposes height param with default 30.0', (tester) async {
-      const label = GlassMenuLabel(title: 'test');
-      expect(label.height, 30.0);
-      const custom = GlassMenuLabel(title: 'big', height: 48.0);
+    testWidgets('exposes height param with default 32.0', (tester) async {
+      const label = GlassMenuLabel(child: Text('test'));
+      expect(label.height, 32.0);
+      const custom = GlassMenuLabel(height: 48.0, child: Text('big'));
       expect(custom.height, 48.0);
     });
   });
@@ -178,7 +180,7 @@ void main() {
     testWidgets('renders GlassMenuLabel and GlassMenuDivider', (tester) async {
       await tester.pumpWidget(_app(GlassMenu(
         trigger: const SizedBox(width: 60, height: 40, child: Text('Open')),
-        items: const [GlassMenuLabel(title: 'Files'), GlassMenuDivider()],
+        items: const [GlassMenuLabel(child: Text('FILES')), GlassMenuDivider()],
       )));
       await _openMenu(tester, 'Open');
       expect(find.text('FILES'), findsOneWidget);
@@ -189,7 +191,7 @@ void main() {
       await tester.pumpWidget(_app(GlassMenu(
         trigger: const SizedBox(width: 60, height: 40, child: Text('Open')),
         items: [
-          const GlassMenuLabel(title: 'Actions'),
+          const GlassMenuLabel(child: Text('ACTIONS')),
           GlassMenuItem(title: 'Save', onTap: () {}),
           const GlassMenuDivider(),
           GlassMenuItem(title: 'Delete', isDestructive: true, onTap: () {}),
@@ -390,10 +392,10 @@ void main() {
         stretch: 0.3,
         stretchResistance: 0.1,
         stretchAxis: Axis.vertical,
-        allowPositiveX: false,
-        allowNegativeX: false,
-        allowPositiveY: true,
-        allowNegativeY: false,
+        allowPositiveXStretch: false,
+        allowNegativeXStretch: false,
+        allowPositiveYStretch: true,
+        allowNegativeYStretch: false,
         items: [GlassMenuItem(title: 'Item', onTap: () {})],
       )));
       await _openMenu(tester, 'Open');

--- a/test/widgets/overlays/glass_menu_primitives_test.dart
+++ b/test/widgets/overlays/glass_menu_primitives_test.dart
@@ -394,10 +394,10 @@ void main() {
         stretch: 0.3,
         stretchResistance: 0.1,
         stretchAxis: Axis.vertical,
-        allowPositiveXStretch: false,
-        allowNegativeXStretch: false,
-        allowPositiveYStretch: true,
-        allowNegativeYStretch: false,
+        allowPositiveX: false,
+        allowNegativeX: false,
+        allowPositiveY: true,
+        allowNegativeY: false,
         items: [GlassMenuItem(title: 'Item', onTap: () {})],
       )));
       await _openMenu(tester, 'Open');


### PR DESCRIPTION
<html><head></head><body><h1>GlassMenu: Performance Restoration &amp; Visual Artifact Fixes</h1>
<h2>Description</h2>
<p>This PR addresses several regressions and visual artifacts in the <code>GlassMenu</code> component that were introduced in the recent architectural refactoring. The primary focus is on restoring the high-performance feel of the menu while maintaining the new internal structure.</p>
<hr>
<h2>Key Changes</h2>
PR which was forced as a result of this #47 #48 
<h3>Restored Item Caching</h3>
<p>Re-implemented the <code>_cachedWrappedItems</code> mechanism. The previous version caused full-list rebuilds on every pointer movement, leading to significant performance degradation. Caching ensures consistent widget identity and smooth animations.</p>
<h3>Granular State Management</h3>
<p>Migrated selection and hover tracking to a <code>ValueNotifier</code> system (<code>_hoveredIndexNotifier</code>, <code>_isDraggingNotifier</code>). Individual menu items now listen only to their specific state changes, eliminating redundant <code>setState</code> calls for the entire menu.</p>
<h3>Visual Artifact Resolution</h3>
<ul>
<li>Fixed the "double-layer" ghosting effect by ensuring <code>GlassMenuItem</code> background transitions to transparent instantly when selected.</li>
<li>Removed <code>RepaintBoundary</code> in items which was causing compositing issues with the glass blur and selection pill.</li>
</ul>
<h3>Architecture Integration</h3>
<p>Successfully bridged the author's new internal shared state (<code>glass_menu_internal.dart</code>) with the optimized selection logic.</p>
<h3>Also accept the merge for the updated demo modal_sheet_showcase.dart to see the new menu</h3>
<ul>
</ul>
<hr>

</body></html>