### PR TITLE
feat: platformViewBackdrop — premium glass over iOS PlatformViews

### DIFF
--- a/lib/widgets/shared/adaptive_glass.dart
+++ b/lib/widgets/shared/adaptive_glass.dart
@@ -199,11 +199,12 @@ class AdaptiveGlass extends StatelessWidget {
 
     // platformViewBackdrop forces the live BackdropFilter path even at premium:
     // the premium shader's toImageSync backdrop can't capture a PlatformView, so
-    // over one it must use BackdropFilter (live) instead.
+    // over one it must use BackdropFilter (live) instead. The local/cheap checks
+    // are evaluated before the platform shader-support query (_canUseImpeller).
     final bool canUsePremiumShader = !kIsWeb &&
-        _canUseImpeller &&
+        !platformViewBackdrop &&
         quality == GlassQuality.premium &&
-        !platformViewBackdrop;
+        _canUseImpeller;
 
     if (!canUsePremiumShader) {
       // 1. Detect Grouped Elevation

--- a/lib/widgets/shared/adaptive_glass.dart
+++ b/lib/widgets/shared/adaptive_glass.dart
@@ -44,6 +44,7 @@ class AdaptiveGlass extends StatelessWidget {
     this.allowElevation = true,
     this.glowIntensity = 0.0,
     this.isInteractive = false,
+    this.platformViewBackdrop = false,
     super.key,
   });
 
@@ -91,6 +92,15 @@ class AdaptiveGlass extends StatelessWidget {
   /// Defaults to 0.0 (no glow).
   final double glowIntensity;
 
+  /// When true, this glass renders via the live `BackdropFilter` path (the
+  /// lightweight render) EVEN at [GlassQuality.premium] — because the premium
+  /// shader samples a `toImageSync` texture, which cannot capture an iOS
+  /// PlatformView (map, video). Set this on glass directly over a PlatformView
+  /// so the live view shows through instead of a solid slab. Refraction is lost
+  /// (no texture), but rim/lighting and the live blur remain. Premium children
+  /// that refract Flutter content (e.g. the indicator) should NOT set this.
+  final bool platformViewBackdrop;
+
   /// Detects if Impeller rendering engine is active.
   ///
   /// Returns true when shader filters are supported (Impeller),
@@ -108,6 +118,7 @@ class AdaptiveGlass extends StatelessWidget {
     Clip clipBehavior = Clip.antiAlias,
     double glowIntensity = 0.0,
     bool isInteractive = false,
+    bool platformViewBackdrop = false,
   }) {
     return AdaptiveGlass(
       shape: shape,
@@ -117,6 +128,7 @@ class AdaptiveGlass extends StatelessWidget {
       clipBehavior: clipBehavior,
       glowIntensity: glowIntensity,
       isInteractive: isInteractive,
+      platformViewBackdrop: platformViewBackdrop,
       child: child,
     );
   }
@@ -185,8 +197,13 @@ class AdaptiveGlass extends StatelessWidget {
     // because those will fall back to FakeGlass (solid color) inside the renderer.
     // We MUST use our LightweightLiquidGlass to get actual glass effects.
 
-    final bool canUsePremiumShader =
-        !kIsWeb && _canUseImpeller && quality == GlassQuality.premium;
+    // platformViewBackdrop forces the live BackdropFilter path even at premium:
+    // the premium shader's toImageSync backdrop can't capture a PlatformView, so
+    // over one it must use BackdropFilter (live) instead.
+    final bool canUsePremiumShader = !kIsWeb &&
+        _canUseImpeller &&
+        quality == GlassQuality.premium &&
+        !platformViewBackdrop;
 
     if (!canUsePremiumShader) {
       // 1. Detect Grouped Elevation

--- a/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
+++ b/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
@@ -87,6 +87,7 @@ class GlassSearchableBottomBar extends StatefulWidget {
     this.quality,
     this.magnification = 1.0,
     this.innerBlur = 0.0,
+    this.platformViewBackdrop = false,
     this.maskingQuality = MaskingQuality.high,
     this.backgroundKey,
     this.springDescription,
@@ -308,6 +309,21 @@ class GlassSearchableBottomBar extends StatefulWidget {
 
   /// Blur amount inside the selected indicator. Defaults to 0.0.
   final double innerBlur;
+
+  /// Set true when the bar sits over an iOS PlatformView (e.g. a map). The bar
+  /// background renders via live `BackdropFilter` (the premium shader can't
+  /// capture a PlatformView), while the premium indicator refracts the bar's
+  /// own icons — so premium animations survive over the PlatformView with no
+  /// quality swap. Defaults to false.
+  ///
+  /// Known limitation: the premium indicator refracts the icon layer via
+  /// `toImageSync`, which asserts the captured boundary is clean. While the
+  /// indicator animates, that layer repaints every frame, so a mid-animation
+  /// capture can fail and the indicator briefly flashes dark. Negligible at
+  /// [magnification] ~1.0 (the default) but grows with magnification. Keep
+  /// magnification near 1.0 over a PlatformView. (The PlatformView itself
+  /// can't be captured, so it can't be refracted directly.)
+  final bool platformViewBackdrop;
 
   /// Rendering quality for the liquid masking effect. Defaults to [MaskingQuality.high].
   final MaskingQuality maskingQuality;
@@ -727,6 +743,7 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
                           isActive: searching,
                           barBorderRadius: widget.barBorderRadius,
                           quality: effectiveQuality,
+                          platformViewBackdrop: widget.platformViewBackdrop,
                           enableBackgroundAnimation:
                               widget.interactionBehavior.hasScale,
                           backgroundPressScale: widget.pressScale,
@@ -828,6 +845,7 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
                           indicatorExpansion: widget.indicatorExpansion,
                           indicatorSettings: widget.indicatorSettings,
                           backgroundKey: widget.backgroundKey,
+                          platformViewBackdrop: widget.platformViewBackdrop,
                           isSearchActive: searching,
                           interactionGlowColor:
                               widget.interactionBehavior.hasGlow

--- a/lib/widgets/surfaces/shared/searchable_bottom_bar_internal.dart
+++ b/lib/widgets/surfaces/shared/searchable_bottom_bar_internal.dart
@@ -127,6 +127,7 @@ class SearchableTabIndicator extends StatefulWidget {
     this.interactionGlowOpacity = 1,
     required this.enableBackgroundAnimation,
     required this.backgroundPressScale,
+    this.platformViewBackdrop = false,
     super.key,
   });
 
@@ -165,6 +166,11 @@ class SearchableTabIndicator extends StatefulWidget {
   final bool enableBackgroundAnimation;
   final double backgroundPressScale;
 
+  /// When true (bar over an iOS PlatformView): the bar background renders via
+  /// live BackdropFilter, and the premium indicator refracts the bar's own icon
+  /// layer (capturable) instead of the PlatformView backdrop.
+  final bool platformViewBackdrop;
+
   @override
   State<SearchableTabIndicator> createState() => SearchableTabIndicatorState();
 }
@@ -180,6 +186,10 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
   void notifyTabChanged(int index) => widget.onTabChanged(index);
 
   static const _fallbackIndicatorColor = Color(0x1AFFFFFF);
+
+  /// RepaintBoundary key for the merged icon layer, so the premium indicator can
+  /// refract the icons (capturable) over a PlatformView.
+  final GlobalKey _iconLayerKey = GlobalKey();
 
   // Cached shape to avoid recreation on every animation frame
   late LiquidRoundedSuperellipse _barShape =
@@ -303,6 +313,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                         decoration: ShapeDecoration(shape: _barShape),
                         child: AdaptiveGlass.grouped(
                           quality: widget.quality,
+                          platformViewBackdrop: widget.platformViewBackdrop,
                           shape: _barShape,
                           child: Container(
                             padding: widget.tabPadding,
@@ -423,6 +434,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                   child: RepaintBoundary(
                     child: AdaptiveGlass.grouped(
                       quality: widget.quality,
+                      platformViewBackdrop: widget.platformViewBackdrop,
                       shape: _barShape,
                       child: const SizedBox.expand(),
                     ),
@@ -499,6 +511,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                   child: RepaintBoundary(
                     child: AdaptiveGlass.grouped(
                       quality: widget.quality,
+                      platformViewBackdrop: widget.platformViewBackdrop,
                       shape: _barShape,
                       child: const SizedBox.expand(),
                     ),
@@ -526,6 +539,9 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                 // 2. Icon Content Layer (Unselected + Selected combined for refraction)
                 Positioned.fill(
                   child: RepaintBoundary(
+                    // Keyed so the premium indicator can refract this icon layer
+                    // (capturable) over a PlatformView.
+                    key: _iconLayerKey,
                     child: Stack(
                       children: [
                         ClipPath(
@@ -581,7 +597,13 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                   padding: const EdgeInsets.all(4),
                   expansion: widget.indicatorExpansion,
                   settings: widget.indicatorSettings,
-                  backgroundKey: widget.backgroundKey,
+                  // Over a PlatformView the normal backdrop (map region) can't be
+                  // captured by toImageSync, so the premium indicator refracts the
+                  // bar's own icon layer instead (capturable) — keeping the
+                  // premium magic-lens over the PlatformView.
+                  backgroundKey: widget.platformViewBackdrop
+                      ? _iconLayerKey
+                      : widget.backgroundKey,
                 ),
               ],
             ),
@@ -611,6 +633,7 @@ class SearchPill extends StatefulWidget {
     this.interactionGlowBlurRadius = 0,
     this.interactionGlowSpreadRadius = 0,
     this.interactionGlowOpacity = 1,
+    this.platformViewBackdrop = false,
     super.key,
   });
 
@@ -620,6 +643,10 @@ class SearchPill extends StatefulWidget {
   final GlassQuality quality;
   final bool enableBackgroundAnimation;
   final double backgroundPressScale;
+
+  /// Render the pill's glass via the live BackdropFilter path so it composites
+  /// over a PlatformView.
+  final bool platformViewBackdrop;
 
   /// Called when the search field gains or loses focus.
   /// Used by the parent bar to drive the dismiss pill visibility.
@@ -784,7 +811,12 @@ class SearchPillState extends State<SearchPill> {
                     : () => widget.config.onSearchToggle(true),
                 width: double.infinity,
                 height: double.infinity,
-                quality: widget.quality,
+                // Over a PlatformView the collapsed button uses the lightweight
+                // veil so it matches the rest of the bar (premium can't sample
+                // the PlatformView).
+                quality: widget.platformViewBackdrop
+                    ? GlassQuality.standard
+                    : widget.quality,
                 iconColor: iconColor,
                 // When fully collapsed (square), LiquidOval gives a perfect
                 // circle that stretches uniformly. During the collapse
@@ -832,6 +864,7 @@ class SearchPillState extends State<SearchPill> {
             child: AdaptiveGlass.grouped(
               shape: shape,
               quality: widget.quality,
+              platformViewBackdrop: widget.platformViewBackdrop,
               child: _wrapWithGlow(
                 child: _buildExpanded(iconColor, micColor),
               ),

--- a/test/widgets/surfaces/platform_view_backdrop_test.dart
+++ b/test/widgets/surfaces/platform_view_backdrop_test.dart
@@ -1,0 +1,84 @@
+// Coverage-targeted tests for the platformViewBackdrop feature.
+// Targets:
+//   - adaptive_glass.dart: the canUsePremiumShader condition operands
+//     (!platformViewBackdrop / quality / _canUseImpeller) and the grouped()
+//     platformViewBackdrop pass-through.
+//   - searchable_bottom_bar_internal.dart: the moving indicator's backgroundKey
+//     `_iconLayerKey` branch, only taken when platformViewBackdrop is true.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+import '../../shared/test_helpers.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      home: Scaffold(body: LiquidGlassWidgets.wrap(child: child)),
+    );
+
+final _tabs = [
+  const GlassBottomBarTab(label: 'Home', icon: Icon(Icons.home)),
+  const GlassBottomBarTab(label: 'Map', icon: Icon(Icons.map)),
+];
+
+void main() {
+  group('platformViewBackdrop', () {
+    testWidgets(
+        'premium AdaptiveGlass evaluates the full canUsePremiumShader condition',
+        (tester) async {
+      // platformViewBackdrop defaults false → the local checks (!kIsWeb,
+      // !platformViewBackdrop, quality == premium) all evaluate, then
+      // _canUseImpeller — so every operand line executes under `flutter test`.
+      await tester.pumpWidget(_wrap(const SizedBox(
+        width: 200,
+        height: 100,
+        child: AdaptiveGlass(
+          shape: LiquidRoundedSuperellipse(borderRadius: 20),
+          settings: LiquidGlassSettings(blur: 5),
+          quality: GlassQuality.premium,
+          child: SizedBox.expand(),
+        ),
+      )));
+      await tester.pump();
+      expect(find.byType(AdaptiveGlass), findsOneWidget);
+    });
+
+    testWidgets('AdaptiveGlass.grouped forwards platformViewBackdrop',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        AdaptiveGlass.grouped(
+          shape: const LiquidRoundedSuperellipse(borderRadius: 20),
+          quality: GlassQuality.premium,
+          platformViewBackdrop: true,
+          child: const SizedBox(width: 200, height: 100),
+        ),
+      ));
+      await tester.pump();
+      expect(find.byType(AdaptiveGlass), findsWidgets);
+    });
+
+    testWidgets(
+        'GlassSearchableBottomBar(platformViewBackdrop) refracts the icon layer',
+        (tester) async {
+      // Exercises the indicator's `backgroundKey: platformViewBackdrop ?
+      // _iconLayerKey : widget.backgroundKey` branch plus the background
+      // grouped() pass-throughs and the search pill.
+      await tester.pumpWidget(createTestApp(
+        child: SizedBox(
+          height: 90,
+          width: 400,
+          child: GlassSearchableBottomBar(
+            tabs: _tabs,
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            searchConfig: GlassSearchBarConfig(onSearchToggle: (_) {}),
+            quality: GlassQuality.premium,
+            platformViewBackdrop: true,
+          ),
+        ),
+      ));
+      await tester.pump();
+      expect(find.byType(GlassSearchableBottomBar), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `platformViewBackdrop` flag so **premium-quality glass renders correctly over an iOS PlatformView** (e.g. a Mapbox map or a video), instead of appearing as a solid slab.

## Motivation

The premium shader builds its backdrop from `RenderRepaintBoundary.toImageSync`, and `toImageSync` **cannot capture an iOS PlatformView** — the OS composites PlatformViews outside Flutter's layer tree. So a premium glass surface placed directly over a map renders as an opaque slab (no live view, no blur of the map).

The existing workaround is to drop the whole surface to `GlassQuality.standard`, but that also swaps the widget type (losing premium animations/state) and forfeits the premium look everywhere, not just over the PlatformView.  Trying to toggle between premium and standard quality on a per-page basis does not animate smoothly, requiring multiple workarounds to address.  This approach allows premium to be used app-wide, even when there are one or more app pages with PlatformViews.

## What this does

`platformViewBackdrop` is an **orthogonal axis** to `GlassQuality` — it changes only the *backdrop source*, not the quality tier:

- **`AdaptiveGlass` / `AdaptiveGlass.grouped`** — new `platformViewBackdrop` flag. When `true`, the surface uses the live `BackdropFilter` path **even at `GlassQuality.premium`**, so the PlatformView shows through. Refraction is lost (there's no sampleable texture), but the live blur + rim/lighting remain.
- **`GlassSearchableBottomBar`** — new `platformViewBackdrop` flag, forwarded to the tab indicator and search pill:
  - the bar **background** uses the `BackdropFilter` path;
  - the premium tab **indicator** refracts the bar's own icon layer (a capturable Flutter `RepaintBoundary`) instead of the uncapturable PlatformView region — so the premium magic-lens animation survives over the map with **no quality swap**;
  - the collapsed search button drops to the lightweight veil over a PlatformView so it matches the bar background.

## Backward compatibility

Every flag defaults to `false` — no behaviour change when unset.

## Known limitation (documented on the field)

The premium indicator refracts the icon layer via `toImageSync`, which asserts the captured boundary is clean. While the indicator animates, that layer repaints every frame, so a mid-animation capture can fail and the indicator briefly flashes dark. It's negligible at `magnification` ≈ 1.0 (the default) but grows with magnification — so keep magnification near 1.0 over a PlatformView. (The PlatformView itself can't be captured, so there's no way to refract it directly.)

## Testing

`flutter analyze lib` is clean. Exercised in a production app: a `GlassSearchableBottomBar` over a full-screen Mapbox `MapWidget` — the live map shows through the bar and indicator, premium tab-morph animations play, no solid slab, no quality swap.

## Diff

3 files, +72/−4 — additive only.
