### PR TITLE
feat:(TabBar) add jelly physics to scrollable indicator; resolve boundary constraints and tab switching

### DIFF
--- a/lib/widgets/surfaces/shared/tab_bar_internal.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_internal.dart
@@ -341,61 +341,77 @@ class TabBarContentState extends State<TabBarContent>
   void _handleDragUpdate(DragUpdateDetails details) {
     final box = context.findRenderObject() as RenderBox?;
     if (box == null || box.size.width <= 0) return;
+    const double rubberBandFactor = 0.5;
+    const double overstepRatio = 0.085;
+    const double fixedModeOverstep = 0.17;
 
+    // --- FIXED MODE ---
     if (!widget.isScrollable) {
       setState(() {
         _isDragging = true;
 
-        // Use absolute pointer position instead of delta accumulation.
-        // Delta-based dragging introduces visible lag/drift on desktop/web
-        // because pointer events may arrive at a different rate than frames.
+        // Use absolute pointer position to prevent drift
         double raw = DraggableIndicatorPhysics.getAlignmentFromGlobalPosition(
           details.globalPosition,
           context,
           widget.tabs.length,
         );
         if (raw < -1.0) {
-          raw = -1.0 + (raw + 1.0) * 0.5;
+          raw = -1.0 + (raw + 1.0) * rubberBandFactor;
         } else if (raw > 1.0) {
-          raw = 1.0 + (raw - 1.0) * 0.5;
+          raw = 1.0 + (raw - 1.0) * rubberBandFactor;
         }
-        final overstep = 0.85 * (2.0 / widget.tabs.length);
-        _xAlign = raw.clamp(-1.0 - overstep, 1.0 + overstep);
+        _xAlign = raw.clamp(-1.0 - fixedModeOverstep, 1.0 + fixedModeOverstep);
       });
       return;
     }
 
+    // --- SCROLLABLE MODE ---
     if (!_isDraggingIndicator || _tabOffsets.isEmpty) return;
-
     setState(() {
       _isDragging = true;
-      double delta = details.delta.dx;
-      final cur = _indOffsetSpring.value;
       final double screenWidth = box.size.width;
-      final double scrollOffset = widget.scrollController.offset;
-      final double viewMin = scrollOffset;
-      final double viewMax = scrollOffset + screenWidth;
-      if ((cur < viewMin && delta < 0) || (cur > viewMax && delta > 0)) {
-        delta *= 0.5;
-      }
-      final newOffset = (cur + delta)
-          .clamp(viewMin - screenWidth * 0.35, viewMax + screenWidth * 0.35);
-      _indOffsetSpring.setValue(newOffset);
+      final double viewMin = widget.scrollController.offset;
+      final double viewMax = viewMin + screenWidth;
+      double delta = details.delta.dx;
+      final double curOffset = _indOffsetSpring.value;
 
-      // Update width based on current position between tabs.
+      // Calculate dynamic width based on current position to avoid jumps
+      double targetWidth = _tabWidths[0];
       if (_tabWidths.length == widget.tabs.length) {
         int index = 0;
         for (int i = 0; i < _tabOffsets.length - 1; i++) {
-          if (newOffset >= _tabOffsets[i]) index = i;
+          if (curOffset >= _tabOffsets[i]) index = i;
         }
-        final nextIndex = (index + 1).clamp(0, widget.tabs.length - 1);
-        final diff = _tabOffsets[nextIndex] - _tabOffsets[index];
-        final t = (diff != 0 ? (newOffset - _tabOffsets[index]) / diff : 0.0)
-            .clamp(0.0, 1.0);
-        final interpolatedWidth =
+        final int nextIndex = (index + 1).clamp(0, widget.tabs.length - 1);
+        final double diff = _tabOffsets[nextIndex] - _tabOffsets[index];
+        final double t =
+            (diff != 0 ? (curOffset - _tabOffsets[index]) / diff : 0.0)
+                .clamp(0.0, 1.0);
+        targetWidth =
             _tabWidths[index] + (_tabWidths[nextIndex] - _tabWidths[index]) * t;
-        _indWidthSpring.setValue(interpolatedWidth);
       }
+
+      // Define physical boundaries
+      final double leftWall = viewMin;
+      final double rightWall = viewMax - targetWidth;
+
+      // Apply rubber-band resistance when hitting boundaries
+      if ((curOffset < leftWall && delta < 0) ||
+          (curOffset > rightWall && delta > 0)) {
+        delta *= rubberBandFactor;
+      }
+
+      // Clamp final position with allowed overstep
+      final double maxOverstep = screenWidth * overstepRatio;
+      final double finalOffset = (curOffset + delta).clamp(
+        leftWall - maxOverstep,
+        rightWall + maxOverstep,
+      );
+
+      // Update springs
+      _indOffsetSpring.setValue(finalOffset);
+      _indWidthSpring.setValue(targetWidth);
     });
   }
 
@@ -404,29 +420,49 @@ class TabBarContentState extends State<TabBarContent>
       _handleDragCancel();
       return;
     }
-
+    final double velocityThreshold = 400.0;
+    final double fixedDistanceThresholdFactor = 0.2;
+    final box = context.findRenderObject() as RenderBox?;
+    final double width = box?.size.width ?? 1.0;
+    final double velocityX = details.velocity.pixelsPerSecond.dx;
     int targetTabIndex;
 
     if (widget.isScrollable) {
+      // Determine closest tab by physical offset
       targetTabIndex = widget.selectedIndex;
       double minDistance = double.infinity;
       for (int i = 0; i < _tabOffsets.length; i++) {
-        final distance = (_indOffsetSpring.value - _tabOffsets[i]).abs();
-        if (distance < minDistance) {
-          minDistance = distance;
+        final double dist = (_indOffsetSpring.value - _tabOffsets[i]).abs();
+        if (dist < minDistance) {
+          minDistance = dist;
           targetTabIndex = i;
         }
       }
+
+      // Override target if flicked with sufficient velocity
+      if (velocityX.abs() > velocityThreshold) {
+        targetTabIndex =
+            (velocityX > 0 ? targetTabIndex + 1 : targetTabIndex - 1)
+                .clamp(0, widget.tabs.length - 1);
+      }
     } else {
-      final currentRelativeX = (_xAlign + 1) / 2;
-      final box = context.findRenderObject() as RenderBox?;
-      final width = box?.size.width ?? 1.0;
-      final velocityX = details.velocity.pixelsPerSecond.dx / width;
-      targetTabIndex = _computeTargetTab(
-        currentRelativeX: currentRelativeX,
-        velocityX: velocityX,
-        tabWidth: 1.0 / widget.tabs.length,
-      );
+      // Fixed mode: calculate position relative to current tab center
+      final double currentPx = ((_xAlign + 1) / 2) * width;
+      final double tabWidth = width / widget.tabs.length;
+      final double centerOfSelected = (widget.selectedIndex + 0.5) * tabWidth;
+
+      // Use direction and a 20% threshold for effortless switching
+      if ((currentPx - centerOfSelected).abs() >
+              tabWidth * fixedDistanceThresholdFactor ||
+          velocityX.abs() > velocityThreshold) {
+        targetTabIndex = currentPx > centerOfSelected
+            ? widget.selectedIndex + 1
+            : widget.selectedIndex - 1;
+      } else {
+        targetTabIndex = widget.selectedIndex;
+      }
+
+      targetTabIndex = targetTabIndex.clamp(0, widget.tabs.length - 1);
     }
 
     setState(() {
@@ -441,6 +477,7 @@ class TabBarContentState extends State<TabBarContent>
     if (targetTabIndex != widget.selectedIndex) {
       widget.onTabSelected(targetTabIndex);
     } else if (widget.isScrollable) {
+      // Snap scrollable indicator to the precise tab position
       _indOffsetSpring.animateTo(_tabOffsets[targetTabIndex]);
       _indWidthSpring.animateTo(_tabWidths[targetTabIndex]);
     }
@@ -455,19 +492,6 @@ class TabBarContentState extends State<TabBarContent>
         _xAlign = _computeXAlignmentForTab(widget.selectedIndex);
       }
     });
-  }
-
-  int _computeTargetTab({
-    required double currentRelativeX,
-    required double velocityX,
-    required double tabWidth,
-  }) {
-    return DraggableIndicatorPhysics.computeTargetIndex(
-      currentRelativeX: currentRelativeX,
-      velocityX: velocityX,
-      itemWidth: tabWidth,
-      itemCount: widget.tabs.length,
-    );
   }
 
   void _onTabTap(int index) {
@@ -613,7 +637,6 @@ class TabBarContentState extends State<TabBarContent>
       final double scrollOffset = widget.scrollController.hasClients
           ? widget.scrollController.offset
           : 0.0;
-      final double screenLeft = _indOffsetSpring.value - scrollOffset;
 
       // Bloom while the position spring is still in transit — deactivates
       // naturally as the spring settles (mirrors GlassSegmentedControl).
@@ -621,108 +644,128 @@ class TabBarContentState extends State<TabBarContent>
           measuredReady && widget.selectedIndex < _tabOffsets.length
               ? _tabOffsets[widget.selectedIndex]
               : 0.0;
-      final bool isMoving = (_indOffsetSpring.value - targetOffset).abs() > 2.0;
 
       final physics = _isDraggingIndicator
           ? const NeverScrollableScrollPhysics()
           : const ClampingScrollPhysics();
 
-      result = Stack(
-        clipBehavior: Clip.none,
-        children: [
-          // ── Layer 1: clipped content ────────────────────────────────────
-          // ClipRRect clips to the tab bar's rounded corners so the solid
-          // background pill and tab labels don't overflow the corner radius.
-          ClipRRect(
-            borderRadius: widget.tabBarBorderRadius ?? BorderRadius.zero,
-            child: Stack(
-              clipBehavior: Clip.none,
-              children: [
-                // Background solid pill — clips with the bar (rendered before
-                // labels so labels paint above the pill — correct z-order).
-                if (measuredReady && _indWidthSpring.value > 0)
-                  SpringBuilder(
-                    spring: GlassSpring.snappy(
-                      duration: const Duration(milliseconds: 300),
-                    ),
-                    value: _isDown || isMoving ? 1.0 : 0.0,
-                    builder: (context, thickness, _) {
-                      return AnimatedGlassIndicator(
-                        velocity: 0.0,
-                        itemCount: widget.tabs.length,
-                        alignment: Alignment.center,
-                        thickness: thickness,
-                        quality: widget.quality,
-                        indicatorColor: indicatorColor,
-                        isBackgroundIndicator: false,
-                        borderRadius:
-                            widget.indicatorBorderRadius?.topLeft.x ?? 16,
-                        glassSettings: widget.indicatorSettings,
-                        backgroundKey: widget.backgroundKey,
-                        exactWidth: _indWidthSpring.value,
-                        exactOffset: screenLeft,
-                        expansion: widget.maskingQuality == MaskingQuality.off
-                            ? 0.0
-                            : 8.0,
-                        paintBackground: true,
-                        paintGlass: false, // glass rendered in layer 2
-                        shadows: _effectiveShadow,
-                      );
-                    },
-                  ),
+      // Wrapping in VelocitySpringBuilder to capture physical movement velocity
+      // for the "jelly" shader effect in scrollable mode.
+      result = VelocitySpringBuilder(
+        value: _indOffsetSpring.value,
+        springWhenActive: GlassSpring.interactive(),
+        springWhenReleased: GlassSpring.snappy(
+          duration: const Duration(milliseconds: 350),
+        ),
+        active: _isDraggingIndicator,
+        builder: (context, currentOffset, velocity, _) {
+          // Normalizing velocity: pixels-per-frame to a manageable 0.0-2.0 scale for the shader.
+          // This prevents the indicator from over-stretching into a vertical line during drag.
+          final double normalizedVelocity = velocity / 300.0;
+          final double screenLeft = currentOffset - scrollOffset;
+          final bool isMoving = (currentOffset - targetOffset).abs() > 2.0;
 
-                // Tab labels (scrollable) — rendered after pill so they
-                // paint on top and are not obscured by the indicator.
-                NotificationListener<ScrollStartNotification>(
-                  onNotification: (_) {
-                    if (_isDown) setState(() => _isDown = false);
-                    return false;
-                  },
-                  child: SingleChildScrollView(
-                    controller: widget.scrollController,
-                    scrollDirection: Axis.horizontal,
-                    physics: physics,
-                    child: _buildTabLabels(
-                      selectedLabelStyle,
-                      unselectedLabelStyle,
-                      selectedIconColor,
-                      unselectedIconColor,
+          return Stack(
+            clipBehavior: Clip.none,
+            children: [
+              // ── Layer 1: clipped content ────────────────────────────────────
+              // ClipRRect clips to the tab bar's rounded corners so the solid
+              // background pill and tab labels don't overflow the corner radius.
+              ClipRRect(
+                borderRadius: widget.tabBarBorderRadius ?? BorderRadius.zero,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    // Background solid pill — clips with the bar (rendered before
+                    // labels so labels paint above the pill — correct z-order).
+                    if (measuredReady && _indWidthSpring.value > 0)
+                      SpringBuilder(
+                        spring: GlassSpring.snappy(
+                          duration: const Duration(milliseconds: 300),
+                        ),
+                        value: _isDown || isMoving ? 1.0 : 0.0,
+                        builder: (context, thickness, _) {
+                          return AnimatedGlassIndicator(
+                            velocity: normalizedVelocity,
+                            itemCount: widget.tabs.length,
+                            alignment: Alignment.center,
+                            thickness: thickness,
+                            quality: widget.quality,
+                            indicatorColor: indicatorColor,
+                            isBackgroundIndicator: false,
+                            borderRadius:
+                                widget.indicatorBorderRadius?.topLeft.x ?? 16,
+                            glassSettings: widget.indicatorSettings,
+                            backgroundKey: widget.backgroundKey,
+                            exactWidth: _indWidthSpring.value,
+                            exactOffset: screenLeft,
+                            expansion:
+                                widget.maskingQuality == MaskingQuality.off
+                                    ? 0.0
+                                    : 8.0,
+                            paintBackground: true,
+                            paintGlass: false, // glass rendered in layer 2
+                            shadows: _effectiveShadow,
+                          );
+                        },
+                      ),
+
+                    // Tab labels (scrollable) — rendered after pill so they
+                    // paint on top and are not obscured by the indicator.
+                    NotificationListener<ScrollStartNotification>(
+                      onNotification: (_) {
+                        if (_isDown) setState(() => _isDown = false);
+                        return false;
+                      },
+                      child: SingleChildScrollView(
+                        controller: widget.scrollController,
+                        scrollDirection: Axis.horizontal,
+                        physics: physics,
+                        child: _buildTabLabels(
+                          selectedLabelStyle,
+                          unselectedLabelStyle,
+                          selectedIconColor,
+                          unselectedIconColor,
+                        ),
+                      ),
                     ),
-                  ),
+                  ],
                 ),
-              ],
-            ),
-          ),
-
-          // ── Layer 2: glass bloom (above all clips) ──────────────────────
-          if (measuredReady && _indWidthSpring.value > 0)
-            SpringBuilder(
-              spring: GlassSpring.snappy(
-                duration: const Duration(milliseconds: 300),
               ),
-              value: _isDown || isMoving ? 1.0 : 0.0,
-              builder: (context, thickness, _) {
-                return AnimatedGlassIndicator(
-                  velocity: 0.0,
-                  itemCount: widget.tabs.length,
-                  alignment: Alignment.center,
-                  thickness: thickness,
-                  quality: widget.quality,
-                  indicatorColor: indicatorColor,
-                  isBackgroundIndicator: false,
-                  borderRadius: widget.indicatorBorderRadius?.topLeft.x ?? 16,
-                  glassSettings: widget.indicatorSettings,
-                  backgroundKey: widget.backgroundKey,
-                  exactWidth: _indWidthSpring.value,
-                  exactOffset: screenLeft,
-                  expansion:
-                      widget.maskingQuality == MaskingQuality.off ? 0.0 : 8.0,
-                  paintBackground: false, // background rendered in layer 1
-                  paintGlass: true,
-                );
-              },
-            ),
-        ],
+
+              // ── Layer 2: glass bloom (above all clips) ──────────────────────
+              if (measuredReady && _indWidthSpring.value > 0)
+                SpringBuilder(
+                  spring: GlassSpring.snappy(
+                    duration: const Duration(milliseconds: 300),
+                  ),
+                  value: _isDown || isMoving ? 1.0 : 0.0,
+                  builder: (context, thickness, _) {
+                    return AnimatedGlassIndicator(
+                      velocity: normalizedVelocity,
+                      itemCount: widget.tabs.length,
+                      alignment: Alignment.center,
+                      thickness: thickness,
+                      quality: widget.quality,
+                      indicatorColor: indicatorColor,
+                      isBackgroundIndicator: false,
+                      borderRadius:
+                          widget.indicatorBorderRadius?.topLeft.x ?? 16,
+                      glassSettings: widget.indicatorSettings,
+                      backgroundKey: widget.backgroundKey,
+                      exactWidth: _indWidthSpring.value,
+                      exactOffset: screenLeft,
+                      expansion: widget.maskingQuality == MaskingQuality.off
+                          ? 0.0
+                          : 8.0,
+                      paintBackground: false, // background rendered in layer 1
+                      paintGlass: true,
+                    );
+                  },
+                ),
+            ],
+          );
+        },
       );
     } else {
       result = buildContent();


### PR DESCRIPTION
- Jelly Physics: Integrated VelocitySpringBuilder in scrollable mode for dynamic, velocity-based stretching
- Rubber-banding: Added symmetric overstep limits and resistance for consistent physical feedback
- Switching Fix: Resolved "stuck" tabs by replacing strict rounding with a 20% distance threshold and velocity tracking for effortless switching
- Boundary Fix: Resolved indicator overflow issues occurring with low tab counts