### PR TITLE
feat(GlassSearchableBottomBar): expose cursorColor + default to theme inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 0.13.0
+
+## ✨ Feature — `GlassSearchBarConfig.cursorColor` + cursor follows Flutter theme by default
+
+`GlassSearchableBottomBar`'s expanded search field now exposes a `cursorColor` knob via `GlassSearchBarConfig`, and the default behaviour aligns with Flutter convention — the cursor follows the standard theme-resolution chain (`Theme.of(context).textSelectionTheme.cursorColor` → `CupertinoTheme.primaryColor` on iOS → `Theme.of(context).colorScheme.primary`) rather than being hard-coupled to `textColor`.
+
+This means theme-driven apps automatically get the right cursor color (matching every other Material `TextField` in the app) without any per-instance configuration. Apps that want the previous behaviour — cursor matching `textColor` — can opt in explicitly:
+
+```dart
+GlassSearchBarConfig(
+  textColor: Colors.white,
+  cursorColor: Colors.white,  // ← previously implicit
+  ...
+)
+```
+
+### ⚠️ Breaking change
+
+Apps that set a `textColor` and rely on the cursor implicitly matching it will see their cursor colour change to whatever their `Theme.of(context).colorScheme.primary` is (typically `Colors.blue` if untouched). Two-line migration above.
+
+The change was driven by an app where `textColor: Colors.white` produced an invisible-on-glass white cursor, and the standard Flutter levers (`textSelectionTheme.cursorColor`, `cupertinoOverrideTheme.primaryColor`) couldn't override it because the package was passing a non-null `cursorColor` to the underlying `TextField` — short-circuiting Flutter's entire resolution chain. Decoupling the two restores the standard mechanism.
+
+---
+
 # 0.12.8
 
 ## 🐛 Fix — `GlassTextField` reverted to v0.12.4 + icon drift fix

--- a/lib/widgets/surfaces/shared/glass_search_bar_config.dart
+++ b/lib/widgets/surfaces/shared/glass_search_bar_config.dart
@@ -37,6 +37,7 @@ class GlassSearchBarConfig {
     this.onSubmitted,
     this.onMicTap,
     this.textColor,
+    this.cursorColor,
     this.trailingBuilder,
     this.textInputAction,
     this.keyboardType,
@@ -140,6 +141,32 @@ class GlassSearchBarConfig {
 
   /// Color of the typed text. Defaults to white.
   final Color? textColor;
+
+  /// Color of the text cursor (blinking caret) in the expanded
+  /// search field.
+  ///
+  /// When `null` (the default), the cursor inherits via Flutter's
+  /// standard resolution chain:
+  ///   1. `Theme.of(context).textSelectionTheme.cursorColor`
+  ///   2. On iOS, `CupertinoTheme.of(context).primaryColor`
+  ///   3. `Theme.of(context).colorScheme.primary`
+  ///
+  /// This matches how every other Material `TextField` cursor in a
+  /// Flutter app resolves color, so theme-driven apps Just Work
+  /// without needing to set this here.
+  ///
+  /// **Breaking change in 0.13.0**: in 0.12.x and earlier the cursor
+  /// was hard-coupled to [textColor]. To restore the previous
+  /// behaviour, pass `cursorColor: textColor` explicitly:
+  ///
+  /// ```dart
+  /// GlassSearchBarConfig(
+  ///   textColor: Colors.white,
+  ///   cursorColor: Colors.white,  // ← previously implicit
+  ///   ...
+  /// )
+  /// ```
+  final Color? cursorColor;
 
   // ── SearchBar parity ────────────────────────────────────────────────────────
 

--- a/lib/widgets/surfaces/shared/searchable_bottom_bar_internal.dart
+++ b/lib/widgets/surfaces/shared/searchable_bottom_bar_internal.dart
@@ -849,7 +849,12 @@ class SearchPillState extends State<SearchPill> {
                     fontSize: 17,
                     fontWeight: FontWeight.w400,
                   ),
-              cursorColor: textColor,
+              // When null, Flutter's standard cursor-color resolution
+              // kicks in (textSelectionTheme → Cupertino primaryColor
+              // on iOS → colorScheme.primary). Callers wanting the
+              // pre-0.13.0 "cursor matches textColor" behaviour pass
+              // `cursorColor: textColor` explicitly via [config].
+              cursorColor: config.cursorColor,
               decoration: InputDecoration(
                 hintText: config.hintText,
                 hintStyle: (config.hintStyle ??

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: liquid_glass_widgets
 description: A Flutter UI kit implementing the iOS 26 Liquid Glass design language. Features shader-based glassmorphism, physics-driven jelly animations, and dynamic lighting.
-version: 0.12.8
+version: 0.13.0
 
 
 homepage: https://github.com/sdegenaar/liquid_glass_widgets


### PR DESCRIPTION
Adds a `cursorColor` field to `GlassSearchBarConfig` and decouples the expanded search field's cursor from its `textColor`. When `cursorColor` is `null` (the new default), the cursor follows Flutter's standard resolution chain — `textSelectionTheme.cursorColor` → `CupertinoTheme.primaryColor` on iOS → `colorScheme.primary` — matching how every other Material `TextField` cursor in a Flutter app resolves color.

## Why

Prior behaviour was `cursorColor: textColor` hard-coupled at construction time in `searchable_bottom_bar_internal.dart` (line 852 on `main` at the time of writing). That short-circuits Flutter's entire cursor-color resolution chain: setting \`Theme.of(context).textSelectionTheme.cursorColor\` has no effect because the underlying \`TextField\` sees a non-null \`cursorColor\` and uses it unconditionally.

This surfaced for me in an app with \`textColor: kLightText\` (near-white) on a glass surface — the cursor was invisible against the glass, and none of the standard Flutter theming levers (\`textSelectionTheme.cursorColor\`, \`cupertinoOverrideTheme.primaryColor\`, \`colorScheme.primary\`) could override it because the package was overriding upstream of all of them. Interestingly, \`selectionColor\` and \`selectionHandleColor\` on \`textSelectionTheme\` DID propagate — confirming the cursor specifically was the trapped property.

## ⚠️ Breaking change

Apps that set a \`textColor\` and relied on the cursor implicitly matching it will see their cursor flip to \`Theme.of(context).colorScheme.primary\` (Material blue if the theme is untouched). Two-line opt-back-in:

\`\`\`dart
GlassSearchBarConfig(
  textColor: Colors.white,
  cursorColor: Colors.white,  // ← previously implicit
  ...
)
\`\`\`

Migration documented in the CHANGELOG and the new field's doc comment. Bumped to **0.13.0** to signal the default behaviour change.

## Alternative considered

I considered a backward-compatible variant where \`cursorColor\` defaults to \`textColor\` if not specified — that would avoid any behaviour change. Decided against it because (a) the current behaviour blocks all theme-based mechanisms even when callers explicitly set them, which feels like a real bug rather than an opinionated default; and (b) the breaking change is a one-liner to fix and the migration is mechanical. Happy to switch to the backward-compatible variant if you'd prefer — let me know and I'll update the PR.

## Files changed

- \`lib/widgets/surfaces/shared/glass_search_bar_config.dart\` — new \`cursorColor\` field + doc comment with resolution-chain explanation + migration snippet
- \`lib/widgets/surfaces/shared/searchable_bottom_bar_internal.dart\` — \`cursorColor: textColor\` → \`cursorColor: config.cursorColor\`, with inline comment explaining the resolution chain
- \`CHANGELOG.md\` — 0.13.0 entry with breaking-change callout + migration
- \`pubspec.yaml\` — 0.12.8 → 0.13.0

## Test plan

- \`flutter analyze\` clean on the package
- Verified by setting \`textSelectionTheme.cursorColor: someColor\` in a consuming app's \`ThemeData\` — cursor now picks it up where it didn't before
- Backward compat path verified by explicitly passing \`cursorColor: yourTextColor\` — restores the old behaviour exactly

Thanks for considering!