### PR TITLE
feat(GlassMenu): setFollowOffset + morphFromZero for gesture-driven menus

### DIFF
--- a/lib/widgets/interactive/glass_icon_button.dart
+++ b/lib/widgets/interactive/glass_icon_button.dart
@@ -195,8 +195,9 @@ class GlassIconButton extends StatelessWidget {
 
   /// Rendering quality for the glass effect.
   ///
-  /// If null, inherits from parent [InheritedLiquidGlass] or defaults to
-  /// [GlassQuality.standard] (backdrop filter).
+  /// If null, resolved via [GlassThemeHelpers.resolveQuality] — inherits from
+  /// the nearest ancestor layer, then the theme, then the [GlassButton]
+  /// widget-class default ([GlassQuality.standard]).
   final GlassQuality? quality;
 
   /// Whether the pressed glass distortion persists while the finger is held
@@ -245,7 +246,7 @@ class GlassIconButton extends StatelessWidget {
       shape: glassShape,
       settings: settings,
       useOwnLayer: useOwnLayer,
-      quality: quality ?? GlassQuality.standard,
+      quality: quality,
       interactionScale: interactionScale,
       glowColor: glowColor, // Let GlassButton use theme if null
       glowRadius: glowRadius,

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -198,6 +198,15 @@ class GlassMenu extends StatefulWidget {
   /// arena) decides when to show and dismiss the menu.
   final GlassMenuController? controller;
 
+  /// Whether to render the full-screen tap-to-dismiss barrier behind the open
+  /// menu. Defaults to `true` (modal: a tap outside the menu closes it).
+  ///
+  /// Set to `false` when an external gesture owner (e.g. a canvas gesture arena)
+  /// must keep receiving pointer events while the menu is open and will handle
+  /// dismissal itself — the barrier otherwise sits in the root overlay above
+  /// everything and swallows all input. Pairs with [controller]-driven open/close.
+  final bool showDismissBarrier;
+
   /// Creates a liquid glass menu.
   const GlassMenu({
     super.key,
@@ -229,6 +238,7 @@ class GlassMenu extends StatefulWidget {
     this.glowIntensity = 0.0,
     this.onClose,
     this.controller,
+    this.showDismissBarrier = true,
   }) : assert(trigger != null || triggerBuilder != null,
             'Either trigger or triggerBuilder must be provided');
 

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -186,6 +186,18 @@ class GlassMenu extends StatefulWidget {
   /// [GlassMorphController] status changes directly.
   final VoidCallback? onClose;
 
+  /// Optional controller to drive the menu imperatively
+  /// ([GlassMenuController.open] / [GlassMenuController.close]) instead of — or
+  /// in addition to — tapping the trigger.
+  ///
+  /// Tapping the trigger goes through [_GlassMenuState._toggleMenu], which is
+  /// gated on the morph progress (a close that lands while the menu is still
+  /// expanding is ignored). The controller commands [_GlassMenuState._openMenu]
+  /// / [_GlassMenuState._closeMenu] directly, so it is deterministic for any
+  /// timing — useful when an external gesture owner (e.g. a central gesture
+  /// arena) decides when to show and dismiss the menu.
+  final GlassMenuController? controller;
+
   /// Creates a liquid glass menu.
   const GlassMenu({
     super.key,
@@ -216,9 +228,40 @@ class GlassMenu extends StatefulWidget {
     this.glowRadius = 0.6,
     this.glowIntensity = 0.0,
     this.onClose,
+    this.controller,
   }) : assert(trigger != null || triggerBuilder != null,
             'Either trigger or triggerBuilder must be provided');
 
   @override
   State<GlassMenu> createState() => _GlassMenuState();
+}
+
+/// Drives a [GlassMenu] imperatively, bypassing the trigger tap.
+///
+/// Pass it to [GlassMenu.controller]. Unlike tapping the trigger (which toggles
+/// and is gated on the morph progress), [open] and [close] command the menu's
+/// morph directly, so a [close] that lands mid-open reliably dismisses the menu
+/// instead of re-opening it. Intended for cases where something other than the
+/// menu's own trigger decides when it appears — e.g. a central gesture arena.
+///
+/// One controller drives one mounted [GlassMenu] at a time.
+class GlassMenuController {
+  _GlassMenuState? _state;
+
+  void _attach(_GlassMenuState state) => _state = state;
+
+  void _detach(_GlassMenuState state) {
+    if (identical(_state, state)) _state = null;
+  }
+
+  /// Whether the menu's overlay is currently shown (open, or animating closed).
+  bool get isOpen => _state?._overlayController.isShowing ?? false;
+
+  /// Opens the menu, morphing from the trigger's current position. Safe to call
+  /// while a close is still animating — the spring reverses toward open.
+  void open() => _state?._openMenu();
+
+  /// Closes the menu with the rubber-band morph. Deterministic for any timing:
+  /// unlike a trigger tap, it never re-opens a still-expanding menu.
+  void close() => _state?._closeMenu();
 }

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -274,4 +274,11 @@ class GlassMenuController {
   /// Closes the menu with the rubber-band morph. Deterministic for any timing:
   /// unlike a trigger tap, it never re-opens a still-expanding menu.
   void close() => _state?._closeMenu();
+
+  /// Nudges the open menu to track a moving anchor: [offset] (screen px) is added
+  /// to the menu's captured trigger position every frame until reset. A no-op
+  /// while closed; cleared on the next [open]. Used by external gesture owners
+  /// that move the anchor AFTER opening — e.g. a canvas tile trailing under a
+  /// rubberband, where the menu should stay glued to the tile.
+  void setFollowOffset(Offset offset) => _state?.setFollowOffset(offset);
 }

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -207,6 +207,21 @@ class GlassMenu extends StatefulWidget {
   /// everything and swallows all input. Pairs with [controller]-driven open/close.
   final bool showDismissBarrier;
 
+  /// Whether the open/close morph blooms from a zero-size point at the trigger
+  /// center instead of from a glass blob the size of the trigger. Defaults to
+  /// `false` (the menu spawns as a small rounded "metaball" matching the trigger
+  /// and morphs outward — the standard iOS-26 liquid-glass behavior).
+  ///
+  /// Set to `true` when the trigger is invisible or zero-sized (e.g. an
+  /// imperatively-driven menu positioned by an external gesture owner via
+  /// [controller]), so there is no button for the spawn blob to grow from. In
+  /// that case the trigger ghost (Blob A) is suppressed entirely and the menu
+  /// body lerps its size from 0 → full while keeping the identical teardrop
+  /// shape morph (radius circle→rounded-rect, J-curve travel, and spring). The
+  /// shape still spawns at — and collapses back to — the trigger center, so a
+  /// zero-sized trigger reads as a point bloom rather than an 8px glass dot.
+  final bool morphFromZero;
+
   /// Creates a liquid glass menu.
   const GlassMenu({
     super.key,
@@ -239,6 +254,7 @@ class GlassMenu extends StatefulWidget {
     this.onClose,
     this.controller,
     this.showDismissBarrier = true,
+    this.morphFromZero = false,
   }) : assert(trigger != null || triggerBuilder != null,
             'Either trigger or triggerBuilder must be provided');
 

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -28,6 +28,10 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
   @override
   void didUpdateWidget(GlassMenu oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(widget.controller, oldWidget.controller)) {
+      oldWidget.controller?._detach(this);
+      widget.controller?._attach(this);
+    }
     if (!identical(widget.items, oldWidget.items)) {
       _cachedWrappedItems = null;
       // BUG 12 FIX: Clear hover state if items shrink while menu is open
@@ -92,10 +96,12 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     _scrollController = ScrollController();
     _hoveredIndexNotifier = ValueNotifier(null);
     _isDraggingNotifier = ValueNotifier(false);
+    widget.controller?._attach(this);
   }
 
   @override
   void dispose() {
+    widget.controller?._detach(this);
     _morphController.dispose();
     _scrollController.dispose();
     _hoveredIndexNotifier.dispose();

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -375,7 +375,7 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     return Stack(
       children: [
         // Invisible full-screen tap-to-close barrier
-        if (clampedValue > 0.3)
+        if (clampedValue > 0.3 && widget.showDismissBarrier)
           Positioned.fill(
             child: GestureDetector(
               behavior: HitTestBehavior.translucent,

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -342,8 +342,15 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     );
 
     final targetHeight = widget.menuHeight ?? menuHeight;
-    final currentHeight = lerpDouble(th, targetHeight, state.sizeT)!;
-    final currentWidth = lerpDouble(tw, widget.menuWidth, state.sizeT)!;
+    // Clamp to >= 0: the rubber-band close drives sizeT slightly negative during
+    // the undershoot, which lerps the size below zero for a tiny trigger and
+    // trips a debug BoxConstraints assert. A size can't be negative; 0 (fully
+    // collapsed) is the correct floor and is visually identical to the intended
+    // shrink-to-nothing at the close tail.
+    final currentHeight =
+        lerpDouble(th, targetHeight, state.sizeT)!.clamp(0.0, double.infinity);
+    final currentWidth =
+        lerpDouble(tw, widget.menuWidth, state.sizeT)!.clamp(0.0, double.infinity);
 
     final inheritedSettings = InheritedLiquidGlass.of(context);
     final effectiveSettings = widget.settings ??

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -363,15 +363,21 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     );
 
     final targetHeight = widget.menuHeight ?? menuHeight;
+    // Under morphFromZero the body lerps from a zero-size point at the trigger
+    // center (collapse-to-point) rather than from the trigger's own size; the
+    // false path keeps tw/th so the spawn-blob behavior is byte-identical.
+    final double sizeStartW = widget.morphFromZero ? 0.0 : tw;
+    final double sizeStartH = widget.morphFromZero ? 0.0 : th;
     // Clamp to >= 0: the rubber-band close drives sizeT slightly negative during
     // the undershoot, which lerps the size below zero for a tiny trigger and
     // trips a debug BoxConstraints assert. A size can't be negative; 0 (fully
     // collapsed) is the correct floor and is visually identical to the intended
-    // shrink-to-nothing at the close tail.
-    final currentHeight =
-        lerpDouble(th, targetHeight, state.sizeT)!.clamp(0.0, double.infinity);
-    final currentWidth =
-        lerpDouble(tw, widget.menuWidth, state.sizeT)!.clamp(0.0, double.infinity);
+    // shrink-to-nothing at the close tail. Under morphFromZero the lerp already
+    // starts at 0, so this same clamp still floors the close undershoot.
+    final currentHeight = lerpDouble(sizeStartH, targetHeight, state.sizeT)!
+        .clamp(0.0, double.infinity);
+    final currentWidth = lerpDouble(sizeStartW, widget.menuWidth, state.sizeT)!
+        .clamp(0.0, double.infinity);
 
     final inheritedSettings = InheritedLiquidGlass.of(context);
     final effectiveSettings = widget.settings ??
@@ -432,28 +438,30 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
                       // closing momentum (pushDx/pushDy) to bounce when slammed.
                       // Shrinks to 0 scale over the first 40% of the animation to
                       // smoothly break the liquid bridge.
-                      Positioned(
-                        left: _triggerGlobalPosition.dx +
-                            _followOffset.dx +
-                            state.pushDx,
-                        top: _triggerGlobalPosition.dy +
-                            _followOffset.dy +
-                            state.pushDy,
-                        child: Transform.scale(
-                          scale: state.anchorScale,
-                          child: GlassContainer(
-                            useOwnLayer: false,
-                            settings: effectiveSettings,
-                            quality: effectiveQuality,
-                            width: tw,
-                            height: th,
-                            shape: LiquidRoundedSuperellipse(
-                              borderRadius: _triggerBorderRadius ??
-                                  _triggerSize!.shortestSide / 2.0,
+                      // Blob A is the spawn blob; under morphFromZero there is no trigger to ghost.
+                      if (!widget.morphFromZero)
+                        Positioned(
+                          left: _triggerGlobalPosition.dx +
+                              _followOffset.dx +
+                              state.pushDx,
+                          top: _triggerGlobalPosition.dy +
+                              _followOffset.dy +
+                              state.pushDy,
+                          child: Transform.scale(
+                            scale: state.anchorScale,
+                            child: GlassContainer(
+                              useOwnLayer: false,
+                              settings: effectiveSettings,
+                              quality: effectiveQuality,
+                              width: tw,
+                              height: th,
+                              shape: LiquidRoundedSuperellipse(
+                                borderRadius: _triggerBorderRadius ??
+                                    _triggerSize!.shortestSide / 2.0,
+                              ),
                             ),
                           ),
                         ),
-                      ),
 
                       // ── Blob B: Menu Body ───────────────────────────────────
                       // Its center travels diagonally relative to the trigger.
@@ -530,6 +538,17 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
 
   Widget _buildMorphingContainer(LiquidMorphState state, double clampedValue,
       double currentWidth, double currentHeight) {
+    // Sub-pixel blob registers no blend-group shape: skip it so the premium
+    // Impeller geometry never rasterizes a 0-area matte (Invalid image dimensions).
+    // The 1.0 logical-px floor is provably safe at every devicePixelRatio: a
+    // logical size in [0.5, 1.0) can still snap to a 0-area matte at dpr=1.0
+    // (matteBounds = (bounds * dpr).snapToPixels(1); ceil() == 0), which would
+    // reach the unclamped toImageSync in the geometry raster. Below 1.0 px is
+    // invisible on any display, so flooring here costs nothing visually.
+    if (currentWidth < 1.0 || currentHeight < 1.0) {
+      return const SizedBox.shrink();
+    }
+
     // Inherit quality from parent layer if not explicitly set
     final effectiveQuality = GlassThemeHelpers.resolveQuality(
       context,

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -18,6 +18,16 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
   double _horizontalOffset = 0.0;
   double _verticalOffset = 0.0;
 
+  /// Live screen-space nudge added to the captured trigger position while the
+  /// menu is OPEN, so an external owner can keep the floating menu glued to a
+  /// moving anchor (e.g. a canvas tile trailing under a rubberband) WITHOUT
+  /// re-opening. Reset to zero on each [_openMenu]. Applied to both morph blobs
+  /// in [_buildMorphingOverlay]. It deliberately does NOT recompute the
+  /// screen-edge clamping ([_horizontalOffset]/[_verticalOffset]) — trails are
+  /// small and bounded, and recomputing per-frame is not worth the cost. Driven
+  /// via [GlassMenuController.setFollowOffset] / [setFollowOffset].
+  Offset _followOffset = Offset.zero;
+
   // --- Granular Update System (Performance + No flicker) ---
   // We cache the outer list but use notifiers to update selection state
   // without rebuilding the entire menu tree.
@@ -197,6 +207,15 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     }
   }
 
+  /// Nudges the OPEN menu by [offset] (screen px) on top of its captured trigger
+  /// position, so an external owner can track a moving anchor live. A no-op
+  /// delta is skipped to avoid needless rebuilds. Has no visible effect while
+  /// closed; the next [_openMenu] resets it to zero.
+  void setFollowOffset(Offset offset) {
+    if (_followOffset == offset) return;
+    setState(() => _followOffset = offset);
+  }
+
   void _openMenu() {
     // Capture geometry and screen position for morphing
     final renderBox = context.findRenderObject() as RenderBox?;
@@ -209,6 +228,8 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     _triggerBorderRadius = _triggerSize!.height / 2;
     _triggerGlobalPosition =
         renderBox.localToGlobal(Offset.zero); // store for overlay
+    // A fresh open must never inherit a previous open's live anchor nudge.
+    _followOffset = Offset.zero;
     final position = _triggerGlobalPosition;
     final mediaQuery = MediaQuery.maybeOf(context);
     final screenWidth = mediaQuery?.size.width ?? double.infinity;
@@ -412,8 +433,12 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
                       // Shrinks to 0 scale over the first 40% of the animation to
                       // smoothly break the liquid bridge.
                       Positioned(
-                        left: _triggerGlobalPosition.dx + state.pushDx,
-                        top: _triggerGlobalPosition.dy + state.pushDy,
+                        left: _triggerGlobalPosition.dx +
+                            _followOffset.dx +
+                            state.pushDx,
+                        top: _triggerGlobalPosition.dy +
+                            _followOffset.dy +
+                            state.pushDy,
                         child: Transform.scale(
                           scale: state.anchorScale,
                           child: GlassContainer(
@@ -436,11 +461,13 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
                       // its edges stay perfectly pinned while it grows!
                       Positioned(
                         left: _triggerGlobalPosition.dx +
+                            _followOffset.dx +
                             tw / 2.0 +
                             state.currentDx -
                             currentWidth / 2.0 +
                             (_horizontalOffset * clampedValue),
                         top: _triggerGlobalPosition.dy +
+                            _followOffset.dy +
                             th / 2.0 +
                             state.currentDy -
                             currentHeight / 2.0 +

--- a/test/widgets/overlays/glass_menu_test.dart
+++ b/test/widgets/overlays/glass_menu_test.dart
@@ -457,4 +457,48 @@ void main() {
 
     expect(tester.takeException(), isNull);
   });
+
+  // ── morphFromZero (point bloom) ───────────────────────────────────────────
+  test('GlassMenu.morphFromZero defaults to false', () {
+    final menu = GlassMenu(
+      trigger: const SizedBox(width: 8, height: 8),
+      items: [GlassMenuItem(title: 'Item', onTap: () {})],
+    );
+    expect(menu.morphFromZero, isFalse);
+  });
+
+  testWidgets('GlassMenu morphFromZero opens and closes without crashing',
+      (tester) async {
+    // morphFromZero lerps Blob B's size from 0 → full and suppresses Blob A,
+    // exercising the radius-0 / 0-area degenerate path the default-false tests
+    // never hit. The zero-size render guard must keep this from throwing.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: GlassMenu(
+              morphFromZero: true,
+              trigger: const SizedBox(width: 8, height: 8, child: Text('Zero')),
+              items: [
+                GlassMenuItem(title: 'ZeroItem', onTap: () {}),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Zero'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+    expect(find.text('ZeroItem'), findsOneWidget);
+
+    // Close via outside tap — the collapse-to-point tail must not throw.
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('ZeroItem'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
 }


### PR DESCRIPTION
## Summary

Two additions for menus driven by an external gesture owner (builds on the `GlassMenuController` from #88 and the clamp fix from #87).

### GlassMenuController.setFollowOffset(Offset)

Nudges the open menu by a screen-space offset on top of its captured trigger position, so the menu tracks a moving anchor live (e.g. a dragged element trailing under a rubberband gesture). Resets to zero on each `open()`. No-op while closed. Skips `setState` when the offset hasn't changed.

### morphFromZero

New `bool morphFromZero` parameter (default `false`, no breaking change).

When `true`:
- **Blob A (trigger ghost) is suppressed** — there is no visible trigger to morph from, so the spawn blob is unwanted visual noise
- **Blob B (menu body) lerps from 0 → full size** instead of from the trigger's size, creating a point-bloom effect
- **Sub-pixel render guard** — returns `SizedBox.shrink()` when either dimension is < 1.0 logical px, preventing a 0-area shape from reaching the Impeller geometry raster (`toImageSync` with invalid image dimensions)

The morph shape (radius circle → rounded-rect, J-curve travel, spring physics) is identical to the default path. `morphFromZero` only changes the size start-point and suppresses Blob A.

### Tests

- `morphFromZero defaults to false` — asserts the opt-in contract
- `morphFromZero opens and closes without crashing` — exercises the 0-size / radius-0 path that previously had no coverage

## Dependencies

- #87 — clamp fix (the 0-start lerp needs the >= 0 floor during close undershoot)
- #88 — GlassMenuController + showDismissBarrier (setFollowOffset is a method on the controller)

## Risk

Both additions are opt-in. Default behavior is byte-identical to current main.