### PR TITLE
fix(glass-scroll-edge): avoid crash when capturing background before paint

### DIFF
--- a/lib/widgets/shared/glass_scroll_edge_effect.dart
+++ b/lib/widgets/shared/glass_scroll_edge_effect.dart
@@ -210,16 +210,20 @@ class _GlassScrollEdgeEffectState extends State<GlassScrollEdgeEffect> {
 
     if (_capturePending) return; // Already in-flight — don't stack captures.
     _capturePending = true;
-    boundary.toImage(pixelRatio: 1.0).then((image) {
+    try {
+      boundary.toImage(pixelRatio: 1.0).then((image) {
+        _capturePending = false;
+        if (!mounted) {
+          image.dispose();
+          return;
+        }
+        _backgroundImage?.dispose();
+        _backgroundImage = image;
+        setState(() {});
+      }).catchError((_) => _capturePending = false);
+    } on Object {
       _capturePending = false;
-      if (!mounted) {
-        image.dispose();
-        return;
-      }
-      _backgroundImage?.dispose();
-      _backgroundImage = image;
-      setState(() {});
-    });
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary

Wraps `RenderRepaintBoundary.toImage()` in `try/catch` (plus `.catchError` on
the returned `Future`) in `GlassScrollEdgeEffect._captureBackground`.

If `layer` is still `null`, `toImage()` throws synchronously on `layer!` before
returning a `Future`. The widget then resets `_capturePending` and falls back
to the solid-color edge fade instead of crashing.

## Context

Found while reviewing Sentry logs from a consumer app using `GlassScaffold`
(iOS, Flutter 3.41.9, release build).

**User-visible symptom:** gray screen on cold start / navigation — only in
**release mode**. Debug builds did not reproduce the crash reliably.

**Sentry:** `TypeError: Null check operator used on a null value` in
`_GlassScrollEdgeEffectState._captureBackground` → `RenderRepaintBoundary.toImage`.

## Root cause (suspected)

`toImage()` requires a composited `OffsetLayer` on the repaint boundary. On
first mount, `_captureBackground()` can run from `didChangeDependencies` while
the boundary already has a size but `layer` is not assigned yet (paint phase
has not completed).

Existing guards (`hasSize`, `debugNeedsPaint`) do not cover this in release:
`debugNeedsPaint` is only checked inside `assert`.

## Fix

Minimal change: only error handling around `toImage()` — no lifecycle / defer
changes in this PR.

```dart
try {
  boundary.toImage(pixelRatio: 1.0).then(...).catchError(...);
} on Object {
  _capturePending = false;
}
```

## Caveats

This likely **treats the symptom, not the root cause**. A more complete fix
may be to defer the first capture to the next frame (same as the
`_backgroundImage != null` path) so `toImage()` is not called before paint.

With this patch alone, texture-based edge fade may not appear on the first
attempt if capture fails; the color gradient fallback is used instead.