### PR TITLE
fix(GlassIconButton): let null quality resolve through the theme chain

### DIFF
--- a/lib/widgets/interactive/glass_icon_button.dart
+++ b/lib/widgets/interactive/glass_icon_button.dart
@@ -195,8 +195,9 @@ class GlassIconButton extends StatelessWidget {
 
   /// Rendering quality for the glass effect.
   ///
-  /// If null, inherits from parent [InheritedLiquidGlass] or defaults to
-  /// [GlassQuality.standard] (backdrop filter).
+  /// If null, resolved via [GlassThemeHelpers.resolveQuality] — inherits from
+  /// the nearest ancestor layer, then the theme, then the [GlassButton]
+  /// widget-class default ([GlassQuality.standard]).
   final GlassQuality? quality;
 
   /// Whether the pressed glass distortion persists while the finger is held
@@ -245,7 +246,7 @@ class GlassIconButton extends StatelessWidget {
       shape: glassShape,
       settings: settings,
       useOwnLayer: useOwnLayer,
-      quality: quality ?? GlassQuality.standard,
+      quality: quality,
       interactionScale: interactionScale,
       glowColor: glowColor, // Let GlassButton use theme if null
       glowRadius: glowRadius,


### PR DESCRIPTION
## Summary

`GlassIconButton.build()` coerces `quality ?? GlassQuality.standard` before passing it to `GlassButton.custom()`. This turns an unset quality into an explicit **Level 1** widget override in `GlassThemeHelpers.resolveQuality()`, making the `GlassThemeData` quality (Level 4) unreachable for icon buttons.

Apps that set a theme-wide quality (e.g. `GlassQuality.minimal` via `GlassThemeData`) see every glass surface honour it **except** `GlassIconButton`, which silently renders at `standard` — visibly glossier than its siblings.

## Fix

Pass `quality` through as-is (nullable). When null, `resolveQuality()` now falls through to the inherited ancestor (Level 2) → theme (Level 4) → `GlassButton` widget-class default of `standard` (Level 5) — matching the documented priority chain in `GlassThemeHelpers`.

## Before / After

| | Before | After |
|---|---|---|
| `GlassIconButton()` (no explicit quality) | Always `standard` (Level 1 override) | Resolved via theme chain — `minimal` if theme says `minimal` |
| `GlassIconButton(quality: GlassQuality.premium)` | `premium` | `premium` (unchanged) |
| `GlassIconButton(quality: GlassQuality.minimal)` | `minimal` | `minimal` (unchanged) |

Only the null (unset) case changes — explicit quality params are unaffected.

## Test plan

- [x] All existing `GlassIconButton` tests pass (9/9)
- [x] `dart analyze` clean