### PR TITLE
feat(GlassMenu): scale menu items with morph animation

### DIFF
--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -657,10 +657,9 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
                 clipBehavior:
                     Clip.none, // Prevent double-clip artifacts during stretch
                 children: [
-                  // Menu content — only appears when container is nearly at
-                  // full size (0.94+), so the teardrop morph is fully visible
-                  // first. Items stagger in rapidly in the last 6% of animation.
-                  if (clampedValue > 0.94)
+                  // Menu content scales up with the container morph — items
+                  // enter the tree at 30% and scale from 0.5× to 1.0×.
+                  if (clampedValue > 0.3)
                     Stack(
                       clipBehavior: Clip.none,
                       children: [
@@ -775,16 +774,24 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
                                         .asMap()
                                         .entries
                                         .expand((entry) {
-                                      // Items fade in smoothly over the second half of the animation.
-                                      // Removed the complex out-to-in 94% stagger so items show up
-                                      // naturally without a delayed "pop-in" on fast springs.
                                       final itemOpacity =
-                                          ((clampedValue - 0.5) / 0.5)
+                                          ((clampedValue - 0.3) / 0.4)
                                               .clamp(0.0, 1.0);
+                                      final itemScale = lerpDouble(
+                                        0.5,
+                                        1.0,
+                                        Curves.easeOut.transform(
+                                          ((clampedValue - 0.3) / 0.7)
+                                              .clamp(0.0, 1.0),
+                                        ),
+                                      )!;
                                       return [
                                         Opacity(
                                           opacity: itemOpacity,
-                                          child: entry.value,
+                                          child: Transform.scale(
+                                            scale: itemScale,
+                                            child: entry.value,
+                                          ),
                                         ),
                                         if (entry.key < widget.items.length - 1)
                                           const SizedBox(height: 2),


### PR DESCRIPTION
## Summary

Menu items now **scale in** with the morph animation instead of popping in at the tail:

- Items enter the tree at **30% morph progress** (down from 94%)
- Scale from **0.5× to 1.0×** via an `easeOut` curve alongside opacity
- Text and icons visually grow with the expanding glass container

This makes the menu open feel more cohesive — items are part of the morph rather than an afterthought that snaps in once the glass is nearly at rest.

## What changed

One file: `glass_menu_internal.dart`

- `clampedValue > 0.94` threshold → `0.3` (items mount earlier)
- Opacity ramp starts at 0.3 (fully opaque by 0.7) instead of 0.5–1.0
- Added `Transform.scale` with `lerpDouble(0.5, 1.0, easeOut(…))` wrapping each item

## Before / After

| Before | After |
|--------|-------|
| Items hidden until 94% morph, then fade in (opacity only) | Items scale from 50% at 30% morph, growing with the container |
| Abrupt "pop-in" feel on fast springs | Smooth, continuous entrance |

No new API surface. No breaking changes. Purely visual polish to the existing morph animation.