### PR TITLE
feat(GlassMenu): GlassMenuController + showDismissBarrier

### DIFF
--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -198,6 +198,15 @@ class GlassMenu extends StatefulWidget {
   /// arena) decides when to show and dismiss the menu.
   final GlassMenuController? controller;
 
+  /// Whether to render the full-screen tap-to-dismiss barrier behind the open
+  /// menu. Defaults to `true` (modal: a tap outside the menu closes it).
+  ///
+  /// Set to `false` when an external gesture owner (e.g. a canvas gesture arena)
+  /// must keep receiving pointer events while the menu is open and will handle
+  /// dismissal itself — the barrier otherwise sits in the root overlay above
+  /// everything and swallows all input. Pairs with [controller]-driven open/close.
+  final bool showDismissBarrier;
+
   /// Creates a liquid glass menu.
   const GlassMenu({
     super.key,
@@ -229,6 +238,7 @@ class GlassMenu extends StatefulWidget {
     this.glowIntensity = 0.0,
     this.onClose,
     this.controller,
+    this.showDismissBarrier = true,
   }) : assert(trigger != null || triggerBuilder != null,
             'Either trigger or triggerBuilder must be provided');
 

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -186,6 +186,18 @@ class GlassMenu extends StatefulWidget {
   /// [GlassMorphController] status changes directly.
   final VoidCallback? onClose;
 
+  /// Optional controller to drive the menu imperatively
+  /// ([GlassMenuController.open] / [GlassMenuController.close]) instead of — or
+  /// in addition to — tapping the trigger.
+  ///
+  /// Tapping the trigger goes through [_GlassMenuState._toggleMenu], which is
+  /// gated on the morph progress (a close that lands while the menu is still
+  /// expanding is ignored). The controller commands [_GlassMenuState._openMenu]
+  /// / [_GlassMenuState._closeMenu] directly, so it is deterministic for any
+  /// timing — useful when an external gesture owner (e.g. a central gesture
+  /// arena) decides when to show and dismiss the menu.
+  final GlassMenuController? controller;
+
   /// Creates a liquid glass menu.
   const GlassMenu({
     super.key,
@@ -216,9 +228,40 @@ class GlassMenu extends StatefulWidget {
     this.glowRadius = 0.6,
     this.glowIntensity = 0.0,
     this.onClose,
+    this.controller,
   }) : assert(trigger != null || triggerBuilder != null,
             'Either trigger or triggerBuilder must be provided');
 
   @override
   State<GlassMenu> createState() => _GlassMenuState();
+}
+
+/// Drives a [GlassMenu] imperatively, bypassing the trigger tap.
+///
+/// Pass it to [GlassMenu.controller]. Unlike tapping the trigger (which toggles
+/// and is gated on the morph progress), [open] and [close] command the menu's
+/// morph directly, so a [close] that lands mid-open reliably dismisses the menu
+/// instead of re-opening it. Intended for cases where something other than the
+/// menu's own trigger decides when it appears — e.g. a central gesture arena.
+///
+/// One controller drives one mounted [GlassMenu] at a time.
+class GlassMenuController {
+  _GlassMenuState? _state;
+
+  void _attach(_GlassMenuState state) => _state = state;
+
+  void _detach(_GlassMenuState state) {
+    if (identical(_state, state)) _state = null;
+  }
+
+  /// Whether the menu's overlay is currently shown (open, or animating closed).
+  bool get isOpen => _state?._overlayController.isShowing ?? false;
+
+  /// Opens the menu, morphing from the trigger's current position. Safe to call
+  /// while a close is still animating — the spring reverses toward open.
+  void open() => _state?._openMenu();
+
+  /// Closes the menu with the rubber-band morph. Deterministic for any timing:
+  /// unlike a trigger tap, it never re-opens a still-expanding menu.
+  void close() => _state?._closeMenu();
 }

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -368,7 +368,7 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     return Stack(
       children: [
         // Invisible full-screen tap-to-close barrier
-        if (clampedValue > 0.3)
+        if (clampedValue > 0.3 && widget.showDismissBarrier)
           Positioned.fill(
             child: GestureDetector(
               behavior: HitTestBehavior.translucent,

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -28,6 +28,10 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
   @override
   void didUpdateWidget(GlassMenu oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(widget.controller, oldWidget.controller)) {
+      oldWidget.controller?._detach(this);
+      widget.controller?._attach(this);
+    }
     if (!identical(widget.items, oldWidget.items)) {
       _cachedWrappedItems = null;
       // BUG 12 FIX: Clear hover state if items shrink while menu is open
@@ -92,10 +96,12 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     _scrollController = ScrollController();
     _hoveredIndexNotifier = ValueNotifier(null);
     _isDraggingNotifier = ValueNotifier(false);
+    widget.controller?._attach(this);
   }
 
   @override
   void dispose() {
+    widget.controller?._detach(this);
     _morphController.dispose();
     _scrollController.dispose();
     _hoveredIndexNotifier.dispose();


### PR DESCRIPTION
## Summary

Adds imperative control over `GlassMenu` for cases where something other than the menu's own trigger decides when it appears — e.g. a central gesture arena, a canvas long-press, or a programmatic popover.

### GlassMenuController

New controller class with `open()`, `close()`, and `isOpen`. Pass it to `GlassMenu(controller: ...)`.

Unlike tapping the trigger (which toggles and is gated on morph progress), the controller commands `_openMenu` / `_closeMenu` directly, so a `close()` that lands mid-open reliably dismisses the menu instead of re-opening it.

Lifecycle:
- Attaches in `initState`, detaches in `dispose`
- Hot-swaps correctly in `didUpdateWidget`

### showDismissBarrier

New `bool showDismissBarrier` parameter (default `true`, no breaking change).

Set to `false` when an external gesture owner must keep receiving pointer events while the menu is open and will handle dismissal itself. The default full-screen barrier sits in the root overlay and swallows all input — `showDismissBarrier: false` removes it so the gesture owner stays in control.

Pairs naturally with controller-driven open/close.

## Risk

Both additions are opt-in with defaults that preserve existing behavior. No changes to the trigger-tap path.