### PR TITLE
Content-aware light/dark adaptation: GlassContentAwareScope + bar adaptiveBrightness (#102)

### DIFF
--- a/lib/liquid_glass_widgets.dart
+++ b/lib/liquid_glass_widgets.dart
@@ -41,6 +41,7 @@ export 'widgets/shared/adaptive_liquid_glass_layer.dart';
 export 'widgets/shared/glass_accessibility_scope.dart'; // GlassAccessibilityScope + GlassAccessibilityData
 export 'widgets/shared/glass_adaptive_scope.dart'; // GlassAdaptiveScope + GlassAdaptiveScopeData + GlassAdaptiveDiagnostic
 export 'widgets/shared/glass_backdrop_scope.dart'; // GlassBackdropScope — per-screen backdrop isolation
+export 'widgets/shared/glass_content_aware_scope.dart'; // GlassContentAwareScope + GlassContentAwareContent + GlassContentAwareBrightness
 export 'widgets/shared/glass_page.dart' show GlassPage, GlassStatusBarStyle;
 export 'widgets/shared/glass_motion_scope.dart';
 export 'widgets/shared/glass_scroll_edge_effect.dart';

--- a/lib/theme/glass_theme_data.dart
+++ b/lib/theme/glass_theme_data.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/material.dart';
 import '../src/renderer/liquid_glass_renderer.dart';
 import 'glass_interaction_settings.dart';
@@ -96,6 +98,45 @@ class GlassGlowColors {
       glowSpreadRadius: glowSpreadRadius ?? this.glowSpreadRadius,
       glowOpacity: glowOpacity ?? this.glowOpacity,
     );
+  }
+
+  /// Linearly interpolates between two glow palettes.
+  ///
+  /// Color fields that are non-null on both sides interpolate smoothly via
+  /// [Color.lerp]; a field that is null on either side switches discretely at
+  /// the midpoint, because `null` means "resolve a brightness-aware default
+  /// at runtime" (see [GlassThemeData.glowColorsFor]) — fading through
+  /// transparent would misrepresent that. The appearance scalars
+  /// ([glowBlurRadius], [glowSpreadRadius], [glowOpacity]) always
+  /// interpolate smoothly.
+  ///
+  /// Returns null when both [a] and [b] are null. Used by
+  /// [GlassThemeVariant.lerp] to cross-fade between light and dark theme
+  /// variants during content-aware brightness flips.
+  static GlassGlowColors? lerp(
+    GlassGlowColors? a,
+    GlassGlowColors? b,
+    double t,
+  ) {
+    if (identical(a, b)) return a;
+    if (a == null || b == null) return t < 0.5 ? a : b;
+    return GlassGlowColors(
+      primary: _lerpColorField(a.primary, b.primary, t),
+      secondary: _lerpColorField(a.secondary, b.secondary, t),
+      success: _lerpColorField(a.success, b.success, t),
+      warning: _lerpColorField(a.warning, b.warning, t),
+      danger: _lerpColorField(a.danger, b.danger, t),
+      info: _lerpColorField(a.info, b.info, t),
+      glowBlurRadius: lerpDouble(a.glowBlurRadius, b.glowBlurRadius, t)!,
+      glowSpreadRadius:
+          lerpDouble(a.glowSpreadRadius, b.glowSpreadRadius, t)!,
+      glowOpacity: lerpDouble(a.glowOpacity, b.glowOpacity, t)!,
+    );
+  }
+
+  static Color? _lerpColorField(Color? a, Color? b, double t) {
+    if (a != null && b != null) return Color.lerp(a, b, t);
+    return t < 0.5 ? a : b;
   }
 
   /// Fallback glow colors with sensible defaults.
@@ -197,6 +238,40 @@ class GlassThemeVariant {
       quality: quality ?? this.quality,
       glowColors: glowColors ?? this.glowColors,
       borderRadius: borderRadius ?? this.borderRadius,
+    );
+  }
+
+  /// Linearly interpolates between two theme variants.
+  ///
+  /// Continuous values interpolate smoothly; discrete or optional values
+  /// switch at the midpoint:
+  ///
+  /// - [settings] delegates to [GlassThemeSettings.lerp] (per-field smooth
+  ///   lerp with midpoint switching for one-sided `null`s).
+  /// - [glowColors] delegates to [GlassGlowColors.lerp].
+  /// - [borderRadius] interpolates when set on both sides, otherwise
+  ///   switches at the midpoint.
+  /// - [quality] is discrete and always switches at the midpoint.
+  ///
+  /// Used to cross-fade between the light and dark variants when a
+  /// content-aware brightness flip animates (see `GlassContentAwareScope`).
+  static GlassThemeVariant lerp(
+    GlassThemeVariant a,
+    GlassThemeVariant b,
+    double t,
+  ) {
+    if (identical(a, b)) return a;
+    final double? radius;
+    if (a.borderRadius != null && b.borderRadius != null) {
+      radius = lerpDouble(a.borderRadius, b.borderRadius, t);
+    } else {
+      radius = t < 0.5 ? a.borderRadius : b.borderRadius;
+    }
+    return GlassThemeVariant(
+      settings: GlassThemeSettings.lerp(a.settings, b.settings, t),
+      quality: t < 0.5 ? a.quality : b.quality,
+      glowColors: GlassGlowColors.lerp(a.glowColors, b.glowColors, t),
+      borderRadius: radius,
     );
   }
 

--- a/lib/theme/glass_theme_settings.dart
+++ b/lib/theme/glass_theme_settings.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/widgets.dart';
 
 import '../src/renderer/liquid_glass_settings.dart';
@@ -107,6 +109,59 @@ class GlassThemeSettings {
       saturation: saturation ?? base.saturation,
       specularSharpness: specularSharpness ?? base.specularSharpness,
     );
+  }
+
+  /// Linearly interpolates between two partial overrides.
+  ///
+  /// Because every field is an *optional* override, interpolation has to
+  /// respect the meaning of `null` ("use the widget's own default") rather
+  /// than treating it as zero:
+  ///
+  /// - When a field is non-null on **both** sides it is smoothly
+  ///   interpolated.
+  /// - When a field is null on **either** side it switches discretely at the
+  ///   midpoint (`t < 0.5` keeps [a]'s value, otherwise [b]'s). Interpolating
+  ///   against an unknown widget default would produce a visible flash
+  ///   through zero.
+  /// - [specularSharpness] is an enum and always switches at the midpoint.
+  ///
+  /// Returns null when both [a] and [b] are null. Used by
+  /// [GlassThemeVariant.lerp] to cross-fade between light and dark theme
+  /// variants during content-aware brightness flips.
+  static GlassThemeSettings? lerp(
+    GlassThemeSettings? a,
+    GlassThemeSettings? b,
+    double t,
+  ) {
+    if (identical(a, b)) return a;
+    if (a == null || b == null) return t < 0.5 ? a : b;
+    return GlassThemeSettings(
+      visibility: _lerpDoubleField(a.visibility, b.visibility, t),
+      glassColor: _lerpColorField(a.glassColor, b.glassColor, t),
+      thickness: _lerpDoubleField(a.thickness, b.thickness, t),
+      blur: _lerpDoubleField(a.blur, b.blur, t),
+      chromaticAberration:
+          _lerpDoubleField(a.chromaticAberration, b.chromaticAberration, t),
+      lightAngle: _lerpDoubleField(a.lightAngle, b.lightAngle, t),
+      lightIntensity: _lerpDoubleField(a.lightIntensity, b.lightIntensity, t),
+      ambientStrength:
+          _lerpDoubleField(a.ambientStrength, b.ambientStrength, t),
+      refractiveIndex:
+          _lerpDoubleField(a.refractiveIndex, b.refractiveIndex, t),
+      saturation: _lerpDoubleField(a.saturation, b.saturation, t),
+      specularSharpness:
+          t < 0.5 ? a.specularSharpness : b.specularSharpness,
+    );
+  }
+
+  static double? _lerpDoubleField(double? a, double? b, double t) {
+    if (a != null && b != null) return lerpDouble(a, b, t);
+    return t < 0.5 ? a : b;
+  }
+
+  static Color? _lerpColorField(Color? a, Color? b, double t) {
+    if (a != null && b != null) return Color.lerp(a, b, t);
+    return t < 0.5 ? a : b;
   }
 
   /// Creates a copy with overridden values.

--- a/lib/widgets/shared/glass_content_aware_scope.dart
+++ b/lib/widgets/shared/glass_content_aware_scope.dart
@@ -1,0 +1,913 @@
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+
+import '../../theme/glass_theme.dart';
+import '../../theme/glass_theme_data.dart';
+
+/// Signature for [GlassContentAwareBrightness.builder].
+///
+/// [brightness] is the committed content-aware verdict for the control.
+/// [darkAmount] is the animated cross-fade position between the light (0.0)
+/// and dark (1.0) appearance — it eases toward `brightness` over the flip
+/// duration, so consumers can interpolate their own colors during the
+/// transition.
+typedef GlassBrightnessWidgetBuilder = Widget Function(
+  BuildContext context,
+  Brightness brightness,
+  double darkAmount,
+);
+
+/// Drives iOS 26-style content-aware light/dark adaptation for glass
+/// controls floating over scrolling content.
+///
+/// iOS 26 bars and controls watch the content scrolling underneath them and
+/// flip between their light and dark appearance so the glyphs always keep
+/// contrast — light controls over bright photos, dark controls over a dark
+/// album cover. This scope productizes that behavior:
+///
+/// 1. Wrap the screen (typically the `Scaffold`) in a
+///    [GlassContentAwareScope].
+/// 2. Wrap the **scrolling content** — not the bars — in a
+///    [GlassContentAwareContent]. This marks the region that is sampled.
+///    The glass controls themselves must stay outside of it so the capture
+///    sees the content *behind* them rather than their own rendering.
+/// 3. Set `adaptiveBrightness: true` on `GlassBottomBar` /
+///    `GlassSearchableBottomBar` (or wrap any custom control in a
+///    [GlassContentAwareBrightness]).
+///
+/// ```dart
+/// GlassContentAwareScope(
+///   child: Scaffold(
+///     extendBody: true, // content scrolls underneath the bar
+///     body: GlassContentAwareContent(
+///       child: ListView(...),
+///     ),
+///     bottomNavigationBar: GlassBottomBar(
+///       adaptiveBrightness: true,
+///       ...
+///     ),
+///   ),
+/// )
+/// ```
+///
+/// The same wiring applies with [GlassScaffold]: wrap the scaffold in the
+/// scope and the scrolling content inside `body` in a
+/// [GlassContentAwareContent]. The scroll-edge fade that [GlassScaffold]
+/// renders sits outside the captured region, so it never feeds back into
+/// the vote.
+///
+/// ## How the verdict is decided
+///
+/// The scope captures the content boundary **once** per sample (a heavily
+/// downscaled, asynchronous `toImage` readback) and serves every registered
+/// control from that single capture. Each control's own rectangle is mapped
+/// into the captured image, divided into a small grid of cells, and each
+/// cell casts a vote: *which glyph color reads better over this content —
+/// the light variant's dark glyphs, or the dark variant's light glyphs?*
+/// The comparison uses WCAG contrast ratios, so the verdict is a **contrast
+/// vote, not a luminance threshold**: dark glyphs hold contrast over light
+/// *and* medium content, which keeps controls in their light appearance
+/// through the medium range and only flips them when the content is
+/// genuinely dark — matching the native behavior and resisting mode-flapping
+/// on mixed content such as photo grids.
+///
+/// On top of the vote, two flap-prevention layers are applied per control:
+///
+/// - **Sticky ties** — a tied or sub-threshold vote keeps the current
+///   appearance.
+/// - **Dual-threshold hysteresis** — flipping light → dark requires the dark
+///   vote fraction to reach [lightToDarkThreshold], while flipping back
+///   requires the light fraction to reach [darkToLightThreshold]. Content
+///   sitting right at the boundary therefore cannot oscillate.
+///
+/// ## Sampling cost
+///
+/// Sampling is scroll-aware: a [ScrollNotification] listener inside the
+/// scope starts a periodic sampler (every [sampleInterval]) when scrolling
+/// begins and stops it when scrolling ends, with one trailing sample to
+/// capture the settled state. While nothing moves, the sample rate is zero.
+/// The capture itself is downscaled to roughly 16 physical pixels per grid
+/// cell, so the readback is a few kilobytes regardless of screen size.
+///
+/// Because the automatic triggers are scroll-driven, content that changes
+/// **without** emitting scroll notifications — pan/zoom viewers such as
+/// [InteractiveViewer], asynchronously decoded images, programmatic
+/// restyles — should request a sample explicitly when it settles:
+///
+/// ```dart
+/// GlassContentAwareScope.maybeOf(context)?.requestSample();
+/// ```
+///
+/// ## Known limit: PlatformViews
+///
+/// Content rendered by an iOS PlatformView (e.g. a map) cannot be captured
+/// by `toImage` — the same wall as `platformViewBackdrop`. For those
+/// screens, drive the appearance explicitly with
+/// `GlassBottomBar.brightnessOverride` (which bypasses the sampler
+/// entirely) keyed off your own signal, such as the active map style.
+///
+/// See also:
+///
+/// * [GlassContentAwareContent], which marks the sampled region.
+/// * [GlassContentAwareBrightness], the per-control consumer used by the
+///   bars and available to custom controls.
+class GlassContentAwareScope extends StatefulWidget {
+  /// Creates a content-aware brightness scope.
+  const GlassContentAwareScope({
+    required this.child,
+    this.sampleInterval = const Duration(milliseconds: 180),
+    this.flipDuration = const Duration(milliseconds: 200),
+    this.flipCurve = Curves.easeInOut,
+    this.lightToDarkThreshold = 0.6,
+    this.darkToLightThreshold = 0.6,
+    this.backgroundColor,
+    super.key,
+  })  : assert(
+          lightToDarkThreshold >= 0.5 && lightToDarkThreshold <= 1.0,
+          'lightToDarkThreshold must be within [0.5, 1.0]',
+        ),
+        assert(
+          darkToLightThreshold >= 0.5 && darkToLightThreshold <= 1.0,
+          'darkToLightThreshold must be within [0.5, 1.0]',
+        );
+
+  /// The subtree containing both the sampled content and the adaptive
+  /// controls.
+  final Widget child;
+
+  /// Minimum interval between samples while scrolling is active.
+  ///
+  /// Scrolling starts a periodic sampler at this rate; when scrolling ends
+  /// the sampler stops (after one trailing sample), so idle screens cost
+  /// nothing. Defaults to 180 ms — roughly 5 samples per second during an
+  /// active scroll, which tracks content changes without competing with
+  /// frame production.
+  final Duration sampleInterval;
+
+  /// Duration of the light ⇄ dark cross-fade when a control flips.
+  ///
+  /// Applied by every [GlassContentAwareBrightness] registered in this
+  /// scope. Defaults to 200 ms, matching the iOS 26 appearance transition.
+  final Duration flipDuration;
+
+  /// Curve of the light ⇄ dark cross-fade when a control flips.
+  final Curve flipCurve;
+
+  /// Vote fraction required to flip a control from light to dark.
+  ///
+  /// A control in its light appearance flips dark only when at least this
+  /// fraction of its grid cells vote for light glyphs (dark appearance).
+  /// Together with [darkToLightThreshold] this forms a hysteresis band:
+  /// content sitting right at the contrast boundary cannot flap the control
+  /// back and forth. Must be within `[0.5, 1.0]`; defaults to 0.6.
+  final double lightToDarkThreshold;
+
+  /// Vote fraction required to flip a control from dark back to light.
+  ///
+  /// The counterpart to [lightToDarkThreshold]. Must be within
+  /// `[0.5, 1.0]`; defaults to 0.6.
+  final double darkToLightThreshold;
+
+  /// Color substituted for fully transparent pixels in the capture.
+  ///
+  /// The content boundary may not paint every pixel (e.g. a transparent
+  /// scaffold background). Transparent pixels are evaluated as this color so
+  /// the vote reflects what the user actually sees behind the control. When
+  /// null, defaults to white in light mode and black in dark mode.
+  final Color? backgroundColor;
+
+  /// The [GlassContentAwareScopeState] from the closest enclosing scope, or
+  /// null if there is none.
+  ///
+  /// Used by [GlassContentAwareBrightness] (and available to custom
+  /// controls) to register for verdicts.
+  static GlassContentAwareScopeState? maybeOf(BuildContext context) {
+    final marker = context
+        .dependOnInheritedWidgetOfExactType<_ContentAwareScopeMarker>();
+    return marker?.state;
+  }
+
+  /// Decides a control's [Brightness] from a raw RGBA capture.
+  ///
+  /// Exposed for tests; production code goes through the sampling pipeline.
+  /// [cellRects] are the control's grid cells in pixel coordinates of the
+  /// [width]×[height] image. Each cell votes via WCAG contrast (light
+  /// variant's dark glyphs vs dark variant's light glyphs over the cell's
+  /// average color, with [background] substituted for transparent pixels);
+  /// the verdict applies sticky ties and the dual-threshold hysteresis
+  /// described on [GlassContentAwareScope].
+  @visibleForTesting
+  static Brightness computeVerdict({
+    required Uint8List rgba,
+    required int width,
+    required int height,
+    required List<Rect> cellRects,
+    required Brightness current,
+    required double lightToDarkThreshold,
+    required double darkToLightThreshold,
+    required Color background,
+  }) {
+    if (width <= 0 || height <= 0) return current;
+    var votesLight = 0;
+    var votesDark = 0;
+    for (final r in cellRects) {
+      final x0 = r.left.floor().clamp(0, width - 1);
+      final x1 = r.right.ceil().clamp(x0 + 1, width);
+      final y0 = r.top.floor().clamp(0, height - 1);
+      final y1 = r.bottom.ceil().clamp(y0 + 1, height);
+      var sumR = 0.0, sumG = 0.0, sumB = 0.0;
+      var n = 0;
+      for (var y = y0; y < y1; y++) {
+        for (var x = x0; x < x1; x++) {
+          final i = (y * width + x) * 4;
+          final a = rgba[i + 3] / 255.0;
+          if (a < 0.02) {
+            // Unpainted pixel — evaluate as the page background.
+            sumR += background.r;
+            sumG += background.g;
+            sumB += background.b;
+          } else {
+            sumR += rgba[i] / 255.0;
+            sumG += rgba[i + 1] / 255.0;
+            sumB += rgba[i + 2] / 255.0;
+          }
+          n++;
+        }
+      }
+      if (n == 0) continue;
+      final cellLuma = _wcagLuma(sumR / n, sumG / n, sumB / n);
+      // Which glyph reads better over this cell? The light variant uses dark
+      // glyphs, the dark variant uses light glyphs. Dark glyphs hold
+      // contrast over light AND medium content; light glyphs only win once
+      // the content is genuinely dark — so the vote keeps controls light
+      // through the medium range and flips late, like the native bars.
+      final lightVariantContrast =
+          _contrast(_lightVariantGlyphLuma, cellLuma);
+      final darkVariantContrast = _contrast(_darkVariantGlyphLuma, cellLuma);
+      if (lightVariantContrast >= darkVariantContrast) {
+        votesLight++;
+      } else {
+        votesDark++;
+      }
+    }
+    final total = votesLight + votesDark;
+    if (total == 0) return current;
+    // Dual-threshold hysteresis on top of sticky ties: each direction needs
+    // a supermajority, so boundary content keeps the current appearance.
+    if (current == Brightness.light) {
+      return votesDark / total >= lightToDarkThreshold
+          ? Brightness.dark
+          : Brightness.light;
+    }
+    return votesLight / total >= darkToLightThreshold
+        ? Brightness.light
+        : Brightness.dark;
+  }
+
+  /// WCAG relative luminance of the light variant's glyphs (near-black).
+  static const double _lightVariantGlyphLuma = 0.0;
+
+  /// WCAG relative luminance of the dark variant's glyphs (white).
+  static const double _darkVariantGlyphLuma = 1.0;
+
+  /// WCAG contrast ratio between two relative luminances.
+  static double _contrast(double l1, double l2) {
+    final hi = math.max(l1, l2);
+    final lo = math.min(l1, l2);
+    return (hi + 0.05) / (lo + 0.05);
+  }
+
+  /// WCAG relative luminance from non-linear sRGB channels in `[0, 1]`.
+  static double _wcagLuma(double r, double g, double b) {
+    double lin(double c) => c <= 0.03928
+        ? c / 12.92
+        : math.pow((c + 0.055) / 1.055, 2.4).toDouble();
+    return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+  }
+
+  @override
+  State<GlassContentAwareScope> createState() =>
+      GlassContentAwareScopeState();
+}
+
+/// State (and registration surface) of a [GlassContentAwareScope].
+///
+/// Custom controls obtain this via [GlassContentAwareScope.maybeOf] and call
+/// [register]; the bars do this internally through
+/// [GlassContentAwareBrightness].
+class GlassContentAwareScopeState extends State<GlassContentAwareScope> {
+  final List<GlassContentAwareSubscription> _subscriptions =
+      <GlassContentAwareSubscription>[];
+  GlobalKey? _contentKey;
+  Timer? _scrollTimer;
+  bool _samplePending = false;
+  bool _sampling = false;
+
+  /// Fraction of a control's height trimmed from the top and bottom before
+  /// gridding. Glyphs sit in the vertical middle of a control; edge rows
+  /// would bias the vote with content that never sits behind a glyph.
+  static const double _kVerticalInsetFraction = 0.18;
+
+  /// Capture downscale target: physical pixels per grid cell edge.
+  static const double _kTargetCellPixels = 16.0;
+
+  /// Registers a glass control to receive content-aware verdicts.
+  ///
+  /// [controlBox] returns the control's render box at sample time (or null
+  /// while it is unmounted — the control is skipped for that sample). The
+  /// control's rectangle is divided into [gridColumns] × [gridRows] voting
+  /// cells — 6×1 suits wide bars; a compact button would use a square grid.
+  /// [onBrightnessChanged] fires only when the verdict actually flips;
+  /// [initialBrightness] seeds the hysteresis state.
+  ///
+  /// Call [GlassContentAwareSubscription.cancel] when the control goes away.
+  GlassContentAwareSubscription register({
+    required RenderBox? Function() controlBox,
+    required ValueChanged<Brightness> onBrightnessChanged,
+    required Brightness initialBrightness,
+    int gridColumns = 6,
+    int gridRows = 1,
+  }) {
+    assert(gridColumns > 0 && gridRows > 0, 'Grid must have at least 1 cell');
+    final sub = GlassContentAwareSubscription._(
+      this,
+      controlBox,
+      onBrightnessChanged,
+      gridColumns,
+      gridRows,
+      initialBrightness,
+    );
+    _subscriptions.add(sub);
+    requestSample();
+    return sub;
+  }
+
+  /// Schedules a single sample after the next frame.
+  ///
+  /// Coalesces multiple requests; used for the initial verdict, trailing
+  /// scroll-end samples, and external invalidation (e.g. the app theme
+  /// changed). Sampling only happens when content is registered, so this is
+  /// free on screens without a [GlassContentAwareContent].
+  void requestSample() {
+    if (_samplePending || !mounted) return;
+    _samplePending = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _samplePending = false;
+      unawaited(_sample());
+    });
+    // Make sure a frame actually comes — the screen may be fully idle.
+    WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
+  /// Runs one sample immediately and returns when verdicts are delivered.
+  @visibleForTesting
+  Future<void> sampleNow() => _sample();
+
+  /// Whether the periodic scroll sampler is currently running.
+  @visibleForTesting
+  bool get isScrollSamplingActive => _scrollTimer != null;
+
+  void _attachContent(GlobalKey boundaryKey) {
+    assert(
+      _contentKey == null || _contentKey == boundaryKey,
+      'A GlassContentAwareScope supports a single GlassContentAwareContent. '
+      'Found a second content region under the same scope.',
+    );
+    _contentKey = boundaryKey;
+    requestSample();
+  }
+
+  void _detachContent(GlobalKey boundaryKey) {
+    if (_contentKey == boundaryKey) _contentKey = null;
+  }
+
+  bool _onScrollNotification(ScrollNotification notification) {
+    if (notification is ScrollStartNotification) {
+      _startScrollSampling();
+    } else if (notification is ScrollEndNotification) {
+      _stopScrollSampling();
+    } else if (notification is ScrollUpdateNotification ||
+        notification is OverscrollNotification) {
+      // A Start may have been swallowed (e.g. programmatic jumps) — make
+      // sure the sampler runs whenever positions are actually moving.
+      _startScrollSampling();
+    }
+    return false;
+  }
+
+  bool _onScrollMetrics(ScrollMetricsNotification notification) {
+    // Content geometry changed without a scroll (new items, viewport
+    // resize). One sample keeps idle verdicts honest; the periodic sampler
+    // already covers the scrolling case.
+    if (_scrollTimer == null) requestSample();
+    return false;
+  }
+
+  void _startScrollSampling() {
+    if (_scrollTimer != null) return;
+    requestSample();
+    _scrollTimer = Timer.periodic(
+      widget.sampleInterval,
+      (_) => unawaited(_sample()),
+    );
+  }
+
+  void _stopScrollSampling() {
+    if (_scrollTimer == null) return;
+    _scrollTimer!.cancel();
+    _scrollTimer = null;
+    // Trailing sample so the settled content decides the resting verdict.
+    requestSample();
+  }
+
+  @override
+  void didUpdateWidget(GlassContentAwareScope oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.sampleInterval != widget.sampleInterval &&
+        _scrollTimer != null) {
+      _scrollTimer!.cancel();
+      _scrollTimer = Timer.periodic(
+        widget.sampleInterval,
+        (_) => unawaited(_sample()),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollTimer?.cancel();
+    _scrollTimer = null;
+    for (final sub in _subscriptions) {
+      sub._cancelled = true;
+    }
+    _subscriptions.clear();
+    super.dispose();
+  }
+
+  Future<void> _sample() async {
+    if (!mounted || _sampling || _subscriptions.isEmpty) return;
+    final boundary = _contentKey?.currentContext?.findRenderObject();
+    if (boundary is! RenderRepaintBoundary ||
+        !boundary.hasSize ||
+        boundary.size.isEmpty) {
+      return;
+    }
+    // Skip frames that are mid-paint. debugNeedsPaint is DEBUG-ONLY — its
+    // backing value is assigned inside an assert, so reading it in profile
+    // or release builds throws. Only consult it behind an assert closure;
+    // release builds sample post-frame where the boundary is always clean.
+    var midPaint = false;
+    assert(() {
+      midPaint = boundary.debugNeedsPaint;
+      return true;
+    }());
+    if (midPaint) return;
+    _sampling = true;
+    try {
+      // Resolve each registered control's grid cells in boundary-local
+      // coordinates, and the smallest cell height for the downscale factor.
+      final work = <(GlassContentAwareSubscription, List<Rect>)>[];
+      var minCellExtent = double.infinity;
+      for (final sub in List.of(_subscriptions)) {
+        final box = sub._controlBox();
+        if (box == null || !box.attached || !box.hasSize) continue;
+        final origin = boundary.globalToLocal(box.localToGlobal(Offset.zero));
+        var rect = origin & box.size;
+        final inset = rect.height * _kVerticalInsetFraction;
+        rect = Rect.fromLTRB(
+          rect.left,
+          rect.top + inset,
+          rect.right,
+          rect.bottom - inset,
+        ).intersect(Offset.zero & boundary.size);
+        if (rect.isEmpty) continue;
+        final cellW = rect.width / sub.gridColumns;
+        final cellH = rect.height / sub.gridRows;
+        final cells = <Rect>[
+          for (var gy = 0; gy < sub.gridRows; gy++)
+            for (var gx = 0; gx < sub.gridColumns; gx++)
+              Rect.fromLTWH(
+                rect.left + gx * cellW,
+                rect.top + gy * cellH,
+                cellW,
+                cellH,
+              ),
+        ];
+        minCellExtent = math.min(minCellExtent, cellH);
+        work.add((sub, cells));
+      }
+      if (work.isEmpty) return;
+
+      // Downscale so a cell maps to ~16 physical pixels — enough for a
+      // stable average, cheap enough to read back at scroll rates.
+      final pixelRatio = (_kTargetCellPixels / math.max(minCellExtent, 1.0))
+          .clamp(0.05, 0.5);
+      final image = await boundary.toImage(pixelRatio: pixelRatio);
+      final width = image.width;
+      final height = image.height;
+      final byteData =
+          await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      image.dispose();
+      if (!mounted || byteData == null) return;
+      final rgba = byteData.buffer.asUint8List();
+      final background = widget.backgroundColor ??
+          (MediaQuery.maybePlatformBrightnessOf(context) == Brightness.dark
+              ? const Color(0xFF000000)
+              : const Color(0xFFFFFFFF));
+
+      for (final (sub, cells) in work) {
+        if (sub._cancelled) continue;
+        final pixelCells = <Rect>[
+          for (final c in cells)
+            Rect.fromLTRB(
+              c.left * pixelRatio,
+              c.top * pixelRatio,
+              c.right * pixelRatio,
+              c.bottom * pixelRatio,
+            ),
+        ];
+        final verdict = GlassContentAwareScope.computeVerdict(
+          rgba: rgba,
+          width: width,
+          height: height,
+          cellRects: pixelCells,
+          current: sub._brightness,
+          lightToDarkThreshold: widget.lightToDarkThreshold,
+          darkToLightThreshold: widget.darkToLightThreshold,
+          background: background,
+        );
+        if (verdict != sub._brightness) {
+          sub._brightness = verdict;
+          sub._onBrightnessChanged(verdict);
+        }
+      }
+    } catch (_) {
+      // Transient capture failure (boundary mid-mutation, detached layer).
+      // The next scroll tick retries; never let sampling take a screen down.
+    } finally {
+      _sampling = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _ContentAwareScopeMarker(
+      state: this,
+      child: NotificationListener<ScrollMetricsNotification>(
+        onNotification: _onScrollMetrics,
+        child: NotificationListener<ScrollNotification>(
+          onNotification: _onScrollNotification,
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+}
+
+/// A live registration of a glass control with a [GlassContentAwareScope].
+///
+/// Returned by [GlassContentAwareScopeState.register]. Holds the control's
+/// hysteresis state; [cancel] detaches the control from the scope.
+class GlassContentAwareSubscription {
+  GlassContentAwareSubscription._(
+    this._scope,
+    this._controlBox,
+    this._onBrightnessChanged,
+    this.gridColumns,
+    this.gridRows,
+    this._brightness,
+  );
+
+  final GlassContentAwareScopeState _scope;
+  final RenderBox? Function() _controlBox;
+  final ValueChanged<Brightness> _onBrightnessChanged;
+
+  /// Number of horizontal voting cells for this control.
+  final int gridColumns;
+
+  /// Number of vertical voting cells for this control.
+  final int gridRows;
+
+  Brightness _brightness;
+  bool _cancelled = false;
+
+  /// The control's current content-aware verdict.
+  Brightness get brightness => _brightness;
+
+  /// Detaches the control from the scope. Safe to call more than once.
+  void cancel() {
+    if (_cancelled) return;
+    _cancelled = true;
+    _scope._subscriptions.remove(this);
+  }
+}
+
+class _ContentAwareScopeMarker extends InheritedWidget {
+  const _ContentAwareScopeMarker({
+    required this.state,
+    required super.child,
+  });
+
+  final GlassContentAwareScopeState state;
+
+  @override
+  bool updateShouldNotify(_ContentAwareScopeMarker oldWidget) =>
+      state != oldWidget.state;
+}
+
+/// Marks the sampled content region of a [GlassContentAwareScope].
+///
+/// Wrap the scrolling content — and only the content — in this widget. It
+/// installs the [RepaintBoundary] that the scope captures, so the adaptive
+/// glass controls themselves must stay **outside** of it (e.g. in
+/// `Scaffold.bottomNavigationBar` with `extendBody: true`); otherwise the
+/// capture would see the controls' own rendering instead of the content
+/// behind them.
+///
+/// A scope supports a single content region. Without one, the scope never
+/// samples and adaptive controls keep their ambient appearance.
+class GlassContentAwareContent extends StatefulWidget {
+  /// Creates a sampled content region.
+  const GlassContentAwareContent({required this.child, super.key});
+
+  /// The scrolling content to sample.
+  final Widget child;
+
+  @override
+  State<GlassContentAwareContent> createState() =>
+      _GlassContentAwareContentState();
+}
+
+class _GlassContentAwareContentState extends State<GlassContentAwareContent> {
+  final GlobalKey _boundaryKey = GlobalKey();
+  GlassContentAwareScopeState? _scope;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final scope = GlassContentAwareScope.maybeOf(context);
+    if (scope != _scope) {
+      _scope?._detachContent(_boundaryKey);
+      _scope = scope;
+      _scope?._attachContent(_boundaryKey);
+    }
+  }
+
+  @override
+  void dispose() {
+    _scope?._detachContent(_boundaryKey);
+    _scope = null;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(key: _boundaryKey, child: widget.child);
+  }
+}
+
+/// Gives a single glass control a content-aware light/dark appearance.
+///
+/// This is the per-control consumer of [GlassContentAwareScope] — the bars
+/// use it internally when `adaptiveBrightness: true`, and custom glass
+/// controls can wrap themselves in it directly.
+///
+/// The widget resolves the control's [Brightness] from one of three
+/// sources, in priority order:
+///
+/// 1. [brightnessOverride] — an external [ValueListenable] that bypasses
+///    the sampler entirely. Use this over PlatformViews, where the content
+///    cannot be captured, and drive it from your own signal.
+/// 2. The enclosing [GlassContentAwareScope], by registering the control's
+///    rectangle for the per-control contrast vote.
+/// 3. The ambient platform brightness, when neither is available.
+///
+/// Every verdict change cross-fades rather than snapping: an internal
+/// animation eases `darkAmount` between 0 (light) and 1 (dark) over
+/// [flipDuration] with [flipCurve] (falling back to the scope's values,
+/// then to 200 ms / [Curves.easeInOut]). During the fade the subtree built
+/// by [builder] is wrapped so the swap "just works" end to end:
+///
+/// - [GlassTheme] is replaced with the lerp of its light and dark variants
+///   (see [GlassThemeVariant.lerp]) — themed glass settings, glow palettes
+///   and radii cross-fade smoothly.
+/// - `MediaQuery.platformBrightness` and the [CupertinoTheme] brightness
+///   flip at the fade midpoint, where the blend makes the discrete residue
+///   (shadows, resolved dynamic colors in user content) least visible.
+///
+/// [onBrightnessChanged] fires once per verdict flip — use it to swap
+/// colors the package cannot see, such as custom-painted icons.
+class GlassContentAwareBrightness extends StatefulWidget {
+  /// Creates a content-aware brightness consumer around [builder].
+  const GlassContentAwareBrightness({
+    required this.builder,
+    this.brightnessOverride,
+    this.onBrightnessChanged,
+    this.flipDuration,
+    this.flipCurve,
+    this.gridColumns = 6,
+    this.gridRows = 1,
+    super.key,
+  }) : assert(
+          gridColumns > 0 && gridRows > 0,
+          'Grid must have at least 1 cell',
+        );
+
+  /// Builds the control under the brightness overrides.
+  ///
+  /// See [GlassBrightnessWidgetBuilder] for the parameters.
+  final GlassBrightnessWidgetBuilder builder;
+
+  /// External brightness source that bypasses the sampler entirely.
+  ///
+  /// When non-null, the control never registers with the scope and follows
+  /// this listenable instead — the escape hatch for content that cannot be
+  /// captured (iOS PlatformViews such as maps).
+  final ValueListenable<Brightness>? brightnessOverride;
+
+  /// Called when the committed verdict flips (not for the initial value).
+  final ValueChanged<Brightness>? onBrightnessChanged;
+
+  /// Cross-fade duration override; falls back to the scope's
+  /// [GlassContentAwareScope.flipDuration], then 200 ms.
+  final Duration? flipDuration;
+
+  /// Cross-fade curve override; falls back to the scope's
+  /// [GlassContentAwareScope.flipCurve], then [Curves.easeInOut].
+  final Curve? flipCurve;
+
+  /// Horizontal voting cells for this control's rect. Defaults to 6 — the
+  /// bar-shaped grid. Compact controls should use a square grid (e.g. 2×2).
+  final int gridColumns;
+
+  /// Vertical voting cells for this control's rect. Defaults to 1.
+  final int gridRows;
+
+  @override
+  State<GlassContentAwareBrightness> createState() =>
+      _GlassContentAwareBrightnessState();
+}
+
+class _GlassContentAwareBrightnessState
+    extends State<GlassContentAwareBrightness>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _flip;
+  late Brightness _brightness;
+  Brightness? _lastAmbient;
+  bool _initialized = false;
+  GlassContentAwareScopeState? _scope;
+  GlassContentAwareSubscription? _subscription;
+
+  static const Duration _kDefaultFlipDuration = Duration(milliseconds: 200);
+
+  @override
+  void initState() {
+    super.initState();
+    _flip = AnimationController(vsync: this, duration: _kDefaultFlipDuration);
+    widget.brightnessOverride?.addListener(_onOverrideChanged);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final ambient =
+        MediaQuery.maybePlatformBrightnessOf(context) ?? Brightness.light;
+    if (!_initialized) {
+      _initialized = true;
+      _brightness = widget.brightnessOverride?.value ?? ambient;
+      _flip.value = _brightness == Brightness.dark ? 1.0 : 0.0;
+    } else if (_lastAmbient != ambient && widget.brightnessOverride == null) {
+      // The app theme flipped underneath us — the old verdict was computed
+      // against content that just restyled. Re-anchor to the ambient
+      // brightness and let the next sample re-vote.
+      _setBrightness(ambient);
+      _scope?.requestSample();
+    }
+    _lastAmbient = ambient;
+  }
+
+  @override
+  void didUpdateWidget(GlassContentAwareBrightness oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.brightnessOverride != widget.brightnessOverride) {
+      oldWidget.brightnessOverride?.removeListener(_onOverrideChanged);
+      widget.brightnessOverride?.addListener(_onOverrideChanged);
+      final override = widget.brightnessOverride;
+      if (override != null) _setBrightness(override.value);
+      // Scope registration is re-resolved in build via _syncSources.
+    }
+    if (oldWidget.gridColumns != widget.gridColumns ||
+        oldWidget.gridRows != widget.gridRows) {
+      // Grid changed — drop the registration; build re-registers with the
+      // new dimensions.
+      _subscription?.cancel();
+      _subscription = null;
+      _scope = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.brightnessOverride?.removeListener(_onOverrideChanged);
+    _subscription?.cancel();
+    _flip.dispose();
+    super.dispose();
+  }
+
+  void _onOverrideChanged() {
+    _setBrightness(widget.brightnessOverride!.value);
+  }
+
+  void _setBrightness(Brightness brightness) {
+    if (brightness == _brightness) return;
+    _brightness = brightness;
+    widget.onBrightnessChanged?.call(brightness);
+    final duration = widget.flipDuration ??
+        _scope?.widget.flipDuration ??
+        _kDefaultFlipDuration;
+    final curve =
+        widget.flipCurve ?? _scope?.widget.flipCurve ?? Curves.easeInOut;
+    _flip.animateTo(
+      brightness == Brightness.dark ? 1.0 : 0.0,
+      duration: duration,
+      curve: curve,
+    );
+    if (mounted) setState(() {});
+  }
+
+  /// Keeps the scope registration in sync with the widget configuration.
+  ///
+  /// Runs at the top of build (inherited lookups are legal there and this
+  /// is where dependencies must be registered anyway) and is idempotent.
+  void _syncSources() {
+    final wantScope = widget.brightnessOverride == null
+        ? GlassContentAwareScope.maybeOf(context)
+        : null;
+    if (wantScope == _scope && (_subscription != null) == (wantScope != null)) {
+      return;
+    }
+    _subscription?.cancel();
+    _subscription = null;
+    _scope = wantScope;
+    if (wantScope != null) {
+      _subscription = wantScope.register(
+        controlBox: () {
+          if (!mounted) return null;
+          final ro = context.findRenderObject();
+          return ro is RenderBox ? ro : null;
+        },
+        onBrightnessChanged: _setBrightness,
+        initialBrightness: _brightness,
+        gridColumns: widget.gridColumns,
+        gridRows: widget.gridRows,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _syncSources();
+    return AnimatedBuilder(
+      animation: _flip,
+      builder: (context, _) {
+        final t = _flip.value;
+        // The discrete residue (shadow gating, dynamic-color resolution in
+        // user content) flips at the fade midpoint, where the lerped colors
+        // cross and the swap is least visible.
+        final displayBrightness =
+            t >= 0.5 ? Brightness.dark : Brightness.light;
+        final baseTheme = GlassThemeData.of(context);
+        final variant = GlassThemeVariant.lerp(
+          baseTheme.light,
+          baseTheme.dark,
+          t,
+        );
+        Widget result = Builder(
+          builder: (inner) => widget.builder(inner, _brightness, t),
+        );
+        result = GlassTheme(
+          data: baseTheme.copyWith(light: variant, dark: variant),
+          child: result,
+        );
+        result = CupertinoTheme(
+          data: CupertinoTheme.of(context)
+              .copyWith(brightness: displayBrightness),
+          child: result,
+        );
+        final mq = MediaQuery.maybeOf(context);
+        if (mq != null) {
+          result = MediaQuery(
+            data: mq.copyWith(platformBrightness: displayBrightness),
+            child: result,
+          );
+        }
+        return result;
+      },
+    );
+  }
+}

--- a/lib/widgets/surfaces/glass_bottom_bar.dart
+++ b/lib/widgets/surfaces/glass_bottom_bar.dart
@@ -8,11 +8,13 @@
 
 import 'dart:ui' as ui;
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show ValueListenable;
 import '../../src/renderer/liquid_glass_renderer.dart';
 
 import '../../types/glass_quality.dart';
 import '../interactive/glass_button.dart';
 import '../shared/adaptive_liquid_glass_layer.dart';
+import '../shared/glass_content_aware_scope.dart';
 import '../shared/inherited_liquid_glass.dart';
 import '../../theme/glass_theme_data.dart';
 import '../../theme/glass_theme_helpers.dart';
@@ -22,7 +24,8 @@ import 'shared/bottom_bar_internal.dart'
         BottomBarExtraBtn,
         BottomBarTabItem,
         TabIndicator,
-        kBottomBarGlassDefaults;
+        kBottomBarGlassDefaults,
+        resolveBarLabelColor;
 import 'shared/bar_layout_utils.dart';
 
 /// A glass morphism bottom navigation bar following Apple's design patterns.
@@ -224,6 +227,9 @@ class GlassBottomBar extends StatefulWidget {
     this.interactionBehavior = GlassInteractionBehavior.full,
     this.pressScale = 1.04,
     this.platformViewBackdrop = false,
+    this.adaptiveBrightness = false,
+    this.onBrightnessChanged,
+    this.brightnessOverride,
   })  : assert(tabs.length > 0, 'GlassBottomBar requires at least one tab'),
         assert(
           selectedIndex >= 0 && selectedIndex < tabs.length,
@@ -281,6 +287,36 @@ class GlassBottomBar extends StatefulWidget {
   /// own icons — so premium animations survive over the PlatformView with no
   /// quality swap. Defaults to false.
   final bool platformViewBackdrop;
+
+  /// Whether the bar adapts its light/dark appearance to the content
+  /// scrolling underneath it, like the iOS 26 system bars.
+  ///
+  /// Requires an enclosing [GlassContentAwareScope] with the scrolling
+  /// content wrapped in a [GlassContentAwareContent]; without one the bar
+  /// keeps its ambient appearance. When the scope's contrast vote flips the
+  /// verdict, the bar cross-fades between the [GlassTheme] light and dark
+  /// variants — themed glass settings, glow palette and the default
+  /// icon/label colors all swap automatically.
+  ///
+  /// Defaults to false.
+  final bool adaptiveBrightness;
+
+  /// Called when the content-aware verdict flips (not for the initial
+  /// value).
+  ///
+  /// Use this to restyle elements the bar cannot see — page scrims, status
+  /// bar icons, custom-painted tab icons.
+  final ValueChanged<Brightness>? onBrightnessChanged;
+
+  /// External brightness source that bypasses the content sampler entirely.
+  ///
+  /// When non-null, the bar follows this listenable instead of registering
+  /// with the [GlassContentAwareScope] — the escape hatch for bars floating
+  /// over content that cannot be captured (iOS PlatformViews such as maps;
+  /// see [platformViewBackdrop]). Drive it from your own signal, e.g. the
+  /// active map style. Implies the adaptive behavior regardless of
+  /// [adaptiveBrightness].
+  final ValueListenable<Brightness>? brightnessOverride;
 
   /// The color of the directional glow effect when interacting with the bar.
   ///
@@ -555,6 +591,21 @@ class _GlassBottomBarState extends State<GlassBottomBar> {
 
   @override
   Widget build(BuildContext context) {
+    if (!widget.adaptiveBrightness && widget.brightnessOverride == null) {
+      return _buildBar(context, null);
+    }
+    return GlassContentAwareBrightness(
+      brightnessOverride: widget.brightnessOverride,
+      onBrightnessChanged: widget.onBrightnessChanged,
+      builder: (context, brightness, darkAmount) =>
+          _buildBar(context, darkAmount),
+    );
+  }
+
+  /// Builds the bar. [darkAmount] is the animated light→dark cross-fade
+  /// position when the adaptive brightness machinery is active, or null in
+  /// the classic (ambient-brightness) path.
+  Widget _buildBar(BuildContext context, double? darkAmount) {
     final effectiveQuality = GlassThemeHelpers.resolveQuality(
       context,
       widgetQuality: widget.quality,
@@ -568,9 +619,7 @@ class _GlassBottomBarState extends State<GlassBottomBar> {
     final effectiveInteractionGlowColor =
         widget.interactionGlowColor ?? resolvedGlowColors.primary;
 
-    final dynamicLabelColor =
-        CupertinoTheme.of(context).textTheme.textStyle.color ??
-            CupertinoColors.label;
+    final dynamicLabelColor = resolveBarLabelColor(context, darkAmount);
     final resolvedSelectedIconColor =
         widget.selectedIconColor ?? dynamicLabelColor;
     final resolvedUnselectedIconColor =

--- a/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
+++ b/lib/widgets/surfaces/glass_searchable_bottom_bar.dart
@@ -4,6 +4,7 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/physics.dart';
 
 import '../../src/renderer/liquid_glass_renderer.dart';
@@ -12,6 +13,7 @@ import '../../types/glass_quality.dart';
 import '../../theme/glass_theme_data.dart';
 import '../../theme/glass_theme_helpers.dart';
 import '../shared/adaptive_liquid_glass_layer.dart';
+import '../shared/glass_content_aware_scope.dart';
 import 'glass_bottom_bar.dart'
     show
         ExtraButtonPosition,
@@ -103,6 +105,10 @@ class GlassSearchableBottomBar extends StatefulWidget {
     this.whitenBottomThreshold = 45.0,
     this.whitenAtBottomTarget = 1.0,
     this.scrollController,
+    // ── Content-aware brightness ─────────────────────────────────────────────
+    this.adaptiveBrightness = false,
+    this.onBrightnessChanged,
+    this.brightnessOverride,
   })  : assert(tabs.length > 0,
             'GlassSearchableBottomBar requires at least one tab'),
         assert(
@@ -255,6 +261,37 @@ class GlassSearchableBottomBar extends StatefulWidget {
   /// disables the whiten-at-bottom effect — there is no scroll position to
   /// watch.
   final ScrollController? scrollController;
+
+  // ── Content-aware brightness ────────────────────────────────────────────────
+  /// Whether the bar adapts its light/dark appearance to the content
+  /// scrolling underneath it, like the iOS 26 system bars.
+  ///
+  /// Requires an enclosing [GlassContentAwareScope] with the scrolling
+  /// content wrapped in a [GlassContentAwareContent]; without one the bar
+  /// keeps its ambient appearance. When the scope's contrast vote flips the
+  /// verdict, the bar cross-fades between the [GlassTheme] light and dark
+  /// variants — themed glass settings, glow palette and the default
+  /// icon/label colors all swap automatically.
+  ///
+  /// Defaults to false.
+  final bool adaptiveBrightness;
+
+  /// Called when the content-aware verdict flips (not for the initial
+  /// value).
+  ///
+  /// Use this to restyle elements the bar cannot see — page scrims, status
+  /// bar icons, custom-painted tab icons.
+  final ValueChanged<Brightness>? onBrightnessChanged;
+
+  /// External brightness source that bypasses the content sampler entirely.
+  ///
+  /// When non-null, the bar follows this listenable instead of registering
+  /// with the [GlassContentAwareScope] — the escape hatch for bars floating
+  /// over content that cannot be captured (iOS PlatformViews such as maps;
+  /// see [platformViewBackdrop]). Drive it from your own signal, e.g. the
+  /// active map style. Implies the adaptive behavior regardless of
+  /// [adaptiveBrightness].
+  final ValueListenable<Brightness>? brightnessOverride;
 
   /// Rendering quality. Inherits from parent or defaults to [GlassQuality.premium].
   final GlassQuality? quality;
@@ -610,6 +647,21 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
 
   @override
   Widget build(BuildContext context) {
+    if (!widget.adaptiveBrightness && widget.brightnessOverride == null) {
+      return _buildBar(context, null);
+    }
+    return GlassContentAwareBrightness(
+      brightnessOverride: widget.brightnessOverride,
+      onBrightnessChanged: widget.onBrightnessChanged,
+      builder: (context, brightness, darkAmount) =>
+          _buildBar(context, darkAmount),
+    );
+  }
+
+  /// Builds the bar. [darkAmount] is the animated light→dark cross-fade
+  /// position when the adaptive brightness machinery is active, or null in
+  /// the classic (ambient-brightness) path.
+  Widget _buildBar(BuildContext context, double? darkAmount) {
     final effectiveQuality = GlassThemeHelpers.resolveQuality(
       context,
       widgetQuality: widget.quality,
@@ -623,9 +675,7 @@ class _GlassSearchableBottomBarState extends State<GlassSearchableBottomBar>
     final effectiveInteractionGlowColor =
         widget.interactionGlowColor ?? resolvedGlowColors.primary;
 
-    final dynamicLabelColor =
-        CupertinoTheme.of(context).textTheme.textStyle.color ??
-            CupertinoColors.label;
+    final dynamicLabelColor = resolveBarLabelColor(context, darkAmount);
     final resolvedSelectedIconColor =
         widget.selectedIconColor ?? dynamicLabelColor;
     final resolvedUnselectedIconColor =

--- a/lib/widgets/surfaces/shared/bottom_bar_internal.dart
+++ b/lib/widgets/surfaces/shared/bottom_bar_internal.dart
@@ -52,6 +52,29 @@ const kBottomBarGlassDefaults = LiquidGlassSettings(
 );
 
 // =============================================================================
+// resolveBarLabelColor — shared icon/label color resolution
+// =============================================================================
+
+/// Resolves the dynamic icon/label color for both bars.
+///
+/// In the classic path ([darkAmount] null) this is the Cupertino label color
+/// resolved against the ambient brightness — identical to the historical
+/// behavior. When the content-aware brightness machinery is active,
+/// [darkAmount] is the animated light→dark cross-fade position, and the
+/// color interpolates between the label's light and dark variants so glyphs
+/// fade with the rest of the appearance instead of snapping. Non-dynamic
+/// custom label colors have no variants to fade between and are returned
+/// as-is.
+Color resolveBarLabelColor(BuildContext context, double? darkAmount) {
+  final labelColor = CupertinoTheme.of(context).textTheme.textStyle.color ??
+      CupertinoColors.label;
+  if (darkAmount != null && labelColor is CupertinoDynamicColor) {
+    return Color.lerp(labelColor.color, labelColor.darkColor, darkAmount)!;
+  }
+  return labelColor;
+}
+
+// =============================================================================
 // buildIconShadows — pure utility function (visibleForTesting for unit tests)
 // =============================================================================
 

--- a/test/theme/glass_theme_lerp_test.dart
+++ b/test/theme/glass_theme_lerp_test.dart
@@ -1,0 +1,228 @@
+// ignore_for_file: require_trailing_commas
+// Unit tests for the theme variant interpolation used by the content-aware
+// brightness cross-fade:
+//   - GlassThemeSettings.lerp (smooth lerp / midpoint switch / null rules)
+//   - GlassGlowColors.lerp
+//   - GlassThemeVariant.lerp (delegation, quality + borderRadius rules)
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+void main() {
+  group('GlassThemeSettings.lerp', () {
+    test('identical instances short-circuit', () {
+      const a = GlassThemeSettings(thickness: 10);
+      expect(GlassThemeSettings.lerp(a, a, 0.3), same(a));
+      expect(GlassThemeSettings.lerp(null, null, 0.3), isNull);
+    });
+
+    test('one side null switches at the midpoint', () {
+      const b = GlassThemeSettings(thickness: 10);
+      expect(GlassThemeSettings.lerp(null, b, 0.49), isNull);
+      expect(GlassThemeSettings.lerp(null, b, 0.5), same(b));
+      expect(GlassThemeSettings.lerp(b, null, 0.49), same(b));
+      expect(GlassThemeSettings.lerp(b, null, 0.5), isNull);
+    });
+
+    test('both-non-null fields interpolate smoothly', () {
+      const a = GlassThemeSettings(
+        visibility: 0.0,
+        glassColor: Color(0xFF000000),
+        thickness: 10.0,
+        blur: 2.0,
+        chromaticAberration: 0.0,
+        lightAngle: 0.0,
+        lightIntensity: 0.5,
+        ambientStrength: 0.0,
+        refractiveIndex: 1.0,
+        saturation: 1.0,
+        specularSharpness: GlassSpecularSharpness.soft,
+      );
+      const b = GlassThemeSettings(
+        visibility: 1.0,
+        glassColor: Color(0xFFFFFFFF),
+        thickness: 30.0,
+        blur: 6.0,
+        chromaticAberration: 1.0,
+        lightAngle: 2.0,
+        lightIntensity: 1.0,
+        ambientStrength: 0.4,
+        refractiveIndex: 2.0,
+        saturation: 2.0,
+        specularSharpness: GlassSpecularSharpness.sharp,
+      );
+      final mid = GlassThemeSettings.lerp(a, b, 0.5)!;
+      expect(mid.visibility, closeTo(0.5, 1e-9));
+      expect(mid.thickness, closeTo(20.0, 1e-9));
+      expect(mid.blur, closeTo(4.0, 1e-9));
+      expect(mid.chromaticAberration, closeTo(0.5, 1e-9));
+      expect(mid.lightAngle, closeTo(1.0, 1e-9));
+      expect(mid.lightIntensity, closeTo(0.75, 1e-9));
+      expect(mid.ambientStrength, closeTo(0.2, 1e-9));
+      expect(mid.refractiveIndex, closeTo(1.5, 1e-9));
+      expect(mid.saturation, closeTo(1.5, 1e-9));
+      expect(mid.glassColor, Color.lerp(a.glassColor, b.glassColor, 0.5));
+      // Discrete enum: midpoint switch.
+      expect(mid.specularSharpness, GlassSpecularSharpness.sharp);
+      expect(
+        GlassThemeSettings.lerp(a, b, 0.49)!.specularSharpness,
+        GlassSpecularSharpness.soft,
+      );
+    });
+
+    test('one-sided null fields switch at the midpoint, not through zero', () {
+      const a = GlassThemeSettings(thickness: 30.0);
+      const b = GlassThemeSettings(blur: 6.0);
+      final early = GlassThemeSettings.lerp(a, b, 0.25)!;
+      expect(early.thickness, 30.0);
+      expect(early.blur, isNull);
+      expect(early.glassColor, isNull);
+      final late_ = GlassThemeSettings.lerp(a, b, 0.75)!;
+      expect(late_.thickness, isNull);
+      expect(late_.blur, 6.0);
+    });
+
+    test('one-sided null color switches at the midpoint', () {
+      const a = GlassThemeSettings(glassColor: Color(0xFF112233));
+      const b = GlassThemeSettings();
+      expect(
+          GlassThemeSettings.lerp(a, b, 0.2)!.glassColor, a.glassColor);
+      expect(GlassThemeSettings.lerp(a, b, 0.8)!.glassColor, isNull);
+    });
+
+    test('endpoints reproduce the inputs', () {
+      const a = GlassThemeSettings(thickness: 12.0, blur: 5.0);
+      const b = GlassThemeSettings(thickness: 10.0, blur: 4.0);
+      final at0 = GlassThemeSettings.lerp(a, b, 0.0)!;
+      final at1 = GlassThemeSettings.lerp(a, b, 1.0)!;
+      expect(at0, a);
+      expect(at1, b);
+    });
+  });
+
+  group('GlassGlowColors.lerp', () {
+    test('identical instances short-circuit', () {
+      const a = GlassGlowColors.fallback;
+      expect(GlassGlowColors.lerp(a, a, 0.4), same(a));
+      expect(GlassGlowColors.lerp(null, null, 0.4), isNull);
+    });
+
+    test('one side null switches at the midpoint', () {
+      const b = GlassGlowColors.fallback;
+      expect(GlassGlowColors.lerp(null, b, 0.4), isNull);
+      expect(GlassGlowColors.lerp(null, b, 0.6), same(b));
+      expect(GlassGlowColors.lerp(b, null, 0.4), same(b));
+      expect(GlassGlowColors.lerp(b, null, 0.6), isNull);
+    });
+
+    test('color fields lerp when set on both sides', () {
+      const a = GlassGlowColors(
+        primary: Color(0xFF000000),
+        secondary: Color(0xFF000000),
+        success: Color(0xFF000000),
+        warning: Color(0xFF000000),
+        danger: Color(0xFF000000),
+        info: Color(0xFF000000),
+        glowBlurRadius: 0.0,
+        glowSpreadRadius: 0.0,
+        glowOpacity: 0.0,
+      );
+      const b = GlassGlowColors(
+        primary: Color(0xFFFFFFFF),
+        secondary: Color(0xFFFFFFFF),
+        success: Color(0xFFFFFFFF),
+        warning: Color(0xFFFFFFFF),
+        danger: Color(0xFFFFFFFF),
+        info: Color(0xFFFFFFFF),
+        glowBlurRadius: 8.0,
+        glowSpreadRadius: 2.0,
+        glowOpacity: 1.0,
+      );
+      final mid = GlassGlowColors.lerp(a, b, 0.5)!;
+      final expected = Color.lerp(const Color(0xFF000000),
+          const Color(0xFFFFFFFF), 0.5);
+      expect(mid.primary, expected);
+      expect(mid.secondary, expected);
+      expect(mid.success, expected);
+      expect(mid.warning, expected);
+      expect(mid.danger, expected);
+      expect(mid.info, expected);
+      expect(mid.glowBlurRadius, closeTo(4.0, 1e-9));
+      expect(mid.glowSpreadRadius, closeTo(1.0, 1e-9));
+      expect(mid.glowOpacity, closeTo(0.5, 1e-9));
+    });
+
+    test('runtime-resolved (null) primary switches at the midpoint', () {
+      // GlassGlowColors.fallback has primary == null ("resolve at runtime").
+      const a = GlassGlowColors.fallback;
+      const b = GlassGlowColors(primary: Color(0xFF123456));
+      expect(GlassGlowColors.lerp(a, b, 0.3)!.primary, isNull);
+      expect(GlassGlowColors.lerp(a, b, 0.7)!.primary,
+          const Color(0xFF123456));
+      // Scalars still interpolate even when colors switch discretely.
+      expect(GlassGlowColors.lerp(a, b, 0.3)!.glowBlurRadius,
+          closeTo(0.7 * a.glowBlurRadius + 0.3 * b.glowBlurRadius, 1e-9));
+    });
+  });
+
+  group('GlassThemeVariant.lerp', () {
+    test('identical instances short-circuit', () {
+      const a = GlassThemeVariant.light;
+      expect(GlassThemeVariant.lerp(a, a, 0.4), same(a));
+    });
+
+    test('delegates settings and glowColors, switches quality at midpoint',
+        () {
+      const a = GlassThemeVariant(
+        settings: GlassThemeSettings(thickness: 12.0),
+        quality: GlassQuality.standard,
+        glowColors: GlassGlowColors(glowOpacity: 0.0),
+        borderRadius: 10.0,
+      );
+      const b = GlassThemeVariant(
+        settings: GlassThemeSettings(thickness: 10.0),
+        quality: GlassQuality.premium,
+        glowColors: GlassGlowColors(glowOpacity: 1.0),
+        borderRadius: 30.0,
+      );
+      final early = GlassThemeVariant.lerp(a, b, 0.25);
+      expect(early.settings!.thickness, closeTo(11.5, 1e-9));
+      expect(early.quality, GlassQuality.standard);
+      expect(early.glowColors!.glowOpacity, closeTo(0.25, 1e-9));
+      expect(early.borderRadius, closeTo(15.0, 1e-9));
+      final late_ = GlassThemeVariant.lerp(a, b, 0.75);
+      expect(late_.quality, GlassQuality.premium);
+      expect(late_.borderRadius, closeTo(25.0, 1e-9));
+    });
+
+    test('one-sided borderRadius switches at the midpoint', () {
+      const a = GlassThemeVariant(borderRadius: 12.0);
+      const b = GlassThemeVariant();
+      expect(GlassThemeVariant.lerp(a, b, 0.2).borderRadius, 12.0);
+      expect(GlassThemeVariant.lerp(a, b, 0.8).borderRadius, isNull);
+    });
+
+    test('lerping the built-in light and dark variants is well-formed', () {
+      final mid =
+          GlassThemeVariant.lerp(GlassThemeVariant.light, GlassThemeVariant.dark, 0.5);
+      expect(mid.settings!.thickness, closeTo(11.0, 1e-9));
+      expect(mid.settings!.blur, closeTo(4.5, 1e-9));
+      expect(mid.quality, isNull);
+      expect(mid.glowColors, isNotNull);
+      // Endpoints reproduce the variants' settings exactly.
+      expect(
+        GlassThemeVariant.lerp(
+                GlassThemeVariant.light, GlassThemeVariant.dark, 0.0)
+            .settings,
+        GlassThemeVariant.light.settings,
+      );
+      expect(
+        GlassThemeVariant.lerp(
+                GlassThemeVariant.light, GlassThemeVariant.dark, 1.0)
+            .settings,
+        GlassThemeVariant.dark.settings,
+      );
+    });
+  });
+}

--- a/test/widgets/shared/glass_content_aware_scope_coverage_test.dart
+++ b/test/widgets/shared/glass_content_aware_scope_coverage_test.dart
@@ -1,0 +1,576 @@
+// ignore_for_file: require_trailing_commas
+// Coverage-targeted tests for the content-aware brightness system.
+// These exercise branches NOT covered by glass_content_aware_scope_test.dart:
+//   - requestSample coalescing and after-dispose guard
+//   - manual register(): custom grids, brightness getter, double cancel,
+//     cancel-during-delivery, null/throwing controlBox providers
+//   - second GlassContentAwareContent assert + non-matching detach
+//   - synthetic scroll notifications: double Start, End without Start,
+//     Overscroll, UserScroll fall-through, ScrollMetrics (idle vs scrolling)
+//   - didUpdateWidget sampleInterval restart (active and idle)
+//   - _sample early returns: no content, no subscriptions, control outside
+//     the boundary, all-controls-skipped
+//   - backgroundColor: explicit param and ambient-dark default
+//   - consumer flipDuration/flipCurve precedence (widget > scope > default)
+//   - consumer didUpdateWidget: override swaps and grid changes
+//   - consumer without MediaQuery ancestor
+
+import 'package:flutter/foundation.dart' show ValueListenable;
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+Future<void> _settleSample(
+  WidgetTester tester,
+  GlassContentAwareScopeState scope,
+) {
+  return tester.runAsync(() async {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await scope.sampleNow();
+  });
+}
+
+ScrollMetrics _metrics() => FixedScrollMetrics(
+      minScrollExtent: 0,
+      maxScrollExtent: 1000,
+      pixels: 100,
+      viewportDimension: 600,
+      axisDirection: AxisDirection.down,
+      devicePixelRatio: 3.0,
+    );
+
+void main() {
+  group('GlassContentAwareScopeState — sampling guards', () {
+    testWidgets('requestSample coalesces and is a no-op after dispose',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(child: Container()),
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      scope.requestSample();
+      scope.requestSample(); // coalesced — _samplePending short-circuits
+      await tester.pump();
+      // Dispose, then request again: the !mounted guard returns.
+      await tester.pumpWidget(Container());
+      scope.requestSample();
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('disposing the scope cancels live registrations',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(child: Container()),
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      final sub = scope.register(
+        controlBox: () => null,
+        onBrightnessChanged: (_) {},
+        initialBrightness: Brightness.light,
+      );
+      // Tear the scope down while the registration is still live.
+      await tester.pumpWidget(Container());
+      // Cancelling afterwards is a safe no-op.
+      sub.cancel();
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('samples are skipped while the boundary is mid-paint',
+        (tester) async {
+      // Regression guard: the mid-paint check must stay inside an assert
+      // closure — debugNeedsPaint is debug-only and reading it in profile/
+      // release builds throws (which the defensive catch would swallow,
+      // silently disabling the sampler).
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          child: GlassContentAwareContent(
+            child: const ColoredBox(color: Color(0xFF000000)),
+          ),
+        ),
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      final boundary = tester.renderObject(
+        find
+            .descendant(
+                of: find.byType(GlassContentAwareContent),
+                matching: find.byType(RepaintBoundary))
+            .first,
+      ) as RenderRepaintBoundary;
+      var flips = 0;
+      final sub = scope.register(
+        controlBox: () => boundary,
+        onBrightnessChanged: (_) => flips++,
+        initialBrightness: Brightness.light,
+      );
+      boundary.markNeedsPaint();
+      // Returns before capturing — the boundary is dirty.
+      await scope.sampleNow();
+      expect(flips, 0);
+      await tester.pump();
+      sub.cancel();
+    });
+
+    testWidgets('sampling without content or subscriptions is inert',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          // No GlassContentAwareContent and no consumers.
+          child: ListView(children: [Container(height: 2000)]),
+        ),
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      // No subscriptions → first early return.
+      await scope.sampleNow();
+      // Subscription but no content → boundary early return.
+      final sub = scope.register(
+        controlBox: () => null,
+        onBrightnessChanged: (_) {},
+        initialBrightness: Brightness.light,
+      );
+      await scope.sampleNow();
+      expect(sub.brightness, Brightness.light);
+      sub.cancel();
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets(
+        'controls that are unmounted, outside the boundary, or throwing '
+        'are skipped', (tester) async {
+      final barKey = GlobalKey();
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          child: Column(
+            children: [
+              // Content boundary only covers the top half of the screen.
+              Expanded(
+                child: GlassContentAwareContent(
+                  child: const ColoredBox(color: Color(0xFF000000)),
+                ),
+              ),
+              // The "control" lives below the boundary — its rect cannot
+              // intersect the captured image.
+              SizedBox(key: barKey, height: 80, width: 400),
+            ],
+          ),
+        ),
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+
+      var outsideFlips = 0;
+      final outside = scope.register(
+        controlBox: () =>
+            barKey.currentContext!.findRenderObject() as RenderBox,
+        onBrightnessChanged: (_) => outsideFlips++,
+        initialBrightness: Brightness.light,
+      );
+      final unmounted = scope.register(
+        controlBox: () => null,
+        onBrightnessChanged: (_) {},
+        initialBrightness: Brightness.light,
+      );
+      // With every control skipped, work.isEmpty returns before capturing.
+      await _settleSample(tester, scope);
+      expect(outsideFlips, 0);
+      expect(outside.brightness, Brightness.light);
+      unmounted.cancel();
+      outside.cancel();
+      outside.cancel(); // double-cancel is safe
+
+      // A throwing provider lands in the defensive catch.
+      final throwing = scope.register(
+        controlBox: () => throw StateError('boom'),
+        onBrightnessChanged: (_) {},
+        initialBrightness: Brightness.light,
+      );
+      await _settleSample(tester, scope);
+      expect(throwing.brightness, Brightness.light);
+      throwing.cancel();
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('a verdict callback can cancel a later subscription mid-'
+        'delivery', (tester) async {
+      final contentKey = GlobalKey();
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          child: GlassContentAwareContent(
+            child: ColoredBox(
+                key: contentKey, color: const Color(0xFF000000)),
+          ),
+        ),
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      RenderBox box() =>
+          contentKey.currentContext!.findRenderObject() as RenderBox;
+
+      late GlassContentAwareSubscription second;
+      var secondFlips = 0;
+      final first = scope.register(
+        controlBox: box,
+        onBrightnessChanged: (_) => second.cancel(),
+        initialBrightness: Brightness.light,
+        gridColumns: 2,
+        gridRows: 2,
+      );
+      second = scope.register(
+        controlBox: box,
+        onBrightnessChanged: (_) => secondFlips++,
+        initialBrightness: Brightness.light,
+      );
+      await _settleSample(tester, scope);
+      // First flipped dark and cancelled the second before delivery.
+      expect(first.brightness, Brightness.dark);
+      expect(secondFlips, 0);
+      first.cancel();
+    });
+
+    testWidgets('explicit backgroundColor decides unpainted pixels',
+        (tester) async {
+      // The content paints nothing, so every pixel is transparent and the
+      // verdict is decided entirely by the substituted background.
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          backgroundColor: const Color(0xFF000000),
+          child: GlassContentAwareContent(
+            child: const SizedBox.expand(),
+          ),
+        ),
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      final contentBox = tester.renderObject(
+          find.byType(GlassContentAwareContent)) as RenderBox;
+      var flipped = Brightness.light;
+      final sub = scope.register(
+        controlBox: () => contentBox,
+        onBrightnessChanged: (b) => flipped = b,
+        initialBrightness: Brightness.light,
+      );
+      await _settleSample(tester, scope);
+      expect(flipped, Brightness.dark);
+      sub.cancel();
+    });
+
+    testWidgets('default background follows a dark ambient brightness',
+        (tester) async {
+      await tester.pumpWidget(MediaQuery(
+        data: const MediaQueryData(platformBrightness: Brightness.dark),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: GlassContentAwareScope(
+            child: GlassContentAwareContent(
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      final contentBox = tester.renderObject(
+          find.byType(GlassContentAwareContent)) as RenderBox;
+      var flipped = Brightness.light;
+      final sub = scope.register(
+        controlBox: () => contentBox,
+        onBrightnessChanged: (b) => flipped = b,
+        initialBrightness: Brightness.light,
+      );
+      await _settleSample(tester, scope);
+      expect(flipped, Brightness.dark);
+      sub.cancel();
+    });
+  });
+
+  group('GlassContentAwareScope — scroll notification handling', () {
+    testWidgets('synthetic notifications drive the sampler state machine',
+        (tester) async {
+      late BuildContext innerContext;
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          child: Builder(builder: (context) {
+            innerContext = context;
+            return Container();
+          }),
+        ),
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+
+      // End without Start: early return, sampler stays idle.
+      ScrollEndNotification(metrics: _metrics(), context: innerContext)
+          .dispatch(innerContext);
+      await tester.pump();
+      expect(scope.isScrollSamplingActive, isFalse);
+
+      // UserScrollNotification falls through every branch.
+      UserScrollNotification(
+        metrics: _metrics(),
+        context: innerContext,
+        direction: ScrollDirection.idle,
+      ).dispatch(innerContext);
+      await tester.pump();
+      expect(scope.isScrollSamplingActive, isFalse);
+
+      // Start begins periodic sampling; a second Start is a no-op.
+      ScrollStartNotification(metrics: _metrics(), context: innerContext)
+          .dispatch(innerContext);
+      await tester.pump();
+      expect(scope.isScrollSamplingActive, isTrue);
+      ScrollStartNotification(metrics: _metrics(), context: innerContext)
+          .dispatch(innerContext);
+      await tester.pump();
+      expect(scope.isScrollSamplingActive, isTrue);
+
+      // Let the periodic timer tick a few times (no content — inert).
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // Metrics change while scrolling: no extra idle sample is scheduled.
+      ScrollMetricsNotification(metrics: _metrics(), context: innerContext)
+          .dispatch(innerContext);
+      await tester.pump();
+
+      // End cancels the timer and schedules the trailing sample.
+      ScrollEndNotification(metrics: _metrics(), context: innerContext)
+          .dispatch(innerContext);
+      await tester.pump();
+      expect(scope.isScrollSamplingActive, isFalse);
+
+      // Metrics change while idle: schedules a one-off sample.
+      ScrollMetricsNotification(metrics: _metrics(), context: innerContext)
+          .dispatch(innerContext);
+      await tester.pump();
+
+      // Overscroll (without a Start) also wakes the sampler.
+      OverscrollNotification(
+        metrics: _metrics(),
+        context: innerContext,
+        overscroll: 12,
+      ).dispatch(innerContext);
+      await tester.pump();
+      expect(scope.isScrollSamplingActive, isTrue);
+
+      // Disposing the scope cancels the running timer.
+      await tester.pumpWidget(Container());
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('changing sampleInterval restarts an active sampler',
+        (tester) async {
+      late BuildContext innerContext;
+      Widget scopeWith(Duration interval) => MaterialApp(
+            home: GlassContentAwareScope(
+              sampleInterval: interval,
+              child: Builder(builder: (context) {
+                innerContext = context;
+                return Container();
+              }),
+            ),
+          );
+
+      await tester.pumpWidget(scopeWith(const Duration(milliseconds: 180)));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+
+      // Idle interval change: nothing to restart.
+      await tester.pumpWidget(scopeWith(const Duration(milliseconds: 120)));
+      expect(scope.isScrollSamplingActive, isFalse);
+
+      ScrollStartNotification(metrics: _metrics(), context: innerContext)
+          .dispatch(innerContext);
+      await tester.pump();
+      expect(scope.isScrollSamplingActive, isTrue);
+
+      // Active interval change: timer is recreated with the new period.
+      await tester.pumpWidget(scopeWith(const Duration(milliseconds: 60)));
+      expect(scope.isScrollSamplingActive, isTrue);
+      // Unrelated rebuild with the same interval: timer untouched.
+      await tester.pumpWidget(scopeWith(const Duration(milliseconds: 60)));
+      expect(scope.isScrollSamplingActive, isTrue);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      ScrollEndNotification(metrics: _metrics(), context: innerContext)
+          .dispatch(innerContext);
+      await tester.pump();
+      expect(scope.isScrollSamplingActive, isFalse);
+    });
+  });
+
+  group('GlassContentAwareContent', () {
+    testWidgets('a second content region under one scope asserts',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          child: Column(children: [
+            Expanded(
+                child: GlassContentAwareContent(child: Container())),
+            Expanded(
+                child: GlassContentAwareContent(child: Container())),
+          ]),
+        ),
+      ));
+      expect(tester.takeException(), isAssertionError);
+      // Removing the second region exercises the non-matching detach.
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          child: Column(children: [
+            Expanded(
+                child: GlassContentAwareContent(child: Container())),
+          ]),
+        ),
+      ));
+      await tester.pumpWidget(Container());
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('GlassContentAwareBrightness — flip timing precedence', () {
+    testWidgets('scope flipDuration/flipCurve apply to registered controls',
+        (tester) async {
+      final override = ValueNotifier<Brightness>(Brightness.light);
+      addTearDown(override.dispose);
+      double? darkAmount;
+      // No scope here — the widget-level override must win over defaults.
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareBrightness(
+          brightnessOverride: override,
+          flipDuration: const Duration(milliseconds: 400),
+          flipCurve: Curves.linear,
+          builder: (context, brightness, t) {
+            darkAmount = t;
+            return const SizedBox.expand();
+          },
+        ),
+      ));
+      override.value = Brightness.dark;
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      // Linear curve, 400 ms duration → exactly halfway after 200 ms.
+      expect(darkAmount, closeTo(0.5, 0.01));
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(darkAmount, 1.0);
+    });
+
+    testWidgets('scope timing is used when the widget does not override it',
+        (tester) async {
+      double? darkAmount;
+      late GlassContentAwareScopeState scope;
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          flipDuration: const Duration(milliseconds: 600),
+          flipCurve: Curves.linear,
+          child: Stack(children: [
+            Positioned.fill(
+              child: GlassContentAwareContent(
+                child: const ColoredBox(color: Color(0xFF000000)),
+              ),
+            ),
+            Positioned.fill(
+              child: GlassContentAwareBrightness(
+                builder: (context, brightness, t) {
+                  darkAmount = t;
+                  return const SizedBox.expand();
+                },
+              ),
+            ),
+          ]),
+        ),
+      ));
+      scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      await _settleSample(tester, scope);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(darkAmount, closeTo(0.5, 0.01));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(darkAmount, 1.0);
+    });
+  });
+
+  group('GlassContentAwareBrightness — configuration changes', () {
+    testWidgets('override can be attached, swapped, and removed',
+        (tester) async {
+      final a = ValueNotifier<Brightness>(Brightness.light);
+      final b = ValueNotifier<Brightness>(Brightness.dark);
+      addTearDown(a.dispose);
+      addTearDown(b.dispose);
+      Brightness? built;
+      Widget host(ValueListenable<Brightness>? override) => MaterialApp(
+            home: GlassContentAwareScope(
+              child: GlassContentAwareBrightness(
+                brightnessOverride: override,
+                builder: (context, brightness, t) {
+                  built = brightness;
+                  return const SizedBox.expand();
+                },
+              ),
+            ),
+          );
+
+      // No override: registered with the scope (no content → ambient).
+      await tester.pumpWidget(host(null));
+      expect(built, Brightness.light);
+
+      // Attach: adopts the override value (and deregisters from the scope).
+      await tester.pumpWidget(host(b));
+      await tester.pumpAndSettle();
+      expect(built, Brightness.dark);
+
+      // Swap to another listenable.
+      await tester.pumpWidget(host(a));
+      await tester.pumpAndSettle();
+      expect(built, Brightness.light);
+      // The detached listenable no longer drives the control.
+      b.value = Brightness.light;
+      a.value = Brightness.dark;
+      await tester.pumpAndSettle();
+      expect(built, Brightness.dark);
+
+      // Remove: re-registers with the scope, keeping the last verdict.
+      await tester.pumpWidget(host(null));
+      await tester.pumpAndSettle();
+      expect(built, Brightness.dark);
+    });
+
+    testWidgets('changing the grid re-registers the control',
+        (tester) async {
+      Widget host(int columns) => MaterialApp(
+            home: GlassContentAwareScope(
+              child: GlassContentAwareBrightness(
+                gridColumns: columns,
+                gridRows: columns == 6 ? 1 : 2,
+                builder: (context, brightness, t) =>
+                    const SizedBox.expand(),
+              ),
+            ),
+          );
+      await tester.pumpWidget(host(6));
+      await tester.pumpWidget(host(2));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('builds without a MediaQuery ancestor', (tester) async {
+      Brightness? built;
+      double? darkAmount;
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: GlassContentAwareBrightness(
+          builder: (context, brightness, t) {
+            built = brightness;
+            darkAmount = t;
+            return const SizedBox.expand();
+          },
+        ),
+      ));
+      // No MediaQuery → ambient defaults to light, no override is injected.
+      expect(built, Brightness.light);
+      expect(darkAmount, 0.0);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/widgets/shared/glass_content_aware_scope_test.dart
+++ b/test/widgets/shared/glass_content_aware_scope_test.dart
@@ -1,0 +1,489 @@
+// ignore_for_file: require_trailing_commas
+// Behavior tests for the content-aware brightness system:
+//   - GlassContentAwareScope.computeVerdict (WCAG contrast vote, sticky
+//     ties, dual-threshold hysteresis, transparent-pixel substitution)
+//   - end-to-end capture pipeline (scope + content + consumer) over dark,
+//     light, medium and mixed content
+//   - the animated cross-fade and the MediaQuery / CupertinoTheme /
+//     GlassTheme overrides seen by the consumer subtree
+//   - brightnessOverride bypassing the sampler
+//   - scroll-aware throttle lifecycle (start / periodic / end / idle)
+
+import 'dart:typed_data';
+
+import 'package:flutter/cupertino.dart' show CupertinoTheme;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+/// Builds a width×1 RGBA image where each pixel is [color] with [alpha].
+Uint8List _rowOf(int width, Color color, {int alpha = 255}) {
+  final bytes = Uint8List(width * 4);
+  final r = ((color.r * 255).round()) & 0xFF;
+  final g = ((color.g * 255).round()) & 0xFF;
+  final b = ((color.b * 255).round()) & 0xFF;
+  for (var x = 0; x < width; x++) {
+    bytes[x * 4] = r;
+    bytes[x * 4 + 1] = g;
+    bytes[x * 4 + 2] = b;
+    bytes[x * 4 + 3] = alpha;
+  }
+  return bytes;
+}
+
+List<Rect> _cells(int count) => <Rect>[
+      for (var i = 0; i < count; i++)
+        Rect.fromLTWH(i.toDouble(), 0, 1, 1),
+    ];
+
+/// Runs one deterministic sample to completion.
+///
+/// Captures (`toImage`) only complete while the real event loop runs, i.e.
+/// inside [WidgetTester.runAsync]. A sample may already be in flight from
+/// the registration post-frame callback and would hold the single-flight
+/// latch, so let it finish first, then run a fresh sample over the current
+/// content.
+Future<void> _settleSample(
+  WidgetTester tester,
+  GlassContentAwareScopeState scope,
+) {
+  return tester.runAsync(() async {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await scope.sampleNow();
+  });
+}
+
+Brightness _verdict(
+  Uint8List rgba,
+  int width, {
+  Brightness current = Brightness.light,
+  double lightToDark = 0.6,
+  double darkToLight = 0.6,
+  Color background = const Color(0xFFFFFFFF),
+  List<Rect>? cells,
+}) {
+  return GlassContentAwareScope.computeVerdict(
+    rgba: rgba,
+    width: width,
+    height: 1,
+    cellRects: cells ?? _cells(width),
+    current: current,
+    lightToDarkThreshold: lightToDark,
+    darkToLightThreshold: darkToLight,
+    background: background,
+  );
+}
+
+void main() {
+  group('computeVerdict — contrast vote', () {
+    test('dark content flips a light control dark', () {
+      final rgba = _rowOf(6, const Color(0xFF000000));
+      expect(_verdict(rgba, 6), Brightness.dark);
+    });
+
+    test('light content flips a dark control light', () {
+      final rgba = _rowOf(6, const Color(0xFFFFFFFF));
+      expect(_verdict(rgba, 6, current: Brightness.dark), Brightness.light);
+    });
+
+    test('medium content keeps the control light (WCAG vote flips late)',
+        () {
+      // Mid-gray (#808080) has WCAG luminance ≈ 0.22 — above the ≈ 0.18
+      // contrast crossover, so dark glyphs still read better and the
+      // control stays light. This is the vote-not-threshold property.
+      final rgba = _rowOf(6, const Color(0xFF808080));
+      expect(_verdict(rgba, 6), Brightness.light);
+      expect(_verdict(rgba, 6, current: Brightness.dark), Brightness.light);
+    });
+
+    test('empty cell list keeps the current appearance', () {
+      final rgba = _rowOf(6, const Color(0xFF000000));
+      expect(_verdict(rgba, 6, cells: const <Rect>[]), Brightness.light);
+      expect(
+        _verdict(rgba, 6,
+            cells: const <Rect>[], current: Brightness.dark),
+        Brightness.dark,
+      );
+    });
+
+    test('degenerate image keeps the current appearance', () {
+      expect(
+        GlassContentAwareScope.computeVerdict(
+          rgba: Uint8List(0),
+          width: 0,
+          height: 0,
+          cellRects: _cells(1),
+          current: Brightness.dark,
+          lightToDarkThreshold: 0.6,
+          darkToLightThreshold: 0.6,
+          background: const Color(0xFFFFFFFF),
+        ),
+        Brightness.dark,
+      );
+    });
+  });
+
+  group('computeVerdict — transparent-pixel substitution', () {
+    test('unpainted pixels read as a light background', () {
+      final rgba = _rowOf(6, const Color(0xFF000000), alpha: 0);
+      expect(
+        _verdict(rgba, 6,
+            current: Brightness.dark,
+            background: const Color(0xFFFFFFFF)),
+        Brightness.light,
+      );
+    });
+
+    test('unpainted pixels read as a dark background', () {
+      final rgba = _rowOf(6, const Color(0xFFFFFFFF), alpha: 0);
+      expect(
+        _verdict(rgba, 6, background: const Color(0xFF000000)),
+        Brightness.dark,
+      );
+    });
+  });
+
+  group('computeVerdict — sticky ties and hysteresis', () {
+    test('a 50/50 split keeps the current appearance in both directions',
+        () {
+      // 3 black + 3 white pixels — a tie under any threshold > 0.5.
+      final rgba = Uint8List.fromList([
+        ..._rowOf(3, const Color(0xFF000000)),
+        ..._rowOf(3, const Color(0xFFFFFFFF)),
+      ]);
+      expect(_verdict(rgba, 6), Brightness.light);
+      expect(_verdict(rgba, 6, current: Brightness.dark), Brightness.dark);
+    });
+
+    test('a strict majority below the threshold does not flip', () {
+      // 4 of 6 dark votes = 0.67 — flips at 0.6 but not at 0.7. The same
+      // content therefore keeps whichever appearance is current when the
+      // threshold is raised: dual-threshold hysteresis.
+      final rgba = Uint8List.fromList([
+        ..._rowOf(4, const Color(0xFF000000)),
+        ..._rowOf(2, const Color(0xFFFFFFFF)),
+      ]);
+      expect(_verdict(rgba, 6, lightToDark: 0.6), Brightness.dark);
+      expect(_verdict(rgba, 6, lightToDark: 0.7), Brightness.light);
+    });
+
+    test('asymmetric thresholds gate each direction independently', () {
+      // 4 of 6 light votes = 0.67.
+      final lightish = Uint8List.fromList([
+        ..._rowOf(4, const Color(0xFFFFFFFF)),
+        ..._rowOf(2, const Color(0xFF000000)),
+      ]);
+      expect(
+        _verdict(lightish, 6,
+            current: Brightness.dark, darkToLight: 0.6),
+        Brightness.light,
+      );
+      expect(
+        _verdict(lightish, 6,
+            current: Brightness.dark, darkToLight: 0.7),
+        Brightness.dark,
+      );
+    });
+  });
+
+  group('end-to-end sampling pipeline', () {
+    Widget pipeline({
+      required Widget content,
+      ValueChanged<Brightness>? onBrightnessChanged,
+      GlassBrightnessWidgetBuilder? builder,
+      Duration sampleInterval = const Duration(milliseconds: 180),
+    }) {
+      return MaterialApp(
+        home: GlassContentAwareScope(
+          sampleInterval: sampleInterval,
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: GlassContentAwareContent(child: content),
+              ),
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                height: 80,
+                child: GlassContentAwareBrightness(
+                  onBrightnessChanged: onBrightnessChanged,
+                  builder: builder ??
+                      (context, brightness, darkAmount) =>
+                          const SizedBox.expand(),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    testWidgets('dark content flips the control dark and cross-fades',
+        (tester) async {
+      final flips = <Brightness>[];
+      Brightness? builtBrightness;
+      double? builtDarkAmount;
+      Brightness? innerPlatformBrightness;
+      Brightness? innerCupertinoBrightness;
+
+      await tester.pumpWidget(pipeline(
+        content: const ColoredBox(color: Color(0xFF000000)),
+        onBrightnessChanged: flips.add,
+        builder: (context, brightness, darkAmount) {
+          builtBrightness = brightness;
+          builtDarkAmount = darkAmount;
+          innerPlatformBrightness =
+              MediaQuery.platformBrightnessOf(context);
+          innerCupertinoBrightness = CupertinoTheme.of(context).brightness;
+          return const SizedBox.expand();
+        },
+      ));
+      expect(builtBrightness, Brightness.light);
+      expect(builtDarkAmount, 0.0);
+      expect(innerPlatformBrightness, Brightness.light);
+
+      final scopeState = tester
+          .state<GlassContentAwareScopeState>(
+              find.byType(GlassContentAwareScope));
+      await _settleSample(tester, scopeState);
+      await tester.pump();
+
+      // Verdict committed immediately; the visual fade is in flight.
+      expect(flips, [Brightness.dark]);
+      expect(builtBrightness, Brightness.dark);
+
+      // Mid-fade: darkAmount strictly between the endpoints.
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(builtDarkAmount, greaterThan(0.0));
+      expect(builtDarkAmount, lessThan(1.0));
+      // Past the midpoint the discrete ambient flips dark.
+      expect(innerPlatformBrightness, Brightness.dark);
+      expect(innerCupertinoBrightness, Brightness.dark);
+
+      await tester.pump(const Duration(milliseconds: 150));
+      expect(builtDarkAmount, 1.0);
+
+      // A second sample over the same content does not re-fire.
+      await _settleSample(tester, scopeState);
+      await tester.pump();
+      expect(flips, [Brightness.dark]);
+    });
+
+    testWidgets('light content keeps the control light — no flip events',
+        (tester) async {
+      final flips = <Brightness>[];
+      await tester.pumpWidget(pipeline(
+        content: const ColoredBox(color: Color(0xFFFFFFFF)),
+        onBrightnessChanged: flips.add,
+      ));
+      final scopeState = tester
+          .state<GlassContentAwareScopeState>(
+              find.byType(GlassContentAwareScope));
+      await _settleSample(tester, scopeState);
+      await tester.pump();
+      expect(flips, isEmpty);
+    });
+
+    testWidgets('half-and-half content is sticky in both directions',
+        (tester) async {
+      final flips = <Brightness>[];
+      await tester.pumpWidget(pipeline(
+        content: const Row(children: [
+          Expanded(child: ColoredBox(color: Color(0xFF000000))),
+          Expanded(child: ColoredBox(color: Color(0xFFFFFFFF))),
+        ]),
+        onBrightnessChanged: flips.add,
+      ));
+      final scopeState = tester
+          .state<GlassContentAwareScopeState>(
+              find.byType(GlassContentAwareScope));
+      await _settleSample(tester, scopeState);
+      await tester.pump();
+      expect(flips, isEmpty);
+    });
+
+    testWidgets('lerped GlassTheme is served to the consumer subtree',
+        (tester) async {
+      GlassThemeData? innerTheme;
+      await tester.pumpWidget(pipeline(
+        content: const ColoredBox(color: Color(0xFF000000)),
+        builder: (context, brightness, darkAmount) {
+          innerTheme = GlassThemeData.of(context);
+          return const SizedBox.expand();
+        },
+      ));
+      final scopeState = tester
+          .state<GlassContentAwareScopeState>(
+              find.byType(GlassContentAwareScope));
+
+      // At rest (light), both slots of the synthetic data hold the light
+      // variant, so variant resolution is brightness-independent.
+      expect(innerTheme!.light, GlassThemeVariant.light);
+      expect(innerTheme!.dark, GlassThemeVariant.light);
+
+      await _settleSample(tester, scopeState);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      // Mid-fade: thickness sits strictly between dark (10) and light (12).
+      final midThickness = innerTheme!.light.settings!.thickness!;
+      expect(midThickness, lessThan(12.0));
+      expect(midThickness, greaterThan(10.0));
+
+      await tester.pump(const Duration(milliseconds: 150));
+      expect(innerTheme!.light, GlassThemeVariant.dark);
+      expect(innerTheme!.dark, GlassThemeVariant.dark);
+    });
+
+    testWidgets('scroll notifications drive the sampler lifecycle',
+        (tester) async {
+      final flips = <Brightness>[];
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: GlassContentAwareContent(
+                  child: ListView(
+                    children: [
+                      Container(
+                          height: 600, color: const Color(0xFFFFFFFF)),
+                      Container(
+                          height: 2000, color: const Color(0xFF000000)),
+                    ],
+                  ),
+                ),
+              ),
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                height: 80,
+                child: GlassContentAwareBrightness(
+                  onBrightnessChanged: flips.add,
+                  builder: (context, brightness, darkAmount) =>
+                      const SizedBox.expand(),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ));
+      final scopeState = tester
+          .state<GlassContentAwareScopeState>(
+              find.byType(GlassContentAwareScope));
+
+      // Idle: no periodic sampler.
+      expect(scopeState.isScrollSamplingActive, isFalse);
+
+      // A drag starts the periodic sampler...
+      final gesture = await tester.startGesture(const Offset(200, 300));
+      await gesture.moveBy(const Offset(0, -50));
+      await tester.pump();
+      expect(scopeState.isScrollSamplingActive, isTrue);
+
+      // ...and releasing ends scrolling, returning the sampler to idle.
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(scopeState.isScrollSamplingActive, isFalse);
+
+      // The scrolled-down content is now dark behind the control; a manual
+      // settle-sample (the trailing sample's payload) flips it.
+      await tester.drag(find.byType(ListView), const Offset(0, -1200));
+      await tester.pumpAndSettle();
+      await _settleSample(tester, scopeState);
+      await tester.pump();
+      expect(flips, [Brightness.dark]);
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('GlassContentAwareBrightness — brightnessOverride', () {
+    testWidgets('follows the listenable and bypasses the scope',
+        (tester) async {
+      final override = ValueNotifier<Brightness>(Brightness.light);
+      addTearDown(override.dispose);
+      final flips = <Brightness>[];
+      Brightness? builtBrightness;
+      double? builtDarkAmount;
+
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          child: GlassContentAwareBrightness(
+            brightnessOverride: override,
+            onBrightnessChanged: flips.add,
+            builder: (context, brightness, darkAmount) {
+              builtBrightness = brightness;
+              builtDarkAmount = darkAmount;
+              return const SizedBox.expand();
+            },
+          ),
+        ),
+      ));
+      expect(builtBrightness, Brightness.light);
+
+      override.value = Brightness.dark;
+      await tester.pump();
+      expect(flips, [Brightness.dark]);
+      expect(builtBrightness, Brightness.dark);
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(builtDarkAmount, 1.0);
+
+      override.value = Brightness.light;
+      await tester.pump();
+      expect(flips, [Brightness.dark, Brightness.light]);
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(builtDarkAmount, 0.0);
+    });
+
+    testWidgets('an initially-dark override starts dark with no animation',
+        (tester) async {
+      final override = ValueNotifier<Brightness>(Brightness.dark);
+      addTearDown(override.dispose);
+      final flips = <Brightness>[];
+      double? builtDarkAmount;
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareBrightness(
+          brightnessOverride: override,
+          onBrightnessChanged: flips.add,
+          builder: (context, brightness, darkAmount) {
+            builtDarkAmount = darkAmount;
+            return const SizedBox.expand();
+          },
+        ),
+      ));
+      expect(builtDarkAmount, 1.0);
+      expect(flips, isEmpty);
+    });
+  });
+
+  group('GlassContentAwareBrightness — no scope, no override', () {
+    testWidgets('follows the ambient platform brightness', (tester) async {
+      Brightness? builtBrightness;
+      double? builtDarkAmount;
+      Widget app(Brightness platform) => MediaQuery(
+            data: MediaQueryData(platformBrightness: platform),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: GlassContentAwareBrightness(
+                builder: (context, brightness, darkAmount) {
+                  builtBrightness = brightness;
+                  builtDarkAmount = darkAmount;
+                  return const SizedBox.expand();
+                },
+              ),
+            ),
+          );
+
+      await tester.pumpWidget(app(Brightness.dark));
+      expect(builtBrightness, Brightness.dark);
+      expect(builtDarkAmount, 1.0);
+
+      // Ambient flip re-anchors the verdict (animated).
+      await tester.pumpWidget(app(Brightness.light));
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(builtBrightness, Brightness.light);
+      expect(builtDarkAmount, 0.0);
+    });
+  });
+}

--- a/test/widgets/surfaces/adaptive_brightness_bar_test.dart
+++ b/test/widgets/surfaces/adaptive_brightness_bar_test.dart
@@ -1,0 +1,294 @@
+// ignore_for_file: require_trailing_commas
+// Tests for adaptiveBrightness / onBrightnessChanged / brightnessOverride on
+// GlassBottomBar and GlassSearchableBottomBar, plus the shared
+// resolveBarLabelColor helper:
+//   - classic path is untouched (no adaptive machinery in the tree)
+//   - adaptiveBrightness without a scope renders and stays ambient
+//   - brightnessOverride drives both bars and fires onBrightnessChanged
+//   - the override reaches the bar subtree (MediaQuery / CupertinoTheme)
+//   - label color lerps for dynamic colors, passes through custom colors
+//   - end-to-end: bar over dark content in a scope flips dark
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show ValueListenable;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/widgets/surfaces/shared/bottom_bar_internal.dart'
+    show resolveBarLabelColor;
+
+/// Records the ambient brightness its build context sees — used as a tab
+/// icon to verify the override layer reaches the bar internals.
+class _BrightnessProbe extends StatelessWidget {
+  const _BrightnessProbe(this.onBuild);
+
+  final void Function(Brightness platform, Brightness? cupertino) onBuild;
+
+  @override
+  Widget build(BuildContext context) {
+    onBuild(
+      MediaQuery.platformBrightnessOf(context),
+      CupertinoTheme.of(context).brightness,
+    );
+    return const SizedBox(width: 16, height: 16);
+  }
+}
+
+List<GlassBottomBarTab> _tabs({Widget? probeIcon}) => [
+      GlassBottomBarTab(
+        label: 'Home',
+        icon: probeIcon ?? const Icon(CupertinoIcons.home),
+      ),
+      const GlassBottomBarTab(
+        label: 'Music',
+        icon: Icon(CupertinoIcons.music_note),
+      ),
+    ];
+
+Widget _wrapBar(Widget bar) => MaterialApp(
+      home: Scaffold(
+        body: const SizedBox.expand(),
+        bottomNavigationBar: SizedBox(height: 100, child: bar),
+      ),
+    );
+
+void main() {
+  group('GlassBottomBar — adaptive brightness plumbing', () {
+    testWidgets('classic path mounts no adaptive machinery',
+        (tester) async {
+      await tester.pumpWidget(_wrapBar(GlassBottomBar(
+        tabs: _tabs(),
+        selectedIndex: 0,
+        onTabSelected: (_) {},
+      )));
+      expect(find.byType(GlassContentAwareBrightness), findsNothing);
+      expect(find.text('Home'), findsWidgets);
+    });
+
+    testWidgets('adaptiveBrightness without a scope stays ambient',
+        (tester) async {
+      await tester.pumpWidget(_wrapBar(GlassBottomBar(
+        tabs: _tabs(),
+        selectedIndex: 0,
+        onTabSelected: (_) {},
+        adaptiveBrightness: true,
+      )));
+      expect(find.byType(GlassContentAwareBrightness), findsOneWidget);
+      expect(find.text('Home'), findsWidgets);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('brightnessOverride drives the bar and its subtree',
+        (tester) async {
+      final override = ValueNotifier<Brightness>(Brightness.light);
+      addTearDown(override.dispose);
+      final flips = <Brightness>[];
+      Brightness? probePlatform;
+      Brightness? probeCupertino;
+
+      await tester.pumpWidget(_wrapBar(GlassBottomBar(
+        tabs: _tabs(
+          probeIcon: _BrightnessProbe((platform, cupertino) {
+            probePlatform = platform;
+            probeCupertino = cupertino;
+          }),
+        ),
+        selectedIndex: 0,
+        onTabSelected: (_) {},
+        brightnessOverride: override,
+        onBrightnessChanged: flips.add,
+      )));
+      expect(probePlatform, Brightness.light);
+
+      override.value = Brightness.dark;
+      await tester.pump();
+      expect(flips, [Brightness.dark]);
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(probePlatform, Brightness.dark);
+      expect(probeCupertino, Brightness.dark);
+
+      override.value = Brightness.light;
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(flips, [Brightness.dark, Brightness.light]);
+      expect(probePlatform, Brightness.light);
+    });
+
+    testWidgets('end-to-end: bar over dark content flips dark',
+        (tester) async {
+      final flips = <Brightness>[];
+      await tester.pumpWidget(MaterialApp(
+        home: GlassContentAwareScope(
+          child: Scaffold(
+            extendBody: true,
+            body: GlassContentAwareContent(
+              child: const ColoredBox(
+                color: Color(0xFF000000),
+                child: SizedBox.expand(),
+              ),
+            ),
+            bottomNavigationBar: SizedBox(
+              height: 100,
+              child: GlassBottomBar(
+                tabs: _tabs(),
+                selectedIndex: 0,
+                onTabSelected: (_) {},
+                adaptiveBrightness: true,
+                onBrightnessChanged: flips.add,
+              ),
+            ),
+          ),
+        ),
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        await scope.sampleNow();
+      });
+      await tester.pump();
+      expect(flips, [Brightness.dark]);
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('GlassSearchableBottomBar — adaptive brightness plumbing', () {
+    Widget searchableBar({
+      ValueListenable<Brightness>? override,
+      ValueChanged<Brightness>? onBrightnessChanged,
+      bool adaptive = false,
+      Widget? probeIcon,
+    }) {
+      return _wrapBar(GlassSearchableBottomBar(
+        tabs: _tabs(probeIcon: probeIcon),
+        selectedIndex: 0,
+        onTabSelected: (_) {},
+        searchConfig: GlassSearchBarConfig(onSearchToggle: (_) {}),
+        adaptiveBrightness: adaptive,
+        brightnessOverride: override,
+        onBrightnessChanged: onBrightnessChanged,
+      ));
+    }
+
+    testWidgets('classic path mounts no adaptive machinery',
+        (tester) async {
+      await tester.pumpWidget(searchableBar());
+      expect(find.byType(GlassContentAwareBrightness), findsNothing);
+    });
+
+    testWidgets('adaptiveBrightness without a scope stays ambient',
+        (tester) async {
+      await tester.pumpWidget(searchableBar(adaptive: true));
+      expect(find.byType(GlassContentAwareBrightness), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('brightnessOverride drives the bar and fires the callback',
+        (tester) async {
+      final override = ValueNotifier<Brightness>(Brightness.light);
+      addTearDown(override.dispose);
+      final flips = <Brightness>[];
+      Brightness? probePlatform;
+
+      await tester.pumpWidget(searchableBar(
+        override: override,
+        onBrightnessChanged: flips.add,
+        probeIcon: _BrightnessProbe((platform, _) {
+          probePlatform = platform;
+        }),
+      ));
+      expect(probePlatform, Brightness.light);
+
+      override.value = Brightness.dark;
+      await tester.pump();
+      expect(flips, [Brightness.dark]);
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(probePlatform, Brightness.dark);
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('resolveBarLabelColor', () {
+    Future<BuildContext> contextUnder(
+      WidgetTester tester,
+      Widget Function(Widget child) wrap,
+    ) async {
+      late BuildContext captured;
+      await tester.pumpWidget(wrap(Builder(builder: (context) {
+        captured = context;
+        return const SizedBox();
+      })));
+      return captured;
+    }
+
+    testWidgets('classic path resolves the ambient label color',
+        (tester) async {
+      final context =
+          await contextUnder(tester, (child) => MaterialApp(home: child));
+      final color = resolveBarLabelColor(context, null);
+      // Light ambient → the label's light variant.
+      expect(color.toARGB32(), CupertinoColors.label.color.toARGB32());
+    });
+
+    testWidgets('dynamic label colors lerp with darkAmount',
+        (tester) async {
+      final context =
+          await contextUnder(tester, (child) => MaterialApp(home: child));
+      final light = resolveBarLabelColor(context, 0.0);
+      final dark = resolveBarLabelColor(context, 1.0);
+      final mid = resolveBarLabelColor(context, 0.5);
+      expect(light.toARGB32(), CupertinoColors.label.color.toARGB32());
+      expect(dark.toARGB32(), CupertinoColors.label.darkColor.toARGB32());
+      expect(
+        mid.toARGB32(),
+        Color.lerp(
+          CupertinoColors.label.color,
+          CupertinoColors.label.darkColor,
+          0.5,
+        )!
+            .toARGB32(),
+      );
+    });
+
+    testWidgets('non-dynamic custom label colors pass through unchanged',
+        (tester) async {
+      const custom = Color(0xFF336699);
+      final context = await contextUnder(
+        tester,
+        (child) => MaterialApp(
+          home: CupertinoTheme(
+            data: const CupertinoThemeData(
+              textTheme: CupertinoTextThemeData(
+                textStyle: TextStyle(color: custom),
+              ),
+            ),
+            child: child,
+          ),
+        ),
+      );
+      expect(resolveBarLabelColor(context, 0.7), custom);
+      expect(resolveBarLabelColor(context, null), custom);
+    });
+
+    testWidgets('a color-less text theme falls back to CupertinoColors.label',
+        (tester) async {
+      final context = await contextUnder(
+        tester,
+        (child) => MaterialApp(
+          home: CupertinoTheme(
+            data: const CupertinoThemeData(
+              textTheme: CupertinoTextThemeData(
+                textStyle: TextStyle(fontSize: 17),
+              ),
+            ),
+            child: child,
+          ),
+        ),
+      );
+      final lerped = resolveBarLabelColor(context, 1.0);
+      expect(
+          lerped.toARGB32(), CupertinoColors.label.darkColor.toARGB32());
+    });
+  });
+}


### PR DESCRIPTION
# Content-aware light/dark adaptation — `GlassContentAwareScope` + bar convenience flags

Implements the first iteration of #102, following the shape we agreed on there: the scope + the bar convenience flags. The premium `GlassEffect`-capture piggyback stays a fast-follow, as discussed — the scope sampler is the universal path and lands first.

## What this adds

```dart
GlassContentAwareScope(
  child: Scaffold(
    extendBody: true, // content scrolls underneath the bar
    body: GlassContentAwareContent(
      child: ListView(...),
    ),
    bottomNavigationBar: GlassBottomBar(
      adaptiveBrightness: true,
      onBrightnessChanged: (b) => /* flip your own icon colors */,
      ...
    ),
  ),
)
```

- **`GlassContentAwareScope`** wraps the screen and owns the sampling engine. It captures the content **once** per sample (throttled, heavily downscaled async `toImage` of the content boundary) and serves every registered control from that one image — N controls share 1 capture, and each control evaluates *its own rect* with its own grid, so a small control over a dark photo can flip dark while a wide bar over mixed content stays light, like iOS.
- **`GlassContentAwareContent`** marks the sampled region (a `RepaintBoundary` around the scrolling content). Controls stay outside it, so the capture sees the content *behind* them rather than their own rendering.
- **`GlassContentAwareBrightness`** is the per-control consumer — the bars use it internally, and custom glass controls can wrap themselves in it directly (`builder` receives the committed `Brightness` plus the animated `darkAmount`).
- **`adaptiveBrightness: true`** on `GlassBottomBar` / `GlassSearchableBottomBar` auto-swaps the `GlassTheme.of(context)` light/dark variants (settings, glow palette, radii) and the Cupertino label-derived icon/label colors, with an **`onBrightnessChanged`** callback for everything the package can't see.
- **`brightnessOverride: ValueListenable<Brightness>`** bypasses the sampler entirely — the PlatformView escape hatch from #94 (e.g. key it off the active map style).

## Decision logic — a contrast vote, not a luminance threshold

Each control's rect is gridded (6×1 for bars); every cell votes for whichever glyph color reads better over the cell's average content — the light variant's dark glyphs vs the dark variant's light glyphs — using WCAG contrast ratios. Because dark glyphs hold contrast over light *and* medium content, the vote keeps controls light through the medium range and only flips when content is genuinely dark, which matches the native behavior and resists mode-flapping on mixed content like photo grids. Unpainted pixels are evaluated as a configurable `backgroundColor` so transparent scaffolds vote as what the user actually sees.

**Two levers, like the App Store — this PR ships the first.** The verdict here is the discrete lever (glass + glyphs, flips late). For the transition itself, `GlassContentAwareBrightness.builder` exposes `darkAmount` — the animated 0→1 fade position — so apps can fade their own elements in lockstep with a flip. The *independent* continuous lever from the issue thread (a scrim-darkness axis driven by mean content luminance with earlier cutoffs, so a bottom scrim darkens over medium content while the controls stay light) is deliberately **not** in this iteration: it wants a content-luminance output on the scope (the engine already averages cell luminance for the vote — it just isn't exposed), and the natural consumer is `GlassScrollEdgeEffect`, the surface `GlassScaffold` already renders under the bars. Scrim band registered as its own client + exposed luminance + an adaptive mode on the edge effect = the full App Store behavior, entirely within existing package surfaces — so it slots cleanly into the fast-follow alongside the premium `GlassEffect`-capture piggyback. Apps that already render their own scrim can keep driving it from their own signal in the meantime.

## Flap prevention, animation, throttling — per your review notes

- **Sticky ties + dual-threshold hysteresis.** A tied or sub-threshold vote keeps the current appearance, and the two directions use separate cutoffs (`lightToDarkThreshold` / `darkToLightThreshold`, vote fractions in `[0.5, 1.0]`, default 0.6), so content sitting right at the contrast boundary cannot oscillate.
- **Animated flips.** Verdict changes cross-fade over `flipDuration` / `flipCurve` (default 200 ms ease-in-out, matching the iOS 26 transition). Continuous theme values lerp throughout via the new `GlassThemeVariant.lerp` (null-aware: partial-override fields that exist on only one side switch at the fade midpoint instead of flashing through zero); the discrete residue (light-mode shadow gating, dynamic-color resolution in user content) flips at the midpoint, where the blend hides it.
- **Scroll-aware throttle.** A `ScrollNotification` listener in the scope starts a periodic sampler (`sampleInterval`, default 180 ms) on scroll start and stops it on scroll end with one trailing sample for the settled state; `ScrollMetricsNotification` covers idle content changes. An idle screen samples zero times. Captures are single-flight and downscaled to ~16 px per grid cell, so a readback is a few KB regardless of screen size.
- **Naming** — `GlassContentAwareScope`, steering clear of the existing `GlassAdaptiveScope` (quality degradation).

## Compatibility

Defaults are inert: `adaptiveBrightness: false` with no override mounts none of the adaptive machinery, and the bars' classic color resolution is byte-for-byte the historical behavior. Explicit `selectedIconColor` / `unselectedIconColor` still override everything.

## Verification

- `flutter analyze` clean.
- Full CI-equivalent suite (excl. golden/renderer): **1907 tests passing**, including 58 new ones — verdict math units (vote, ties, hysteresis, transparency substitution), the real capture pipeline end-to-end over dark/light/medium/mixed content, the cross-fade + override layers, the scroll-driven sampler lifecycle, registration/teardown edge cases, and both bars' integration (probes inside the bar subtree verify the `MediaQuery`/`CupertinoTheme` swap actually reaches the internals).
- New lib code is at 100 % line coverage locally (`lcov`); golden/renderer failure set on a macOS host verified byte-identical to `main`.
- The approach itself is the productization of the adapter we've been running in production in our app (the App Store-style screens from the #102 thread) — validated on-device in both modes with no measurable jank at scroll-time sample rates.
- This exact implementation was also exercised on-device before submitting (iPhone 16 Pro Max, premium tier, ported into our app's glass test harness over panning/zooming map content): verdict flips in both directions through the real capture pipeline, the ~200 ms cross-fade reads correctly (caught mid-lerp on screen), medium-luminance content stays in the light appearance under continuous interaction-driven sampling, and the session log shows zero exceptions.
- The profile-mode leg of that pass caught a release-only bug that no debug-mode test can see: the sampler's mid-paint guard read `debugNeedsPaint`, whose backing value is only assigned inside an assert — in profile/release it throws on read, and the defensive catch swallowed it, silently disabling the sampler. The guard now lives behind an assert closure (release builds sample post-frame, where the boundary is always clean) with a regression test documenting why it must stay that way.

Happy to adjust naming/defaults wherever you'd like — and the `GlassEffect` capture piggyback for premium is queued as the fast-follow.
