### PR TITLE
feat(Menu): dynamic screen adjustment and enhanced geometry; fix(TabBar): glass refraction & fixed drag

### DIFF
--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -61,13 +61,24 @@ class GlassMenu extends StatefulWidget {
   /// Typically contains [GlassMenuItem] and [GlassMenuDivider].
   final List<Widget> items;
 
+  /// The alignment of the menu relative to the trigger.
+  final GlassMenuAlignment? menuAlignment;
+
+  /// Whether to automatically adjust the menu position to keep it on screen.
+  final bool autoAdjustToScreen;
+
   /// Width of the expanded menu.
   final double menuWidth;
 
   /// Border radius of the expanded menu.
   ///
-  /// Defaults to 28.0 for a modern rounded look.
+  /// Defaults to 32.0 for a modern rounded look.
   final double menuBorderRadius;
+
+  /// Border radius of the selection highlight and menu items.
+  ///
+  /// Defaults to 24.0.
+  final double itemBorderRadius;
 
   /// Custom glass settings for the menu container.
   final LiquidGlassSettings? glassSettings;
@@ -134,14 +145,23 @@ class GlassMenu extends StatefulWidget {
   /// If provided, the menu will have a fixed height and internal scrolling.
   final double? menuHeight;
 
+  /// The minimum distance between the menu and the screen edges.
+  ///
+  /// Only applies when [autoAdjustToScreen] is true.
+  /// Defaults to 0.0 (touches the edge). Set to a value like 12.0 for a safe margin.
+  final EdgeInsets menuPadding;
+
   /// Creates a liquid glass menu.
   const GlassMenu({
     super.key,
     this.trigger,
     this.triggerBuilder,
     required this.items,
+    this.menuAlignment,
+    this.autoAdjustToScreen = false,
     this.menuWidth = 200,
     this.menuBorderRadius = 32.0,
+    this.itemBorderRadius = 24.0,
     this.glassSettings,
     this.quality,
     this.stretch = 0.5,
@@ -153,6 +173,7 @@ class GlassMenu extends StatefulWidget {
     this.allowPositiveY,
     this.allowNegativeY,
     this.menuHeight,
+    this.menuPadding = EdgeInsets.zero,
     this.selectionColor = const Color(0x3DFFFFFF),
     this.enableInteractionGlow = true,
     this.glowOnTapOnly = true,

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -14,6 +14,8 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
       false; // Prevents closing if we moved into stretch territory
   double _initialScrollOffset = 0.0;
   Offset _initialLocalPosition = Offset.zero;
+  double _horizontalOffset = 0.0;
+  double _verticalOffset = 0.0;
 
   // --- Granular Update System (Performance + No flicker) ---
   // We cache the outer list but use notifiers to update selection state
@@ -54,6 +56,35 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
   );
 
   Alignment _morphAlignment = Alignment.topLeft;
+
+  Alignment? _getAlignment(GlassMenuAlignment align) {
+    switch (align) {
+      case GlassMenuAlignment.none:
+        return null;
+
+      // When the user selects "Left", we return "Right" alignment.
+      // This anchors the menu's RIGHT edge to the button's RIGHT edge,
+      // causing the menu body to expand to the LEFT (away from the button).
+      case GlassMenuAlignment.topLeft:
+        return Alignment.topRight;
+      case GlassMenuAlignment.topCenter:
+        return Alignment.topCenter;
+      case GlassMenuAlignment.topRight:
+        return Alignment.topLeft;
+      case GlassMenuAlignment.centerLeft:
+        return Alignment.centerRight;
+      case GlassMenuAlignment.center:
+        return Alignment.center;
+      case GlassMenuAlignment.centerRight:
+        return Alignment.centerLeft;
+      case GlassMenuAlignment.bottomLeft:
+        return Alignment.bottomRight;
+      case GlassMenuAlignment.bottomCenter:
+        return Alignment.bottomCenter;
+      case GlassMenuAlignment.bottomRight:
+        return Alignment.bottomLeft;
+    }
+  }
 
   @override
   void initState() {
@@ -162,26 +193,71 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     // Calculate menu height for vertical boundary check
     final menuHeight = _calculateMenuHeight();
 
-    // Horizontal alignment: left vs right half
-    final isRightHalf = screenWidth.isFinite && position.dx > screenWidth / 2;
+    // 1. Determine base alignment (Auto vs Manual)
+    if (widget.menuAlignment == null ||
+        widget.menuAlignment == GlassMenuAlignment.none) {
+      // Horizontal alignment: left vs right half
+      final isRightHalf = screenWidth.isFinite && position.dx > screenWidth / 2;
 
-    // Vertical alignment: check if menu would overflow bottom
-    final spaceBelow = screenHeight.isFinite
-        ? screenHeight - (position.dy + _triggerSize!.height)
-        : double.infinity;
-    final spaceAbove = screenHeight.isFinite ? position.dy : double.infinity;
+      // Vertical alignment: check if menu would overflow bottom
+      final spaceBelow = screenHeight.isFinite
+          ? screenHeight - (position.dy + _triggerSize!.height)
+          : double.infinity;
+      final spaceAbove = screenHeight.isFinite ? position.dy : double.infinity;
 
-    // Prefer downward opening unless insufficient space
-    final shouldFlipVertical =
-        spaceBelow < menuHeight && spaceAbove > menuHeight;
+      // Prefer downward opening unless insufficient space
+      final shouldFlipVertical =
+          spaceBelow < menuHeight && spaceAbove > menuHeight;
 
-    // Determine final alignment based on both axes
-    if (shouldFlipVertical) {
-      _morphAlignment =
-          isRightHalf ? Alignment.bottomRight : Alignment.bottomLeft;
+      if (shouldFlipVertical) {
+        _morphAlignment =
+            isRightHalf ? Alignment.bottomRight : Alignment.bottomLeft;
+      } else {
+        _morphAlignment = isRightHalf ? Alignment.topRight : Alignment.topLeft;
+      }
     } else {
-      _morphAlignment = isRightHalf ? Alignment.topRight : Alignment.topLeft;
+      // MANUAL: Use provided alignment with inverted mapping
+      _morphAlignment =
+          _getAlignment(widget.menuAlignment!) ?? Alignment.center;
     }
+
+    // 2. Clamping: calculate offsets to keep menu within screen bounds
+    double hOffset = 0.0;
+    double vOffset = 0.0;
+
+    if (widget.autoAdjustToScreen) {
+      final padding = widget.menuPadding;
+
+      // Calculate global menu position
+      final double targetX =
+          position.dx + (1 + _morphAlignment.x) * _triggerSize!.width / 2;
+      final double targetY =
+          position.dy + (1 + _morphAlignment.y) * _triggerSize!.height / 2;
+      final double menuLeft =
+          targetX - (1 + _morphAlignment.x) * widget.menuWidth / 2;
+      final double menuTop = targetY - (1 + _morphAlignment.y) * menuHeight / 2;
+
+      // Horizontal adjustment
+      if (menuLeft < padding.left) {
+        hOffset = padding.left - menuLeft;
+      } else if (screenWidth.isFinite &&
+          menuLeft + widget.menuWidth > screenWidth - padding.right) {
+        hOffset = (screenWidth - padding.right) - (menuLeft + widget.menuWidth);
+      }
+
+      // Vertical adjustment
+      if (menuTop < padding.top) {
+        vOffset = padding.top - menuTop;
+      } else if (screenHeight.isFinite &&
+          menuTop + menuHeight > screenHeight - padding.bottom) {
+        vOffset = (screenHeight - padding.bottom) - (menuTop + menuHeight);
+      }
+    }
+
+    setState(() {
+      _horizontalOffset = hOffset;
+      _verticalOffset = vOffset;
+    });
 
     _overlayController.show();
     _runSpring(1.0);
@@ -227,7 +303,10 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
           // - Parabolic curve creates smooth, gravity-like arc
           // - Subtle 5px vertical displacement at peak (t=0.5)
           // - Seamless in both directions (opening and closing)
-          offset: Offset(0, _calculateSwoopOffset(value)),
+          offset: Offset(
+            _horizontalOffset * value,
+            _calculateSwoopOffset(value) + (_verticalOffset * value),
+          ),
           child: IgnorePointer(
             ignoring: value < 0.8,
             child: _buildMorphingContainer(value),
@@ -399,7 +478,8 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
                             child: Container(
                               decoration: BoxDecoration(
                                 color: widget.selectionColor,
-                                borderRadius: BorderRadius.circular(24),
+                                borderRadius: BorderRadius.circular(
+                                    widget.itemBorderRadius),
                                 border: Border.all(
                                   color: const Color(
                                       0x0DFFFFFF), // 5% white border
@@ -652,4 +732,17 @@ class _SelectionItemWrapper extends StatelessWidget {
       },
     );
   }
+}
+
+enum GlassMenuAlignment {
+  none,
+  topLeft,
+  topCenter,
+  topRight,
+  centerLeft,
+  center,
+  centerRight,
+  bottomLeft,
+  bottomCenter,
+  bottomRight,
 }

--- a/lib/widgets/surfaces/shared/tab_bar_internal.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_internal.dart
@@ -452,12 +452,21 @@ class TabBarContentState extends State<TabBarContent>
       final double centerOfSelected = (widget.selectedIndex + 0.5) * tabWidth;
 
       // Use direction and a 20% threshold for effortless switching
-      if ((currentPx - centerOfSelected).abs() >
-              tabWidth * fixedDistanceThresholdFactor ||
+      // Added: logic to determine how many tabs were actually traversed
+      final double offsetFromStart = (currentPx - centerOfSelected);
+      final int tabsJumped = (offsetFromStart / tabWidth).round();
+
+      if (offsetFromStart.abs() > tabWidth * fixedDistanceThresholdFactor ||
           velocityX.abs() > velocityThreshold) {
-        targetTabIndex = currentPx > centerOfSelected
-            ? widget.selectedIndex + 1
-            : widget.selectedIndex - 1;
+        // If we flicked or moved significantly, we calculate target relative to start
+        // but allow it to be more than just +/- 1
+        if (tabsJumped.abs() > 1) {
+          targetTabIndex = widget.selectedIndex + tabsJumped;
+        } else {
+          targetTabIndex = currentPx > centerOfSelected
+              ? widget.selectedIndex + 1
+              : widget.selectedIndex - 1;
+        }
       } else {
         targetTabIndex = widget.selectedIndex;
       }
@@ -548,228 +557,27 @@ class TabBarContentState extends State<TabBarContent>
   @override
   Widget build(BuildContext context) {
     final indicatorColor = widget.indicatorColor ?? _defaultIndicatorColor;
-    final targetAlignment = _computeXAlignmentForTab(widget.selectedIndex);
 
     final selectedLabelStyle = widget.selectedLabelStyle ??
         const TextStyle(
-          fontSize: 14,
-          fontWeight: FontWeight.w600,
-          color: Colors.white,
-        );
+            fontSize: 14, fontWeight: FontWeight.w600, color: Colors.white);
 
     final unselectedLabelStyle = widget.unselectedLabelStyle ??
         const TextStyle(
-          fontSize: 14,
-          fontWeight: FontWeight.w500,
-          color: _defaultUnselectedTextColor,
-        );
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+            color: _defaultUnselectedTextColor);
 
     final selectedIconColor = widget.selectedIconColor ?? Colors.white;
     final unselectedIconColor =
         widget.unselectedIconColor ?? _defaultUnselectedIconColor;
 
-    Widget buildContent() {
-      return VelocitySpringBuilder(
-        value: _xAlign,
-        springWhenActive: GlassSpring.interactive(),
-        springWhenReleased: GlassSpring.snappy(
-          duration: const Duration(milliseconds: 350),
-        ),
-        active: _isDragging && !widget.isScrollable,
-        builder: (context, value, velocity, child) {
-          final alignment = Alignment(value, 0);
-
-          return SpringBuilder(
-            spring: GlassSpring.snappy(
-              duration: const Duration(milliseconds: 300),
-            ),
-            // Bloom while dragging, held down, or still in transit.
-            // Mirrors GlassSegmentedControl: the bloom deactivates naturally
-            // as the spring settles, with no artificial timer.
-            value: _isDown || (alignment.x - targetAlignment).abs() > 0.05
-                ? 1.0
-                : 0.0,
-            builder: (context, thickness, child) {
-              return Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  if (!widget.isScrollable)
-                    AnimatedGlassIndicator(
-                      velocity: velocity,
-                      itemCount: widget.tabs.length,
-                      alignment: alignment,
-                      thickness: thickness,
-                      quality: widget.quality,
-                      indicatorColor: indicatorColor,
-                      isBackgroundIndicator: false,
-                      borderRadius:
-                          widget.indicatorBorderRadius?.topLeft.x ?? 16,
-                      glassSettings: widget.indicatorSettings,
-                      backgroundKey: widget.backgroundKey,
-                      expansion: widget.maskingQuality == MaskingQuality.off
-                          ? 0.0
-                          : 8.0,
-                      shadows: _effectiveShadow,
-                    ),
-                  child!,
-                ],
-              );
-            },
-            child: _buildTabLabels(
-              selectedLabelStyle,
-              unselectedLabelStyle,
-              selectedIconColor,
-              unselectedIconColor,
-            ),
-          );
-        },
-      );
-    }
-
-    Widget result;
-    if (widget.isScrollable) {
-      // Three-layer architecture:
-      //  1. ClipRect layer: tab labels + solid background pill — both clip
-      //     cleanly at the viewport boundary as the user scrolls.
-      //  2. Glass bloom layer (above ClipRect): only the glass effect renders
-      //     here, so the jelly bloom can expand freely past the bar edges.
-      final bool measuredReady = _tabWidths.length == widget.tabs.length;
-      final double scrollOffset = widget.scrollController.hasClients
-          ? widget.scrollController.offset
-          : 0.0;
-
-      // Bloom while the position spring is still in transit — deactivates
-      // naturally as the spring settles (mirrors GlassSegmentedControl).
-      final double targetOffset =
-          measuredReady && widget.selectedIndex < _tabOffsets.length
-              ? _tabOffsets[widget.selectedIndex]
-              : 0.0;
-
-      final physics = _isDraggingIndicator
-          ? const NeverScrollableScrollPhysics()
-          : const ClampingScrollPhysics();
-
-      // Wrapping in VelocitySpringBuilder to capture physical movement velocity
-      // for the "jelly" shader effect in scrollable mode.
-      result = VelocitySpringBuilder(
-        value: _indOffsetSpring.value,
-        springWhenActive: GlassSpring.interactive(),
-        springWhenReleased: GlassSpring.snappy(
-          duration: const Duration(milliseconds: 350),
-        ),
-        active: _isDraggingIndicator,
-        builder: (context, currentOffset, velocity, _) {
-          // Normalizing velocity: pixels-per-frame to a manageable 0.0-2.0 scale for the shader.
-          // This prevents the indicator from over-stretching into a vertical line during drag.
-          final double normalizedVelocity = velocity / 300.0;
-          final double screenLeft = currentOffset - scrollOffset;
-          final bool isMoving = (currentOffset - targetOffset).abs() > 2.0;
-
-          return Stack(
-            clipBehavior: Clip.none,
-            children: [
-              // ── Layer 1: clipped content ────────────────────────────────────
-              // ClipRRect clips to the tab bar's rounded corners so the solid
-              // background pill and tab labels don't overflow the corner radius.
-              ClipRRect(
-                borderRadius: widget.tabBarBorderRadius ?? BorderRadius.zero,
-                child: Stack(
-                  clipBehavior: Clip.none,
-                  children: [
-                    // Background solid pill — clips with the bar (rendered before
-                    // labels so labels paint above the pill — correct z-order).
-                    if (measuredReady && _indWidthSpring.value > 0)
-                      SpringBuilder(
-                        spring: GlassSpring.snappy(
-                          duration: const Duration(milliseconds: 300),
-                        ),
-                        value: _isDown || isMoving ? 1.0 : 0.0,
-                        builder: (context, thickness, _) {
-                          return AnimatedGlassIndicator(
-                            velocity: normalizedVelocity,
-                            itemCount: widget.tabs.length,
-                            alignment: Alignment.center,
-                            thickness: thickness,
-                            quality: widget.quality,
-                            indicatorColor: indicatorColor,
-                            isBackgroundIndicator: false,
-                            borderRadius:
-                                widget.indicatorBorderRadius?.topLeft.x ?? 16,
-                            glassSettings: widget.indicatorSettings,
-                            backgroundKey: widget.backgroundKey,
-                            exactWidth: _indWidthSpring.value,
-                            exactOffset: screenLeft,
-                            expansion:
-                                widget.maskingQuality == MaskingQuality.off
-                                    ? 0.0
-                                    : 8.0,
-                            paintBackground: true,
-                            paintGlass: false, // glass rendered in layer 2
-                            shadows: _effectiveShadow,
-                          );
-                        },
-                      ),
-
-                    // Tab labels (scrollable) — rendered after pill so they
-                    // paint on top and are not obscured by the indicator.
-                    NotificationListener<ScrollStartNotification>(
-                      onNotification: (_) {
-                        if (_isDown) setState(() => _isDown = false);
-                        return false;
-                      },
-                      child: SingleChildScrollView(
-                        controller: widget.scrollController,
-                        scrollDirection: Axis.horizontal,
-                        physics: physics,
-                        child: _buildTabLabels(
-                          selectedLabelStyle,
-                          unselectedLabelStyle,
-                          selectedIconColor,
-                          unselectedIconColor,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-
-              // ── Layer 2: glass bloom (above all clips) ──────────────────────
-              if (measuredReady && _indWidthSpring.value > 0)
-                SpringBuilder(
-                  spring: GlassSpring.snappy(
-                    duration: const Duration(milliseconds: 300),
-                  ),
-                  value: _isDown || isMoving ? 1.0 : 0.0,
-                  builder: (context, thickness, _) {
-                    return AnimatedGlassIndicator(
-                      velocity: normalizedVelocity,
-                      itemCount: widget.tabs.length,
-                      alignment: Alignment.center,
-                      thickness: thickness,
-                      quality: widget.quality,
-                      indicatorColor: indicatorColor,
-                      isBackgroundIndicator: false,
-                      borderRadius:
-                          widget.indicatorBorderRadius?.topLeft.x ?? 16,
-                      glassSettings: widget.indicatorSettings,
-                      backgroundKey: widget.backgroundKey,
-                      exactWidth: _indWidthSpring.value,
-                      exactOffset: screenLeft,
-                      expansion: widget.maskingQuality == MaskingQuality.off
-                          ? 0.0
-                          : 8.0,
-                      paintBackground: false, // background rendered in layer 1
-                      paintGlass: true,
-                    );
-                  },
-                ),
-            ],
-          );
-        },
-      );
-    } else {
-      result = buildContent();
-    }
+    final Widget tabLabels = _buildTabLabels(
+      selectedLabelStyle,
+      unselectedLabelStyle,
+      selectedIconColor,
+      unselectedIconColor,
+    );
 
     return RawGestureDetector(
       gestures: {
@@ -784,7 +592,148 @@ class TabBarContentState extends State<TabBarContent>
           (instance) {},
         ),
       },
-      child: result,
+      // Wrapping in VelocitySpringBuilder to capture physical movement velocity
+      // for the "jelly" shader effect.
+      child: VelocitySpringBuilder(
+        value: widget.isScrollable ? _indOffsetSpring.value : _xAlign,
+        springWhenActive: GlassSpring.interactive(),
+        springWhenReleased: GlassSpring.snappy(
+          duration: const Duration(milliseconds: 350),
+        ),
+        active: widget.isScrollable ? _isDraggingIndicator : _isDragging,
+        builder: (context, currentValue, velocity, _) {
+          // Normalizing velocity: pixels-per-frame to a manageable 0.0-2.0 scale for the shader
+          // in scrollable mode. Prevents over-stretching into a vertical line during drag.
+          final double normalizedVelocity =
+              widget.isScrollable ? velocity / 300.0 : velocity;
+
+          final Alignment alignment = widget.isScrollable
+              ? Alignment.center
+              : Alignment(currentValue, 0);
+          final double screenLeft =
+              widget.isScrollable && widget.scrollController.hasClients
+                  ? currentValue - widget.scrollController.offset
+                  : 0.0;
+
+          // Bloom while the position spring is still in transit — deactivates
+          // naturally as the spring settles (mirrors GlassSegmentedControl).
+          final bool isMoving;
+          final bool canShowIndicator;
+
+          if (widget.isScrollable) {
+            final bool measuredReady = _tabWidths.length == widget.tabs.length;
+            final double targetOffset =
+                measuredReady && widget.selectedIndex < _tabOffsets.length
+                    ? _tabOffsets[widget.selectedIndex]
+                    : 0.0;
+            isMoving = (currentValue - targetOffset).abs() > 2.0;
+            canShowIndicator = measuredReady && _indWidthSpring.value > 0;
+          } else {
+            final double targetAlignment =
+                _computeXAlignmentForTab(widget.selectedIndex);
+            isMoving = (alignment.x - targetAlignment).abs() > 0.05;
+            canShowIndicator = true;
+          }
+
+          return SpringBuilder(
+            spring: GlassSpring.snappy(
+              duration: const Duration(milliseconds: 300),
+            ),
+            value: _isDown || isMoving ? 1.0 : 0.0,
+            builder: (context, thickness, _) {
+              // Helper to prevent indicator parameter duplication
+              Widget buildIndicator(
+                  {required bool paintBackground, required bool paintGlass}) {
+                return AnimatedGlassIndicator(
+                  velocity: normalizedVelocity,
+                  itemCount: widget.tabs.length,
+                  alignment: alignment,
+                  thickness: thickness,
+                  quality: widget.quality,
+                  indicatorColor: indicatorColor,
+                  isBackgroundIndicator: false,
+                  borderRadius: widget.indicatorBorderRadius?.topLeft.x ?? 16,
+                  glassSettings: widget.indicatorSettings,
+                  backgroundKey: widget.backgroundKey,
+                  expansion:
+                      widget.maskingQuality == MaskingQuality.off ? 0.0 : 8.0,
+                  paintBackground: paintBackground,
+                  paintGlass: paintGlass,
+                  shadows: paintBackground ? _effectiveShadow : null,
+                  exactWidth:
+                      widget.isScrollable ? _indWidthSpring.value : null,
+                  exactOffset: widget.isScrollable ? screenLeft : null,
+                );
+              }
+
+              if (widget.isScrollable) {
+                // Three-layer architecture:
+                //  1. ClipRect layer: tab labels + solid background pill — both clip
+                //     cleanly at the viewport boundary as the user scrolls.
+                //  2. Glass bloom layer (above ClipRect): only the glass effect renders
+                //     here, so the jelly bloom can expand freely past the bar edges.
+                final physics = _isDraggingIndicator
+                    ? const NeverScrollableScrollPhysics()
+                    : const ClampingScrollPhysics();
+
+                return Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    // ── Layer 1: clipped content ────────────────────────────────────
+                    // ClipRRect clips to the tab bar's rounded corners so the solid
+                    // background pill and tab labels don't overflow the corner radius.
+                    ClipRRect(
+                      borderRadius:
+                          widget.tabBarBorderRadius ?? BorderRadius.zero,
+                      child: Stack(
+                        clipBehavior: Clip.none,
+                        children: [
+                          // Background solid pill — clips with the bar (rendered before
+                          // labels so labels paint above the pill — correct z-order).
+                          if (canShowIndicator)
+                            buildIndicator(
+                                paintBackground: true, paintGlass: false),
+
+                          // Tab labels (scrollable) — rendered after pill so they
+                          // paint on top and are not obscured by the indicator.
+                          NotificationListener<ScrollStartNotification>(
+                            onNotification: (_) {
+                              if (_isDown) setState(() => _isDown = false);
+                              return false;
+                            },
+                            child: SingleChildScrollView(
+                              controller: widget.scrollController,
+                              scrollDirection: Axis.horizontal,
+                              physics: physics,
+                              child: tabLabels,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+
+                    // ── Layer 2: glass bloom (above all clips) ──────────────────────
+                    if (canShowIndicator)
+                      buildIndicator(paintBackground: false, paintGlass: true),
+                  ],
+                );
+              } else {
+                // Non-scrollable mode: stacking background, labels, glass without clipping.
+                return Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    if (canShowIndicator)
+                      buildIndicator(paintBackground: true, paintGlass: false),
+                    tabLabels,
+                    if (canShowIndicator)
+                      buildIndicator(paintBackground: false, paintGlass: true),
+                  ],
+                );
+              }
+            },
+          );
+        },
+      ),
     );
   }
 


### PR DESCRIPTION
Menu
- Screen Padding: Migrated to EdgeInsets for per-side control and updated autoAdjustToScreen to respect these boundaries
- Smart Alignment: Integrated GlassMenuAlignment enum with auto-flip logic to prevent vertical viewport overflow
- Selection: Added itemBorderRadius
- Morphing Fix: Included calculated offsets in the transformation to ensure correct sliding within screen bounds

TabBar
- Refraction Layer: Added a background layer in non-scrollable mode. Without it, the labels didn't interact with the glass; now the indicator correctly refracts the tabs in active mode
- Fixed Mode Jumping: Fixed a bug where dragging from the first to the last tab snapped the indicator back to the previous tab. It now correctly calculates multi-tab jumps while keeping the original drag sensitivity