### PR TITLE
feat: whitenStrength — opt-in light-mode whitening (legibility veil) across all quality tiers

### DIFF
--- a/lib/src/renderer/liquid_glass_settings.dart
+++ b/lib/src/renderer/liquid_glass_settings.dart
@@ -27,6 +27,8 @@ class LiquidGlassSettings with EquatableMixin {
     this.standardOpacityMultiplier = 1.0,
     this.shadowElevation = 1.0,
     this.shadow,
+    this.whitenStrength = 0.0,
+    this.whitenGated = true,
   });
 
   /// Creates [LiquidGlassSettings] using Figma-inspired parameter names.
@@ -219,6 +221,36 @@ class LiquidGlassSettings with EquatableMixin {
     return GlassShadow.scaled(shadowElevation);
   }
 
+  /// Light-mode whitening ("legibility veil") amount, from 0 to 1.
+  ///
+  /// On the Premium (Impeller) path this is applied as the last step of the
+  /// render: the finished glass is mixed uniformly toward white,
+  /// `mix(glass, white, whitenStrength)`. Because it is a single control-wide
+  /// value (not per-pixel) there is no spatial seam, so no halo or outline
+  /// artifacts. This models iOS 26 light-mode glass, which lays an even
+  /// whitening layer over the refracted content for legibility on bright
+  /// backgrounds — content stays visible, just whiter.
+  ///
+  /// The Standard and Frosted paths approximate the same knob by lifting the
+  /// glass tint toward white (a "veil"), so a single value reads consistently
+  /// across all quality tiers.
+  ///
+  /// Defaults to 0.0, which disables whitening entirely.
+  final double whitenStrength;
+
+  /// Whether [whitenStrength] is luminance-gated (true, the default) or
+  /// applied uniformly (false).
+  ///
+  /// Gated: the lift only affects brighter pixels and leaves dark content
+  /// (text, icons) crisp — the light-mode behaviour. Ungated: an even lift
+  /// across the whole control — useful in dark mode to give dark glass a
+  /// subtle frost, where a per-pixel gate over an all-dark backdrop would
+  /// zero the whitening out entirely.
+  ///
+  /// Only affects the Premium (Impeller) path; the Standard and Frosted
+  /// approximations are always uniform.
+  final bool whitenGated;
+
   /// The effective saturation taking visibility into account.
   double get effectiveSaturation => 1 + (saturation - 1) * visibility;
 
@@ -259,6 +291,8 @@ class LiquidGlassSettings with EquatableMixin {
           a.standardOpacityMultiplier, b.standardOpacityMultiplier, t)!,
       shadowElevation: lerpDouble(a.shadowElevation, b.shadowElevation, t)!,
       shadow: t < 0.5 ? a.shadow : b.shadow,
+      whitenStrength: lerpDouble(a.whitenStrength, b.whitenStrength, t)!,
+      whitenGated: t < 0.5 ? a.whitenGated : b.whitenGated,
     );
   }
 
@@ -288,6 +322,8 @@ class LiquidGlassSettings with EquatableMixin {
     double? standardOpacityMultiplier,
     double? shadowElevation,
     List<BoxShadow>? shadow,
+    double? whitenStrength,
+    bool? whitenGated,
   }) =>
       LiquidGlassSettings(
         visibility: visibility ?? this.visibility,
@@ -306,6 +342,8 @@ class LiquidGlassSettings with EquatableMixin {
             standardOpacityMultiplier ?? this.standardOpacityMultiplier,
         shadowElevation: shadowElevation ?? this.shadowElevation,
         shadow: shadow ?? this.shadow,
+        whitenStrength: whitenStrength ?? this.whitenStrength,
+        whitenGated: whitenGated ?? this.whitenGated,
       );
 
   @override
@@ -325,5 +363,7 @@ class LiquidGlassSettings with EquatableMixin {
         standardOpacityMultiplier,
         shadowElevation,
         shadow,
+        whitenStrength,
+        whitenGated,
       ];
 }

--- a/lib/src/renderer/rendering/liquid_glass_render_object.dart
+++ b/lib/src/renderer/rendering/liquid_glass_render_object.dart
@@ -143,6 +143,13 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
         // not on every visibility, blur, or color animation frame.
         ..setOffset(_cachedLightDir);
     });
+    // Slot 18: uWhiten (whitening amount); slot 19: uWhitenGated
+    // (1 = luminance-gated, the light-mode behaviour; 0 = uniform lift).
+    renderShader.setFloatUniforms(initialIndex: 18, (value) {
+      value
+        ..setFloat(settings.whitenStrength)
+        ..setFloat(settings.whitenGated ? 1.0 : 0.0);
+    });
   }
 
   ui.Rect _paintBounds = ui.Rect.zero;

--- a/lib/widgets/shared/adaptive_glass.dart
+++ b/lib/widgets/shared/adaptive_glass.dart
@@ -275,6 +275,11 @@ class AdaptiveGlass extends StatelessWidget {
                   (normalizedSettings.effectiveAmbientStrength * 0.4)
                       .clamp(0.0, 1.0),
               glowIntensity: normalizedSettings.glowIntensity,
+              // Preserve whiten through the elevation rebuild; otherwise the
+              // whitening would silently drop to 0 for grouped/elevated
+              // surfaces such as bars.
+              whitenStrength: normalizedSettings.whitenStrength,
+              whitenGated: normalizedSettings.whitenGated,
             )
           : normalizedSettings;
 
@@ -558,7 +563,22 @@ class _FrostedFallback extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final blur = settings.effectiveBlur.clamp(0.0, 40.0);
-    final tint = settings.effectiveGlassColor;
+    // Whiten veil: lift the tint toward white by a ramp of
+    // [LiquidGlassSettings.whitenStrength], matching the Standard path
+    // (lightweight_liquid_glass.dart). This is why minimal-tier controls
+    // whiten from the same single knob — no per-widget code needed. The veil
+    // ramp uses the same gain as the Standard path so a single whitenStrength
+    // value reads consistently across tiers. Minimal's tint is already a
+    // uniform flat fill, so this lerp is the whole whiten here.
+    const double kWhitenVeilGain = 1.5;
+    final double whiten = settings.whitenStrength.clamp(0.0, 1.0).toDouble();
+    final double veil = whiten <= 0.0
+        ? 0.0
+        : (whiten * kWhitenVeilGain).clamp(0.0, 1.0).toDouble();
+    final tint = veil <= 0.0
+        ? settings.effectiveGlassColor
+        : Color.lerp(
+            settings.effectiveGlassColor, const Color(0xFFFFFFFF), veil)!;
 
     final double frostedAlpha = isAccessibilityFallback
         // Accessibility: boost opacity so content remains legible

--- a/lib/widgets/shared/lightweight_liquid_glass.dart
+++ b/lib/widgets/shared/lightweight_liquid_glass.dart
@@ -847,7 +847,24 @@ class _RenderLightweightGlass extends RenderProxyBox {
     // modulation in Stage 2.5 (lightweight_glass.frag) so the alpha creates
     // a depth gradient (full at rim, 12% at center) instead of a flat fill.
     // This correctly approximates the 3D SDF Fresnel of the Premium path.
-    final color = _settings.effectiveGlassColor;
+    //
+    // Whiten veil: lift glassColor toward white by a ramp of
+    // [LiquidGlassSettings.whitenStrength]. This is the Standard-path
+    // approximation of the Premium shader's whiten — the Fresnel modulation
+    // keeps the center lighter (content reads through) and the rim brighter.
+    // Because it is a tint overlay rather than a backdrop color operation, it
+    // also works over platform views, where BackdropFilter color ops don't
+    // apply. The gain calibrates the veil so a single whitenStrength value
+    // reads close to the Premium path's gated whiten at the same value.
+    final double whitenStrength =
+        _settings.whitenStrength.clamp(0.0, 1.0).toDouble();
+    const double kWhitenVeilGain = 1.5;
+    final double whitenVeil =
+        (whitenStrength * kWhitenVeilGain).clamp(0.0, 1.0).toDouble();
+    final color = whitenVeil <= 0.0
+        ? _settings.effectiveGlassColor
+        : Color.lerp(_settings.effectiveGlassColor, const Color(0xFFFFFFFF),
+            whitenVeil)!;
     shader.setFloat(index++, (color.r * 255.0).round().clamp(0, 255) / 255.0);
     shader.setFloat(index++, (color.g * 255.0).round().clamp(0, 255) / 255.0);
     shader.setFloat(index++, (color.b * 255.0).round().clamp(0, 255) / 255.0);

--- a/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
+++ b/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
@@ -98,6 +98,11 @@ class GlassSearchableBottomBar extends StatefulWidget {
     this.tabWidth,
     this.indicatorExpansion = 14,
     this.onBarTap,
+    // ── Whiten-at-bottom (light-mode legibility) ─────────────────────────────
+    this.whitenAtBottom = true,
+    this.whitenBottomThreshold = 45.0,
+    this.whitenAtBottomTarget = 1.0,
+    this.scrollController,
   })  : assert(tabs.length > 0,
             'GlassSearchableBottomBar requires at least one tab'),
         assert(
@@ -227,6 +232,29 @@ class GlassSearchableBottomBar extends StatefulWidget {
   // ── Glass ────────────────────────────────────────────────────────────────────
   /// Custom glass settings. Falls back to identical defaults as [GlassBottomBar].
   final LiquidGlassSettings? settings;
+
+  // ── Whiten-at-bottom (light-mode legibility) ───────────────────────────────
+  /// When true (default), the bar lifts its whitening toward
+  /// [whitenAtBottomTarget] as the scrolled content nears the bottom of the
+  /// page, so a light page stays readable through the bar. Light-mode only;
+  /// set false to opt out.
+  ///
+  /// Inert unless a [scrollController] is provided (the bar needs a scroll
+  /// position to watch), so the defaults change nothing for existing callers.
+  final bool whitenAtBottom;
+
+  /// Distance (logical px) from the scroll bottom within which the bar is
+  /// considered "at the bottom" and whitens. Defaults to 45.
+  final double whitenBottomThreshold;
+
+  /// Whiten value the bar lifts to at the bottom. Defaults to 1.0
+  /// (fully white).
+  final double whitenAtBottomTarget;
+
+  /// Scroll controller for the page beneath the bar. Null (the default)
+  /// disables the whiten-at-bottom effect — there is no scroll position to
+  /// watch.
+  final ScrollController? scrollController;
 
   /// Rendering quality. Inherits from parent or defaults to [GlassQuality.premium].
   final GlassQuality? quality;
@@ -431,6 +459,15 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
   /// Animated current width of the search pill.
   late AnimationController _searchWCtrl;
 
+  // ── Whiten-at-bottom ───────────────────────────────────────────────────────
+  /// Animates the whiten lift: 0 = recipe whiten, 1 = lifted to
+  /// [GlassSearchableBottomBar.whitenAtBottomTarget]. Smoothed so the bar
+  /// doesn't snap when the page reaches/leaves the bottom.
+  late AnimationController _whitenBoostCtrl;
+
+  /// The destination the whiten boost is currently animating toward.
+  double _whitenTarget = 0.0;
+
   @override
   void initState() {
     super.initState();
@@ -467,6 +504,15 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
       lowerBound: double.negativeInfinity,
       upperBound: double.infinity,
     )..addListener(_onSpringTick);
+    // Whiten-at-bottom boost: 0..1, rebuilds the bar as it animates.
+    _whitenBoostCtrl = AnimationController(vsync: this)
+      ..addListener(_onSpringTick);
+    widget.scrollController?.addListener(_onScrollMaybeWhiten);
+    // Evaluate once after the first frame so a page that starts at the
+    // bottom (e.g. short content) pins immediately.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _onScrollMaybeWhiten();
+    });
   }
 
   @override
@@ -487,6 +533,20 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
       }
       _controller.addListener(_onControllerChanged);
     }
+    // Re-subscribe the whiten watcher if the scroll source changed, and
+    // re-evaluate immediately so the boost re-pins to the new page's position.
+    if (widget.scrollController != old.scrollController) {
+      old.scrollController?.removeListener(_onScrollMaybeWhiten);
+      widget.scrollController?.addListener(_onScrollMaybeWhiten);
+      _onScrollMaybeWhiten();
+    }
+    // Re-evaluate when the feature itself is toggled while the page sits at
+    // the bottom — no scroll event fires in that case, so without this the
+    // boost stays stale (off after re-enable, or lingering after disable)
+    // until the next scroll.
+    if (widget.whitenAtBottom != old.whitenAtBottom) {
+      _onScrollMaybeWhiten();
+    }
     // Delegate focus-clear logic to the controller.
     _controller.onSearchActiveChanged(
       wasActive: old.isSearchActive,
@@ -499,6 +559,8 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
     _tabWCtrl.dispose();
     _searchLeftCtrl.dispose();
     _searchWCtrl.dispose();
+    widget.scrollController?.removeListener(_onScrollMaybeWhiten);
+    _whitenBoostCtrl.dispose();
     _controller.removeListener(_onControllerChanged);
     if (_ownsController) _controller.dispose();
     super.dispose();
@@ -507,6 +569,43 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
   void _onFocusLost() {
     // Delegates to controller → triggers setState via listener.
     _controller.onFocusChanged(false);
+  }
+
+  /// Re-evaluate bottom proximity whenever the watched scroll position moves.
+  void _onScrollMaybeWhiten() {
+    final c = widget.scrollController;
+    final atBottom = widget.whitenAtBottom &&
+        c != null &&
+        c.hasClients &&
+        c.position.maxScrollExtent > 0 &&
+        (c.position.maxScrollExtent - c.position.pixels) <=
+            widget.whitenBottomThreshold;
+    final target = atBottom ? 1.0 : 0.0;
+    if (_whitenTarget != target) {
+      _whitenTarget = target;
+      _whitenBoostCtrl.animateTo(target,
+          duration: const Duration(milliseconds: 200), curve: Curves.easeOut);
+    }
+  }
+
+  /// Applies the (possibly boosted) whiten to [s]. Every quality tier consumes
+  /// `whitenStrength` directly — the veil is rendered in the shared render
+  /// paths (premium: render object + shader; standard: lightweight glass;
+  /// minimal: the frosted fallback in adaptive_glass.dart), so the one knob
+  /// whitens the whole bar.
+  ///
+  /// The whiten-at-bottom lift is light-mode only: it keeps a light page
+  /// readable through the bar, but in dark mode it would just bloom a white
+  /// slab at the bottom — so [isLight] gates the boost off there. The
+  /// recipe's base whitenStrength still applies in both modes; only the
+  /// at-bottom lift is gated.
+  LiquidGlassSettings _applyWhiten(LiquidGlassSettings s, bool isLight) {
+    final base = s.whitenStrength;
+    final t = (widget.whitenAtBottom && isLight) ? _whitenBoostCtrl.value : 0.0;
+    final eff = (base + (widget.whitenAtBottomTarget - base) * t)
+        .clamp(0.0, 1.0)
+        .toDouble();
+    return s.copyWith(whitenStrength: eff);
   }
 
   @override
@@ -537,7 +636,12 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
     final effectiveGlowSpreadRadius = resolvedGlowColors.glowSpreadRadius;
     final effectiveGlowOpacity = resolvedGlowColors.glowOpacity;
 
-    final effectiveSettings = widget.settings ?? _defaultGlassSettings;
+    // CupertinoTheme.brightnessOf falls back to the platform brightness, so
+    // this resolves correctly in both Material and pure-Cupertino apps.
+    final bool isLight =
+        CupertinoTheme.brightnessOf(context) == Brightness.light;
+    final effectiveSettings =
+        _applyWhiten(widget.settings ?? _defaultGlassSettings, isLight);
     final searching = widget.isSearchActive;
 
     final barContent = TweenAnimationBuilder<double>(

--- a/shaders/liquid_glass_final_render.frag
+++ b/shaders/liquid_glass_final_render.frag
@@ -26,7 +26,8 @@ precision highp float; // mediump causes colour banding (10-bit mantissa on mobi
 // Slots 10-12: uOpticalProps (refractiveIndex, chromaticAberration, thickness)
 // Slots 13-15: uLightConfig  (lightIntensity, ambientStrength, saturation)
 // Slots 16-17: uLightDirection
-// Slot 18: uBlurSigma
+// Slot 18: uWhiten
+// Slot 19: uWhitenGated
 uniform vec2 uSize;          // physical-pixel size of the backdrop capture
 uniform vec2 uGeometryOffset;
 uniform vec2 uGeometrySize;
@@ -35,6 +36,20 @@ uniform vec4 uGlassColor;
 uniform vec3 uOpticalProps;
 uniform vec3 uLightConfig;
 uniform vec2 uLightDirection;
+
+// Slot 18: uWhiten — whitening ("legibility veil") amount [0..1]. Lifts the
+// glass toward white (result = mix(glass, white, uWhiten)). A single
+// control-wide value (not spatially varying), so there is no spatial seam and
+// therefore no halo/outline artifacts. Models iOS 26 light-mode glass, which
+// places an even whitening veil over the refracted content for legibility on
+// light backgrounds. 0 = pure glass (no-op); higher = whiter.
+uniform float uWhiten;
+
+// Slot 19: uWhitenGated. 1 = the whiten is luminance-gated (protects dark
+// pixels — the light-mode behaviour, keeps text/icons beneath the glass dark);
+// 0 = ungated, uniform whiten across the whole control (the dark-mode
+// behaviour, gives dark glass a small even lift toward white).
+uniform float uWhitenGated;
 
 uniform sampler2D uBackgroundTexture;
 uniform sampler2D uGeometryTexture;
@@ -202,6 +217,37 @@ void main() {
                          uGlassColor.rgb,
                          uGlassColor.a * 0.12 * (adaptiveStrength - 1.0));
 
+    // Whitening veil — applied here, right after the body tint and BEFORE the
+    // rim/fresnel passes. Applying it before the edge lighting means the rim
+    // and fresnel highlights are drawn on top of the whitened body, so the
+    // bright edges stay crisp even when the body is heavily whitened —
+    // matching iOS 26's light-mode bar, where the white ring / edge
+    // reflections stay sharp over a whitened interior.
+    //
+    // Luminance-gated mode: scale the whiten by how bright this pixel already
+    // is, so near-white content beneath the glass lifts to pure white while
+    // darks (text, icons) are left untouched — instead of a uniform veil that
+    // grays the darks too. This is a point operation (per-pixel, depending
+    // only on this pixel's own luminance — no neighbourhood sampling), so
+    // unlike a spatial content detector it cannot produce a halo or seam; at
+    // a dark-on-light edge it just steepens the existing gradient (crisper
+    // edge, no gray ring).
+    //
+    // WHITEN_LO / WHITEN_HI are content-classification thresholds (what
+    // luminance counts as "a dark to protect" vs "a white to push"), not
+    // aesthetic per-recipe values — so they are hardcoded rather than passed
+    // as uniforms. The single tunable lever is uWhiten (the strength).
+    //   below WHITEN_LO → gate 0 (fully protected, stays dark)
+    //   above WHITEN_HI → gate 1 (fully whitened, lifts to white)
+    const float WHITEN_LO = 0.40;
+    const float WHITEN_HI = 0.80;
+    float whitenLuma = dot(finalColor.rgb, LUMA_WEIGHTS);
+    // uWhitenGated 1 → gate by luminance (light mode, protects darks);
+    // uWhitenGated 0 → gate = 1, uniform whiten (dark mode, even lift).
+    float whitenGate =
+        mix(1.0, smoothstep(WHITEN_LO, WHITEN_HI, whitenLuma), uWhitenGated);
+    finalColor.rgb =
+        mix(finalColor.rgb, vec3(1.0), clamp(uWhiten, 0.0, 1.0) * whitenGate);
 
     // Edge lighting — uses the true normal.xy (V1; was normalize(displacement))
     float normalizedHeight = geometryData.b;

--- a/test/renderer/liquid_glass_settings_test.dart
+++ b/test/renderer/liquid_glass_settings_test.dart
@@ -316,5 +316,79 @@ void main() {
         expect(original.copyWith(), equals(original));
       });
     });
+
+    // ─── whitenStrength / whitenGated ────────────────────────────────────────
+
+    group('whitenStrength / whitenGated', () {
+      test('whitenStrength defaults to 0.0 (no-op)', () {
+        const s = LiquidGlassSettings();
+        expect(s.whitenStrength, 0.0);
+      });
+
+      test('whitenGated defaults to true', () {
+        const s = LiquidGlassSettings();
+        expect(s.whitenGated, isTrue);
+      });
+
+      test('copyWith round-trips whitenStrength', () {
+        const base = LiquidGlassSettings();
+        final copy = base.copyWith(whitenStrength: 0.7);
+        expect(copy.whitenStrength, 0.7);
+        // Other fields untouched.
+        expect(copy.whitenGated, base.whitenGated);
+        expect(copy.blur, base.blur);
+        // Round-trip back.
+        expect(copy.copyWith(whitenStrength: 0.0), equals(base));
+      });
+
+      test('copyWith round-trips whitenGated', () {
+        const base = LiquidGlassSettings();
+        final copy = base.copyWith(whitenGated: false);
+        expect(copy.whitenGated, isFalse);
+        expect(copy.whitenStrength, base.whitenStrength);
+        expect(copy.copyWith(whitenGated: true), equals(base));
+      });
+
+      test('lerp interpolates whitenStrength linearly', () {
+        const a = LiquidGlassSettings(whitenStrength: 0.0);
+        const b = LiquidGlassSettings(whitenStrength: 1.0);
+        expect(
+          LiquidGlassSettings.lerp(a, b, 0.25).whitenStrength,
+          closeTo(0.25, 1e-10),
+        );
+        expect(
+          LiquidGlassSettings.lerp(a, b, 0.75).whitenStrength,
+          closeTo(0.75, 1e-10),
+        );
+      });
+
+      test('lerp switches whitenGated at t=0.5', () {
+        const a = LiquidGlassSettings(whitenGated: true);
+        const b = LiquidGlassSettings(whitenGated: false);
+        expect(LiquidGlassSettings.lerp(a, b, 0.49).whitenGated, isTrue);
+        expect(LiquidGlassSettings.lerp(a, b, 0.5).whitenGated, isFalse);
+        expect(LiquidGlassSettings.lerp(a, b, 1.0).whitenGated, isFalse);
+      });
+
+      test('equality includes whitenStrength', () {
+        const a = LiquidGlassSettings(whitenStrength: 0.3);
+        const b = LiquidGlassSettings(whitenStrength: 0.3);
+        const c = LiquidGlassSettings(whitenStrength: 0.6);
+        expect(a, equals(b));
+        expect(a, isNot(equals(c)));
+      });
+
+      test('equality includes whitenGated', () {
+        const a = LiquidGlassSettings();
+        const b = LiquidGlassSettings(whitenGated: false);
+        expect(a, isNot(equals(b)));
+      });
+
+      test('props contains both whiten fields', () {
+        const s = LiquidGlassSettings(whitenStrength: 0.4, whitenGated: false);
+        expect(s.props, contains(0.4));
+        expect(s.props, contains(false));
+      });
+    });
   });
 }

--- a/test/widgets/surfaces/whiten_at_bottom_test.dart
+++ b/test/widgets/surfaces/whiten_at_bottom_test.dart
@@ -21,10 +21,13 @@ GlassSearchBarConfig _basicSearchConfig() => GlassSearchBarConfig(
     );
 
 /// A scrollable page with the bar pinned over the bottom edge — the layout
-/// the whiten-at-bottom feature is designed for.
+/// the whiten-at-bottom feature is designed for. [barController] lets a test
+/// hand the bar a different controller than the list (to exercise the
+/// didUpdateWidget controller swap); it defaults to [controller].
 Widget _buildScrollPage({
   required ScrollController controller,
   bool whitenAtBottom = true,
+  ScrollController? barController,
 }) {
   return createTestApp(
     theme: ThemeData(brightness: Brightness.light),
@@ -49,7 +52,7 @@ Widget _buildScrollPage({
               selectedIndex: 0,
               onTabSelected: (_) {},
               searchConfig: _basicSearchConfig(),
-              scrollController: controller,
+              scrollController: barController ?? controller,
               whitenAtBottom: whitenAtBottom,
             ),
           ),
@@ -118,6 +121,61 @@ void main() {
 
       controller.jumpTo(controller.position.maxScrollExtent);
       await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(tester.takeException(), isNull);
+      expect(find.byType(GlassSearchableBottomBar), findsOneWidget);
+    });
+
+    testWidgets('didUpdateWidget re-subscribes when the scrollController swaps',
+        (tester) async {
+      final controllerA = ScrollController();
+      final controllerB = ScrollController();
+      addTearDown(controllerA.dispose);
+      addTearDown(controllerB.dispose);
+
+      await tester.pumpWidget(_buildScrollPage(controller: controllerA));
+      await tester.pump();
+
+      // Same tree, new scroll source — the bar must drop the old listener,
+      // subscribe to the new controller, and re-evaluate immediately.
+      await tester.pumpWidget(
+        _buildScrollPage(controller: controllerA, barController: controllerB),
+      );
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+
+      // The new controller drives the boost once attached to the list too.
+      await tester.pumpWidget(_buildScrollPage(controller: controllerB));
+      await tester.pump();
+      controllerB.jumpTo(controllerB.position.maxScrollExtent);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets(
+        'didUpdateWidget re-evaluates when whitenAtBottom toggles at the bottom',
+        (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+
+      // Engage the boost at the bottom…
+      await tester.pumpWidget(_buildScrollPage(controller: controller));
+      await tester.pump();
+      controller.jumpTo(controller.position.maxScrollExtent);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // …then disable the feature while parked there. No scroll event fires,
+      // so the toggle itself must release the boost.
+      await tester.pumpWidget(
+        _buildScrollPage(controller: controller, whitenAtBottom: false),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(tester.takeException(), isNull);
+
+      // And re-enabling re-engages it without any scrolling.
+      await tester.pumpWidget(_buildScrollPage(controller: controller));
       await tester.pump(const Duration(milliseconds: 300));
       expect(tester.takeException(), isNull);
       expect(find.byType(GlassSearchableBottomBar), findsOneWidget);

--- a/test/widgets/surfaces/whiten_at_bottom_test.dart
+++ b/test/widgets/surfaces/whiten_at_bottom_test.dart
@@ -1,0 +1,126 @@
+// ignore_for_file: require_trailing_commas
+// Smoke tests for the whiten feature:
+//   - minimal-quality AdaptiveGlass renders the frosted whiten veil path
+//   - GlassSearchableBottomBar whiten-at-bottom engages/disengages with a
+//     ScrollController without throwing
+//   - whitenAtBottom: false opt-out builds
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+import '../../shared/test_helpers.dart';
+
+final _testTabs = [
+  const GlassBottomBarTab(label: 'Home', icon: Icon(Icons.home)),
+  const GlassBottomBarTab(label: 'Music', icon: Icon(Icons.music_note)),
+];
+
+GlassSearchBarConfig _basicSearchConfig() => GlassSearchBarConfig(
+      onSearchToggle: (_) {},
+    );
+
+/// A scrollable page with the bar pinned over the bottom edge — the layout
+/// the whiten-at-bottom feature is designed for.
+Widget _buildScrollPage({
+  required ScrollController controller,
+  bool whitenAtBottom = true,
+}) {
+  return createTestApp(
+    theme: ThemeData(brightness: Brightness.light),
+    child: Stack(
+      children: [
+        ListView.builder(
+          controller: controller,
+          itemCount: 60,
+          itemBuilder: (context, i) => SizedBox(
+            height: 40,
+            child: Text('Row $i'),
+          ),
+        ),
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: SizedBox(
+            height: 90,
+            child: GlassSearchableBottomBar(
+              tabs: _testTabs,
+              selectedIndex: 0,
+              onTabSelected: (_) {},
+              searchConfig: _basicSearchConfig(),
+              scrollController: controller,
+              whitenAtBottom: whitenAtBottom,
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+void main() {
+  group('AdaptiveGlass — whiten veil (minimal quality)', () {
+    testWidgets('whitenStrength 0.6 builds and renders the frosted path',
+        (tester) async {
+      await tester.pumpWidget(createTestApp(
+        child: const SizedBox(
+          width: 200,
+          height: 100,
+          child: AdaptiveGlass(
+            shape: LiquidRoundedSuperellipse(borderRadius: 20),
+            settings: LiquidGlassSettings(blur: 5, whitenStrength: 0.6),
+            quality: GlassQuality.minimal,
+            child: SizedBox.expand(),
+          ),
+        ),
+      ));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+      expect(find.byType(AdaptiveGlass), findsOneWidget);
+    });
+  });
+
+  group('GlassSearchableBottomBar — whiten-at-bottom', () {
+    testWidgets('boost engages at scroll bottom and releases at top',
+        (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(_buildScrollPage(controller: controller));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+
+      // Jump to the bottom — the whiten boost should animate in.
+      controller.jumpTo(controller.position.maxScrollExtent);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(tester.takeException(), isNull);
+
+      // Jump back to the top — the boost should animate back out.
+      controller.jumpTo(0);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(tester.takeException(), isNull);
+
+      expect(find.byType(GlassSearchableBottomBar), findsOneWidget);
+    });
+
+    testWidgets('whitenAtBottom: false builds and stays inert',
+        (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        _buildScrollPage(controller: controller, whitenAtBottom: false),
+      );
+      await tester.pump();
+
+      controller.jumpTo(controller.position.maxScrollExtent);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(tester.takeException(), isNull);
+      expect(find.byType(GlassSearchableBottomBar), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds an opt-in **light-mode whitening ("legibility veil")** to `LiquidGlassSettings` — `whitenStrength` + `whitenGated` — rendered consistently across all three quality tiers, plus an optional **whiten-at-bottom** boost on `GlassSearchableBottomBar`. Both default to no-op (`whitenStrength: 0.0` → byte-identical rendering for existing users).

## Motivation

iOS 26 light-mode glass doesn't just blur and tint — it lays an even whitening layer over the refracted content so glass stays legible over busy light backgrounds, while letting the content remain visible through it. Today the closest approximation in the package is a heavy semi-opaque white `glassColor` (e.g. `Color(0x99FFFFFF)` as in the example app). We A/B-tested that approach against this PR's whitening in a production app (bottom nav over scrolling light content and over a full-screen map) and found the static tint has three drawbacks the whiten avoids:

- it **desaturates/dulls colorful content** behind the glass noticeably more,
- it reads **gray rather than white** (the tint mixes with mid-tone content; whiten lifts toward white *after* the glass render),
- it's **static** — at the bottom of a scroll, where content crowds right up under a bar, there's no extra legibility, which is exactly where iOS lifts hardest.

The new GPU SDF shadows (0.15.2) solve light-mode *elevation*; this PR is the complementary half: light-mode *fill legibility*.

## Visual comparison

Same bar, same light content behind it (iPhone, Impeller, premium tier):

| Gated whiten — this PR (`whitenStrength: 0.30`) | Static white tint (`glassColor: Color(0x99FFFFFF)`) |
|---|---|
| ![gated whiten](https://raw.githubusercontent.com/jfhair/liquid_glass_widgets/whiten-assets/whiten_gated_0_30.jpeg) | ![static tint](https://raw.githubusercontent.com/jfhair/liquid_glass_widgets/whiten-assets/static_tint_60.jpeg) |

The gated whiten reads **white** and preserves the color of the content bleeding through, while dark glyphs stay crisp; the static tint reads **gray** and desaturates everything behind it uniformly.

## What this does

### `LiquidGlassSettings.whitenStrength` / `whitenGated`

- **`whitenStrength`** (0..1, default **0.0** = off): the finished glass is lifted toward white — `mix(glass, white, whitenStrength)` — as the last step of the render. A single control-wide value, so there are no spatial seams or halo artifacts.
- **`whitenGated`** (default `true`): when gated, the lift is scaled by a per-pixel luminance gate (`smoothstep(0.40, 0.80, luma)`) so **bright content lifts toward white while dark content (text, icons) stays crisp** — the iOS light-mode behaviour. Ungated applies the lift uniformly — useful in dark mode as a subtle frost, where a luminance gate over all-dark content would zero the effect out.

Rendered per tier from the same knob, calibrated so one value reads consistently across tiers:

| Tier | Mechanism |
|---|---|
| premium (Impeller) | fragment shader, slots 18/19 (`uWhiten`, `uWhitenGated`), gate per-pixel |
| standard (lightweight) | glassColor lerped toward white (gain 1.5) before upload |
| minimal (frosted) | same veil applied to the fallback tint |

### `GlassSearchableBottomBar` whiten-at-bottom (opt-in)

`whitenAtBottom` / `whitenBottomThreshold` / `whitenAtBottomTarget` / `scrollController`: when a `scrollController` is provided, the bar animates its effective `whitenStrength` toward `whitenAtBottomTarget` (default 1.0) as the page nears its scroll bottom, and back as it leaves — a 200 ms eased boost. **Inert unless a `scrollController` is passed**, so the defaults change nothing. Light-mode only (resolved via `CupertinoTheme.brightnessOf`); in dark mode only the recipe's base `whitenStrength` applies.

*Design note: the boost lives on the bar (which owns the glass settings and sits over the scrolling content), in its own commit. If you'd rather see this integrated at the `GlassScaffold` / scroll-edge level instead, happy to rework it that way.*

## Backward compatibility

- `whitenStrength` defaults to `0.0`: the shader's whiten mix is a no-op and the veil lerps are skipped — existing rendering is unchanged (full test suite + goldens pass unchanged).
- All new parameters are additive with no-op defaults.

## Testing

- `flutter analyze` clean; full suite passes (the only failures on my host are the pre-existing golden mismatches, byte-identical with and without this change).
- New tests: settings (defaults / `copyWith` / `lerp` / equality), the minimal-tier veil path, and whiten-at-bottom engage/disengage with a live `ScrollController`.
- Exercised in a production app across premium/standard/minimal on-device (iPhone, Impeller): one whiten value reads consistently across tiers; gated whiten preserves dark glyphs over light scrolling content.

## Diff

8 files, +438/−4 — additive only; 2 of the 8 are tests.
