### PR TITLE
fix: eliminate rectangular blur halo around rounded glass over iOS PlatformViews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Unreleased
+
+## 🐛 Fix — eliminate rectangular blur halo over PlatformViews (iOS Impeller)
+
+`LightweightLiquidGlass` and `_FrostedFallback` previously wrapped their glass surface in `ClipPath(ShapeBorderClipper(...))`. When the parent was an iOS PlatformView (e.g. `mapbox_maps_flutter` `MapWidget`, `video_player` on iOS), the descendant `BackdropFilter`'s rectangular blur output leaked past the rounded clip — visible as a faint square halo around the rounded glass shape, most obvious when light backdrop content scrolled underneath.
+
+Flutter framework [PR #177551](https://github.com/flutter/flutter/pull/177551) (merged Dec 2025, shipped in 3.41.0-0.0.pre+) fixed this at the engine level by forwarding `ClipRRect` clip data to the iOS PlatformView mutator stack — but **only `ClipRRect`, not `ClipPath`**, even when the path inside is mathematically a rounded rect.
+
+This release routes shapes that resolve to a `RoundedRectangleBorder` (i.e. `LiquidRoundedSuperellipse`, `LiquidVerticalRoundedSuperellipse`) through `ClipRRect` instead of `ClipPath`. The engine fix now triggers and the halo disappears for those shapes.
+
+`LiquidOval` is intentionally NOT routed through `ClipRRect` — empirically the engine fix doesn't forward `ClipRRect` with `circular(double.infinity)` nor a `LayoutBuilder`-computed finite radius on the `LiquidOval` path. Callers that need a halo-free circular glass surface over a PlatformView should use `LiquidRoundedSuperellipse(borderRadius: size / 2)` instead, which renders identically on a square widget and triggers the engine fix.
+
+Closes upstream Flutter [#175048](https://github.com/flutter/flutter/issues/175048) and [#115926](https://github.com/flutter/flutter/issues/115926) for `liquid_glass_widgets` users.
+
 # 0.11.0
 
 ## ✨ New — Liquid Morph Engine (new architectural system)

--- a/lib/widgets/shared/adaptive_glass.dart
+++ b/lib/widgets/shared/adaptive_glass.dart
@@ -420,12 +420,17 @@ class _FrostedFallback extends StatelessWidget {
           .hardEdge, // Locks dirty region to widget bounds — prevents page-wide flicker
       children: [
         if (useBlur)
-          // Stationary surfaces: blur + tint clipped to shape
+          // Stationary surfaces: blur + tint clipped to shape.
+          //
+          // Use ClipRRect when the shape resolves to a rounded rect —
+          // Flutter PR #177551 (in 3.41+) forwards ClipRRect clip data
+          // to iOS PlatformView mutators, so ClipRRect (not ClipPath)
+          // is what lets the engine clip a descendant BackdropFilter
+          // over a PlatformView. Eliminates the rectangular blur halo
+          // around rounded glass surfaces stacked over PlatformViews
+          // (e.g. mapbox_maps_flutter, video_player on iOS).
           Positioned.fill(
-            child: ClipPath(
-              clipper: ShapeBorderClipper(shape: shape),
-              child: body,
-            ),
+            child: _ShapeClip(shape: shape, child: body),
           ),
 
         if (!useBlur)
@@ -449,11 +454,10 @@ class _FrostedFallback extends StatelessWidget {
             ),
           ),
 
-        // Text and contents MUST be strictly clipped to corner radii
-        ClipPath(
-          clipper: ShapeBorderClipper(shape: shape),
-          child: child,
-        ),
+        // Text and contents MUST be strictly clipped to corner radii.
+        // Same ClipRRect-over-ClipPath rationale as the blur body
+        // above — see the [_ShapeClip] doc comment.
+        _ShapeClip(shape: shape, child: child),
 
         // Specular Rim: drawn as a pure native overlay vector perfectly on top
         Positioned.fill(
@@ -564,4 +568,59 @@ class _SpecularRimPainter extends CustomPainter {
   @override
   bool shouldRepaint(_SpecularRimPainter old) =>
       old.settings != settings || old.shape != shape;
+}
+
+/// Wraps [child] in [ClipRRect] when the shape resolves to a
+/// `RoundedRectangleBorder` (i.e. [LiquidRoundedSuperellipse] or
+/// [LiquidVerticalRoundedSuperellipse]), otherwise falls back to
+/// [ClipPath] with `ShapeBorderClipper`.
+///
+/// **Why this matters:** Flutter framework PR #177551 (merged Dec 2025,
+/// shipped in 3.41.0-0.0.pre and forward) forwards `ClipRRect` clip data
+/// to the iOS PlatformView mutator stack — which lets the engine
+/// correctly clip a descendant [BackdropFilter] over a PlatformView.
+/// The same fix does NOT apply to `ClipPath`, even when the path inside
+/// is mathematically a rounded rect.
+///
+/// Eliminates the rectangular blur halo that appeared around rounded
+/// `_FrostedFallback` surfaces when stacked over a PlatformView (e.g.
+/// `mapbox_maps_flutter`'s `MapWidget`, `video_player` on iOS).
+///
+/// **Caveat — [LiquidOval] is not handled.** Empirically the engine fix
+/// does not forward `ClipRRect` with `circular(double.infinity)`, nor
+/// does it forward a `LayoutBuilder`-computed finite radius on a
+/// `LiquidOval` shape. Callers that need a halo-free circular surface
+/// over a PlatformView should pass
+/// `LiquidRoundedSuperellipse(borderRadius: size / 2)` instead, which
+/// renders identically to a circle on a square widget and triggers the
+/// engine fix.
+class _ShapeClip extends StatelessWidget {
+  const _ShapeClip({required this.shape, required this.child});
+
+  final LiquidShape shape;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final shape = this.shape;
+    if (shape is LiquidRoundedSuperellipse) {
+      return ClipRRect(
+        borderRadius: BorderRadius.all(Radius.circular(shape.borderRadius)),
+        child: child,
+      );
+    }
+    if (shape is LiquidVerticalRoundedSuperellipse) {
+      return ClipRRect(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(shape.topRadius),
+          bottom: Radius.circular(shape.bottomRadius),
+        ),
+        child: child,
+      );
+    }
+    return ClipPath(
+      clipper: ShapeBorderClipper(shape: shape),
+      child: child,
+    );
+  }
 }

--- a/lib/widgets/shared/lightweight_liquid_glass.dart
+++ b/lib/widgets/shared/lightweight_liquid_glass.dart
@@ -245,20 +245,47 @@ class _LightweightLiquidGlassState extends State<LightweightLiquidGlass> {
       clipShape = widget.shape;
     }
 
+    // When the resolved clipShape is a RoundedRectangleBorder with a
+    // BorderRadius, wrap in ClipRRect instead of ClipPath. Flutter PR
+    // #177551 (in 3.41+) forwards ClipRRect clip data to the iOS
+    // PlatformView mutator stack, which lets the engine clip a
+    // descendant BackdropFilter over a PlatformView — eliminating the
+    // rectangular blur halo that appears around rounded glass surfaces
+    // stacked over a PlatformView (e.g. mapbox_maps_flutter,
+    // video_player on iOS). The same engine fix does NOT apply to
+    // ClipPath, even when the path inside is mathematically a rounded
+    // rect.
+    //
+    // LiquidOval is NOT covered: empirically the engine fix does not
+    // forward ClipRRect with circular(double.infinity), nor does it
+    // forward a LayoutBuilder-computed finite radius on a LiquidOval
+    // path. App code that needs a halo-free circular glass surface
+    // over a PlatformView should use
+    // LiquidRoundedSuperellipse(borderRadius: size/2) instead, which
+    // renders identically and triggers the engine fix.
+    final BorderRadius? roundedRectRadius =
+        (clipShape is RoundedRectangleBorder &&
+                clipShape.borderRadius is BorderRadius)
+            ? clipShape.borderRadius as BorderRadius
+            : null;
+    final Widget effect = _LightweightGlassEffect(
+      // Nullable: render object paints tinted passthrough when null.
+      shader: shader,
+      settings: settings,
+      shape: widget.shape,
+      skipBlur: skipBlur,
+      glowIntensity: widget.glowIntensity,
+      densityFactor: widget.densityFactor,
+      indicatorWeight: widget.indicatorWeight,
+      backdropLuma: backdropLuma,
+      child: widget.child,
+    );
+    if (roundedRectRadius != null) {
+      return ClipRRect(borderRadius: roundedRectRadius, child: effect);
+    }
     return ClipPath(
       clipper: ShapeBorderClipper(shape: clipShape),
-      child: _LightweightGlassEffect(
-        // Nullable: render object paints tinted passthrough when null.
-        shader: shader,
-        settings: settings,
-        shape: widget.shape,
-        skipBlur: skipBlur,
-        glowIntensity: widget.glowIntensity,
-        densityFactor: widget.densityFactor,
-        indicatorWeight: widget.indicatorWeight,
-        backdropLuma: backdropLuma,
-        child: widget.child,
-      ),
+      child: effect,
     );
   }
 }

--- a/test/widgets/shared/adaptive_glass_coverage_test.dart
+++ b/test/widgets/shared/adaptive_glass_coverage_test.dart
@@ -23,7 +23,11 @@ void main() {
         ),
       )));
       await tester.pump();
-      expect(find.byType(ClipPath), findsWidgets);
+      // Frosted-fallback path used to wrap in ClipPath(ShapeBorderClipper);
+      // for RoundedRectangleBorder-resolving shapes it now wraps in
+      // ClipRRect via _ShapeClip (so Flutter PR #177551's PlatformView
+      // clip-forwarding takes effect over a PlatformView backdrop).
+      expect(find.byType(ClipRRect), findsWidgets);
     });
 
     testWidgets('blur=0 triggers minimal fast path', (tester) async {
@@ -38,7 +42,7 @@ void main() {
         ),
       )));
       await tester.pump();
-      expect(find.byType(ClipPath), findsWidgets);
+      expect(find.byType(ClipRRect), findsWidgets);
     });
 
     testWidgets('standard quality renders lightweight glass', (tester) async {
@@ -96,7 +100,9 @@ void main() {
         ),
       ));
       await tester.pump();
-      expect(find.byType(ClipPath), findsWidgets);
+      // See note above on the ClipPath → ClipRRect swap in _ShapeClip
+      // for RoundedRectangleBorder-resolving shapes.
+      expect(find.byType(ClipRRect), findsWidgets);
     });
   });
 

--- a/test/widgets/shared/adaptive_glass_coverage_test.dart
+++ b/test/widgets/shared/adaptive_glass_coverage_test.dart
@@ -106,6 +106,54 @@ void main() {
     });
   });
 
+  // _ShapeClip — the private helper used by _FrostedFallback to route
+  // RoundedRectangleBorder-resolving shapes through ClipRRect (so the
+  // Flutter PR #177551 PlatformView clip-forward fix takes effect) and
+  // everything else through ClipPath. Exercise both branches that
+  // aren't covered by the LiquidRoundedSuperellipse cases above.
+  group('AdaptiveGlass — _ShapeClip shape branches via _FrostedFallback', () {
+    testWidgets(
+        'LiquidVerticalRoundedSuperellipse routes through ClipRRect.vertical',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox(
+        width: 200,
+        height: 100,
+        child: AdaptiveGlass(
+          shape: LiquidVerticalRoundedSuperellipse(
+            topRadius: 18,
+            bottomRadius: 4,
+          ),
+          settings: _settings,
+          quality: GlassQuality.minimal,
+          child: SizedBox.expand(),
+        ),
+      )));
+      await tester.pump();
+      // Asymmetric vertical rounded rect should still resolve to
+      // ClipRRect (with BorderRadius.vertical) via _ShapeClip.
+      expect(find.byType(ClipRRect), findsWidgets);
+    });
+
+    testWidgets('LiquidOval falls back to ClipPath via _ShapeClip',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox(
+        width: 80,
+        height: 80,
+        child: AdaptiveGlass(
+          shape: LiquidOval(),
+          settings: _settings,
+          quality: GlassQuality.minimal,
+          child: SizedBox.expand(),
+        ),
+      )));
+      await tester.pump();
+      // LiquidOval is intentionally NOT routed through ClipRRect (see
+      // _ShapeClip doc comment) — verify the ClipPath fallback path is
+      // taken.
+      expect(find.byType(ClipPath), findsWidgets);
+    });
+  });
+
   group('AdaptiveGlass — grouped factory', () {
     testWidgets('grouped() returns AdaptiveGlass', (tester) async {
       await tester.pumpWidget(_wrap(SizedBox(

--- a/test/widgets/shared/lightweight_liquid_glass_coverage_test.dart
+++ b/test/widgets/shared/lightweight_liquid_glass_coverage_test.dart
@@ -39,10 +39,10 @@ void main() {
     LightweightLiquidGlass.resetForTesting();
   });
 
-  // ── Shader null → ClipPath fallback ───────────────────────────────────────
+  // ── Shader null → clip wrap fallback ──────────────────────────────────────
 
   group('LightweightLiquidGlass — fallback (shader == null)', () {
-    testWidgets('renders ClipPath fallback when no shader cached',
+    testWidgets('renders ClipRRect fallback for RoundedRectangleBorder shapes',
         (tester) async {
       // resetForTesting ensures _cachedProgram == null → fallback path.
       await tester.pumpWidget(
@@ -55,11 +55,16 @@ void main() {
         ),
       );
       await tester.pump();
-      // Fallback uses ClipPath.
-      expect(find.byType(ClipPath), findsAtLeastNWidgets(1));
+      // Shapes that resolve to RoundedRectangleBorder are wrapped in
+      // ClipRRect (not ClipPath) so Flutter PR #177551's PlatformView
+      // clip-forwarding kicks in over a PlatformView backdrop.
+      expect(find.byType(ClipRRect), findsAtLeastNWidgets(1));
     });
 
     testWidgets('LiquidOval fallback uses ClipPath', (tester) async {
+      // LiquidOval is intentionally NOT routed through ClipRRect — the
+      // engine fix doesn't trigger for it (see _ShapeClip doc comment).
+      // The fallback remains ClipPath.
       await tester.pumpWidget(
         createTestApp(
           child: LightweightLiquidGlass(


### PR DESCRIPTION
## Summary

When a rounded `liquid_glass_widgets` surface is stacked over an iOS PlatformView (e.g. `mapbox_maps_flutter` `MapWidget`, `video_player` on iOS), a faint **rectangular halo** appears extending past the rounded corners of the glass shape. It's most visible when light backdrop content scrolls underneath — the blurred light pixels bleed into the corner regions outside the rounded silhouette.

Root cause: `LightweightLiquidGlass` and `_FrostedFallback` wrap their glass surface in `ClipPath(ShapeBorderClipper(...))`. Flutter framework [PR flutter/flutter#177551](https://github.com/flutter/flutter/pull/177551) (merged Dec 2025, shipped in 3.41.0-0.0.pre+) fixed this at the engine level by forwarding clip data to the iOS PlatformView mutator stack — but **only for `ClipRRect`, not `ClipPath`**, even when the path inside is mathematically a rounded rect.

This PR routes shapes that resolve to a `RoundedRectangleBorder` (`LiquidRoundedSuperellipse`, `LiquidVerticalRoundedSuperellipse`) through `ClipRRect` instead of `ClipPath`. The engine fix triggers and the halo disappears.

Closes upstream Flutter [#175048](https://github.com/flutter/flutter/issues/175048) and [#115926](https://github.com/flutter/flutter/issues/115926) for `liquid_glass_widgets` users. Also matches the symptom in closed issue [#10](https://github.com/sdegenaar/liquid_glass_widgets/issues/10) of this repo.

## Changes

- **`lib/widgets/shared/lightweight_liquid_glass.dart`** — `LightweightLiquidGlass.build`: when the resolved `clipShape` is a `RoundedRectangleBorder` with a `BorderRadius`, wrap the `_LightweightGlassEffect` in `ClipRRect(borderRadius: ...)` instead of `ClipPath(clipper: ShapeBorderClipper(...))`. Other shapes fall back to `ClipPath` unchanged.
- **`lib/widgets/shared/adaptive_glass.dart`** — `_FrostedFallback.build`: same swap at the two `ClipPath(ShapeBorderClipper(...))` sites (the blur-body wrap and the child-content wrap). Logic extracted into a private `_ShapeClip` helper widget for reuse and clear documentation.
- **Tests updated** to reflect the new widget type (`adaptive_glass_coverage_test.dart`, `lightweight_liquid_glass_coverage_test.dart`).
- **CHANGELOG entry** under \`# Unreleased\`.

## `LiquidOval` — intentionally not changed

`LiquidOval` is NOT routed through `ClipRRect`. Empirically the engine fix does **not** trigger for:
- `ClipRRect` with `BorderRadius.all(Radius.circular(double.infinity))` (paint-time-clamped radius)
- `LayoutBuilder`-computed finite circular radius on a `LiquidOval` shape

Callers that need a halo-free **circular** glass surface over a PlatformView should use `LiquidRoundedSuperellipse(borderRadius: size / 2)` instead — renders identically to a circle on a square widget and triggers the engine fix. Documented in the new `_ShapeClip` doc comment.

If anyone has insight into making `LiquidOval` work with the engine clip-forwarding path, happy to take a follow-up.

## Test plan

- [x] `flutter test test/widgets/` — all 1,122 tests pass
- [x] Visual verification in a real app over a Mapbox `MapWidget` PlatformView on iOS Impeller (Flutter 3.41.7 stable):
  - Bottom nav pill (`LiquidRoundedSuperellipse`) — halo gone ✅
  - Search button (`LiquidRoundedSuperellipse`) — halo gone ✅
  - Settings ⋯ button (`LiquidRoundedSuperellipse` via `GlassIconButtonShape.roundedSquare + borderRadius: size/2` workaround for `LiquidOval`) — halo gone ✅
  - Modal sheet (`LiquidVerticalRoundedSuperellipse`) — halo gone on top corners; minor imperfection on bottom corners with asymmetric radii (engine fix is documented for "uniform corner radii", so asymmetric is best-effort).
- [x] `flutter analyze` clean on patched files.
- [ ] (Draft) Maintainer review of approach + doc comment wording.

## Backward compatibility

- Visual: pixel-identical to `ClipPath` for all shapes EXCEPT when the engine fix activates (over PlatformViews on iOS Impeller), where the halo is now correctly absent.
- API: no public-facing changes; private widget restructure only.
- Test breakage: covered above. The previous tests asserted `find.byType(ClipPath)`; updated to `find.byType(ClipRRect)` for the cases that now route through the new path.

## Notes for reviewer

- Posting as a draft for your review of approach + wording before publishing publicly.
- Branch builds clean off your current `main` (no merge conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)