### PR TITLE
fix(GlassMenu): clamp morph size to >= 0 during spring undershoot

### DIFF
--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -336,8 +336,15 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     );
 
     final targetHeight = widget.menuHeight ?? menuHeight;
-    final currentHeight = lerpDouble(th, targetHeight, state.sizeT)!;
-    final currentWidth = lerpDouble(tw, widget.menuWidth, state.sizeT)!;
+    // Clamp to >= 0: the rubber-band close drives sizeT slightly negative during
+    // the undershoot, which lerps the size below zero for a tiny trigger and
+    // trips a debug BoxConstraints assert. A size can't be negative; 0 (fully
+    // collapsed) is the correct floor and is visually identical to the intended
+    // shrink-to-nothing at the close tail.
+    final currentHeight =
+        lerpDouble(th, targetHeight, state.sizeT)!.clamp(0.0, double.infinity);
+    final currentWidth =
+        lerpDouble(tw, widget.menuWidth, state.sizeT)!.clamp(0.0, double.infinity);
 
     final inheritedSettings = InheritedLiquidGlass.of(context);
     final effectiveSettings = widget.settings ??


### PR DESCRIPTION
## Summary

The underdamped spring that drives the open/close morph can briefly drive `sizeT` below zero during the close undershoot. `lerpDouble(triggerHeight, menuHeight, negativeSizeT)` then produces a negative `currentWidth`/`currentHeight`, which trips a `BoxConstraints` debug assert (and on release builds, passes a negative size to the `GlassContainer`).

This is already acknowledged in-code — the radius path clamps `sizeT` with a comment noting the overshoot — but the size path was left unclamped.

## Fix

Clamp the `lerpDouble` result to `>= 0.0` for both width and height. A size of 0 (fully collapsed) is the correct physical floor and is visually identical to the intended shrink-to-nothing at the close tail.

## Reproduction

Trigger a GlassMenu close with a small trigger widget (e.g. 8×8 px icon). The spring's underdamped close overshoots past zero for ~1 frame, causing:
```
BoxConstraints has a negative minimum width/height.
```

## Risk

Zero — the clamp only affects the overshoot tail where the menu is already visually collapsed. No behavioral change for existing users.