### PR TITLE
Content-aware scroll-edge scrim (#102 fast-follow) + small GlassModalSheet / GlassEffect fixes

### DIFF
--- a/example/lib/demos/content_aware_brightness_demo.dart
+++ b/example/lib/demos/content_aware_brightness_demo.dart
@@ -118,6 +118,10 @@ class _ContentAwareBrightnessDemoState
       topEdgeFade: true,
       bottomEdgeFade: true,
       contentAwareBrightness: true,
+      // The continuous companion: the scroll-edge fades darken early as
+      // medium/dark content scrolls under them (the App Store scrim), while
+      // the bar's contrast vote flips its appearance late.
+      contentAwareEdgeFade: true,
 
       // ── Body ──────────────────────────────────────────────────────────────
       body: CustomScrollView(

--- a/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
@@ -27,6 +27,11 @@ class _SheetLayout extends StatelessWidget {
   final ScrollController scrollController;
   final ValueNotifier<SheetState> currentStateNotifier;
   final double expandProgressValue;
+
+  /// When true, the inner content scroll is force-disabled regardless
+  /// of expand state. Set during a handle drag so the scrollable can't
+  /// claim the vertical-drag gesture and fight the sheet drag.
+  final bool disableInnerScroll;
   final Widget child;
   final bool showDragIndicator;
   final Color? dragIndicatorColor;
@@ -67,6 +72,7 @@ class _SheetLayout extends StatelessWidget {
     required this.scrollController,
     required this.currentStateNotifier,
     required this.expandProgressValue,
+    this.disableInnerScroll = false,
     required this.child,
     required this.showDragIndicator,
     this.dragIndicatorColor,
@@ -83,11 +89,14 @@ class _SheetLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final handleZone = _SheetHandleZone(indicatorWidth: dragIndicatorWidth);
+    final handleZone = _SheetHandleZone(
+      indicatorWidth: dragIndicatorWidth,
+      indicatorColor: dragIndicatorColor,
+    );
 
     final contentZone = _SheetContent(
       scrollController: scrollController,
-      isFullScreen: expandProgressValue > 0.95,
+      isFullScreen: expandProgressValue > 0.95 && !disableInnerScroll,
       padding: padding,
       child: child,
     );
@@ -332,9 +341,10 @@ class _SheetLayout extends StatelessWidget {
 // ===========================================================================
 
 class _SheetHandleZone extends StatelessWidget {
-  const _SheetHandleZone({required this.indicatorWidth});
+  const _SheetHandleZone({required this.indicatorWidth, this.indicatorColor});
 
   final double indicatorWidth;
+  final Color? indicatorColor;
 
   @override
   Widget build(BuildContext context) {
@@ -346,7 +356,11 @@ class _SheetHandleZone extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           const SizedBox(height: 8),
-          _GlassDragIndicator(isGlass: isGlass, width: indicatorWidth),
+          _GlassDragIndicator(
+            isGlass: isGlass,
+            width: indicatorWidth,
+            color: indicatorColor,
+          ),
           const SizedBox(height: 8),
         ],
       ),
@@ -355,10 +369,21 @@ class _SheetHandleZone extends StatelessWidget {
 }
 
 class _GlassDragIndicator extends StatelessWidget {
-  const _GlassDragIndicator({required this.isGlass, required this.width});
+  const _GlassDragIndicator({
+    required this.isGlass,
+    required this.width,
+    this.color,
+  });
 
   final bool isGlass;
   final double width;
+
+  /// Explicit handle color. When null, falls back to the iOS-26
+  /// default themed against the ambient [CupertinoTheme] brightness.
+  /// Callers that float the sheet over content with its own brightness
+  /// (e.g. a map mode that differs from the app theme) should pass an
+  /// explicit color so the handle matches that surface.
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
@@ -374,7 +399,7 @@ class _GlassDragIndicator extends StatelessWidget {
         width: width,
         height: 4,
         decoration: BoxDecoration(
-          color: defaultColor,
+          color: color ?? defaultColor,
           borderRadius: BorderRadius.circular(2),
         ),
       ),

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -12,6 +12,16 @@ class _GlassModalSheetState extends State<GlassModalSheet>
   SheetState get _currentState => _currentStateNotifier.value;
   set _currentState(SheetState v) => _currentStateNotifier.value = v;
 
+  /// True for the lifetime of a handle drag (pointer-down in the top
+  /// handle zone through pointer-up/cancel). While set, the inner
+  /// content scroll is disabled so the scrollable never claims the
+  /// vertical-drag gesture and fights the handle drag — the cause of a
+  /// stall where, at full state, grabbing the handle let the content
+  /// overscroll and steal the pointer. Folded into the build's
+  /// [AnimatedBuilder] listenable so it takes effect on pointer-down,
+  /// BEFORE the scrollable's drag recognizer can claim (needs slop).
+  final ValueNotifier<bool> _handleDragActive = ValueNotifier(false);
+
   /// The state most recently published to consumers via
   /// [GlassModalSheet.onStateChanged] (and from which haptics and
   /// scroll-to-top side effects fired).
@@ -105,6 +115,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
     _saturationController.dispose();
     _scrollController.dispose();
     _currentStateNotifier.dispose();
+    _handleDragActive.dispose();
     super.dispose();
   }
 
@@ -244,8 +255,13 @@ class _GlassModalSheetState extends State<GlassModalSheet>
         event.position.dy, event.position.dx, _currentPosition, event.kind);
 
     // If the touch is in the handle zone (top 44 pixels), immediately set phase.
+    // Also disable the inner scroll for this gesture so the content scrollable
+    // can't claim the vertical drag and fight the handle drag. Set here, on
+    // pointer-down, so the physics swap lands before the scrollable's drag
+    // recognizer accumulates enough slop to claim.
     if (event.localPosition.dy <= 44.0) {
       _gestureArena.phase = GesturePhase.handleDrag;
+      _handleDragActive.value = true;
     }
 
     // Now, if we are interacting with a child (e.g. a button), we SUPPRESS
@@ -322,6 +338,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
   }
 
   void _onPointerUp(PointerUpEvent event) {
+    _handleDragActive.value = false;
     _isInteractingWithChild = false;
     _suppressScalingForSession = false;
     _saturationController.reverse();
@@ -352,6 +369,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
   }
 
   void _onPointerCancel(PointerCancelEvent event) {
+    _handleDragActive.value = false;
     _isInteractingWithChild = false;
     _suppressScalingForSession = false;
     _saturationController.reverse();
@@ -744,8 +762,8 @@ class _GlassModalSheetState extends State<GlassModalSheet>
     );
 
     return AnimatedBuilder(
-      animation:
-          Listenable.merge([_animationController, _saturationController]),
+      animation: Listenable.merge(
+          [_animationController, _saturationController, _handleDragActive]),
       builder: (context, _) {
         final fullPos = _geometry.positionForState(SheetState.full, mqHeight);
         final halfPos = _geometry.positionForState(SheetState.half, mqHeight);
@@ -823,6 +841,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
           scrollController: _scrollController,
           currentStateNotifier: _currentStateNotifier,
           expandProgressValue: t,
+          disableInnerScroll: _handleDragActive.value,
           maintainContentGlass: widget.maintainContentGlass,
           fullStateContentSettings: widget.fullStateContentSettings,
           enableSaturationGlow: widget.enableSaturationGlow,

--- a/lib/widgets/shared/glass_content_aware_scope.dart
+++ b/lib/widgets/shared/glass_content_aware_scope.dart
@@ -268,6 +268,54 @@ class GlassContentAwareScope extends StatefulWidget {
         : Brightness.dark;
   }
 
+  /// Mean content luminance of [cellRects] in a raw RGBA capture.
+  ///
+  /// Exposed for tests; production code goes through the sampling pipeline.
+  /// Returns the average **perceptual** luminance (BT.601 weights on the
+  /// non-linear sRGB channels, 0 = black, 1 = white) across the cells, with
+  /// [background] substituted for transparent pixels. This is deliberately a
+  /// different metric from the vote in [computeVerdict]: the vote is a
+  /// late-flipping WCAG contrast decision, while this axis moves smoothly
+  /// through the medium range — the input early-darkening consumers (e.g.
+  /// the adaptive scroll edge fade) key their thresholds off.
+  @visibleForTesting
+  static double computeMeanLuminance({
+    required Uint8List rgba,
+    required int width,
+    required int height,
+    required List<Rect> cellRects,
+    required Color background,
+  }) {
+    if (width <= 0 || height <= 0) return 1.0;
+    var sum = 0.0;
+    var n = 0;
+    for (final r in cellRects) {
+      final x0 = r.left.floor().clamp(0, width - 1);
+      final x1 = r.right.ceil().clamp(x0 + 1, width);
+      final y0 = r.top.floor().clamp(0, height - 1);
+      final y1 = r.bottom.ceil().clamp(y0 + 1, height);
+      for (var y = y0; y < y1; y++) {
+        for (var x = x0; x < x1; x++) {
+          final i = (y * width + x) * 4;
+          final a = rgba[i + 3] / 255.0;
+          double rr, gg, bb;
+          if (a < 0.02) {
+            rr = background.r;
+            gg = background.g;
+            bb = background.b;
+          } else {
+            rr = rgba[i] / 255.0;
+            gg = rgba[i + 1] / 255.0;
+            bb = rgba[i + 2] / 255.0;
+          }
+          sum += 0.299 * rr + 0.587 * gg + 0.114 * bb;
+          n++;
+        }
+      }
+    }
+    return n == 0 ? 1.0 : sum / n;
+  }
+
   /// WCAG relative luminance of the light variant's glyphs (near-black).
   static const double _lightVariantGlyphLuma = 0.0;
 
@@ -323,11 +371,20 @@ class GlassContentAwareScopeState extends State<GlassContentAwareScope> {
   /// [onBrightnessChanged] fires only when the verdict actually flips;
   /// [initialBrightness] seeds the hysteresis state.
   ///
+  /// [onLuminanceChanged] additionally delivers the rect's **mean content
+  /// luminance** (perceptual BT.601, 0 = black, 1 = white) each time it
+  /// changes meaningfully. Unlike the verdict — a late-flipping contrast
+  /// vote — this is the continuous axis: it moves through the medium range,
+  /// which is what early-darkening consumers such as the adaptive scroll
+  /// edge fade need. Registrations that only need the luminance may omit
+  /// [onBrightnessChanged].
+  ///
   /// Call [GlassContentAwareSubscription.cancel] when the control goes away.
   GlassContentAwareSubscription register({
     required RenderBox? Function() controlBox,
-    required ValueChanged<Brightness> onBrightnessChanged,
-    required Brightness initialBrightness,
+    ValueChanged<Brightness>? onBrightnessChanged,
+    ValueChanged<double>? onLuminanceChanged,
+    Brightness initialBrightness = Brightness.light,
     int gridColumns = 6,
     int gridRows = 1,
   }) {
@@ -336,6 +393,7 @@ class GlassContentAwareScopeState extends State<GlassContentAwareScope> {
       this,
       controlBox,
       onBrightnessChanged,
+      onLuminanceChanged,
       gridColumns,
       gridRows,
       initialBrightness,
@@ -529,19 +587,37 @@ class GlassContentAwareScopeState extends State<GlassContentAwareScope> {
               c.bottom * pixelRatio,
             ),
         ];
-        final verdict = GlassContentAwareScope.computeVerdict(
-          rgba: rgba,
-          width: width,
-          height: height,
-          cellRects: pixelCells,
-          current: sub._brightness,
-          lightToDarkThreshold: widget.lightToDarkThreshold,
-          darkToLightThreshold: widget.darkToLightThreshold,
-          background: background,
-        );
-        if (verdict != sub._brightness) {
-          sub._brightness = verdict;
-          sub._onBrightnessChanged(verdict);
+        if (sub._onBrightnessChanged != null) {
+          final verdict = GlassContentAwareScope.computeVerdict(
+            rgba: rgba,
+            width: width,
+            height: height,
+            cellRects: pixelCells,
+            current: sub._brightness,
+            lightToDarkThreshold: widget.lightToDarkThreshold,
+            darkToLightThreshold: widget.darkToLightThreshold,
+            background: background,
+          );
+          if (verdict != sub._brightness) {
+            sub._brightness = verdict;
+            sub._onBrightnessChanged!(verdict);
+          }
+        }
+        if (sub._onLuminanceChanged != null) {
+          final luminance = GlassContentAwareScope.computeMeanLuminance(
+            rgba: rgba,
+            width: width,
+            height: height,
+            cellRects: pixelCells,
+            background: background,
+          );
+          // Deliver on meaningful movement only — sub-0.005 jitter would
+          // churn consumer animations without a visible result.
+          final previous = sub._meanLuminance;
+          if (previous == null || (luminance - previous).abs() > 0.005) {
+            sub._meanLuminance = luminance;
+            sub._onLuminanceChanged!(luminance);
+          }
         }
       }
     } catch (e, stack) {
@@ -589,6 +665,7 @@ class GlassContentAwareSubscription {
     this._scope,
     this._controlBox,
     this._onBrightnessChanged,
+    this._onLuminanceChanged,
     this.gridColumns,
     this.gridRows,
     this._brightness,
@@ -596,7 +673,8 @@ class GlassContentAwareSubscription {
 
   final GlassContentAwareScopeState _scope;
   final RenderBox? Function() _controlBox;
-  final ValueChanged<Brightness> _onBrightnessChanged;
+  final ValueChanged<Brightness>? _onBrightnessChanged;
+  final ValueChanged<double>? _onLuminanceChanged;
 
   /// Number of horizontal voting cells for this control.
   final int gridColumns;
@@ -605,10 +683,16 @@ class GlassContentAwareSubscription {
   final int gridRows;
 
   Brightness _brightness;
+  double? _meanLuminance;
   bool _cancelled = false;
 
   /// The control's current content-aware verdict.
   Brightness get brightness => _brightness;
+
+  /// The rect's latest mean content luminance (perceptual BT.601, 0–1), or
+  /// null before the first sample or when no luminance listener is
+  /// registered.
+  double? get meanLuminance => _meanLuminance;
 
   /// Detaches the control from the scope. Safe to call more than once.
   void cancel() {

--- a/lib/widgets/shared/glass_effect.dart
+++ b/lib/widgets/shared/glass_effect.dart
@@ -275,6 +275,26 @@ class _GlassEffectState extends State<GlassEffect>
   /// Synchronous capture path for native (non-web) platforms.
   void _captureBackgroundSync(
       RenderRepaintBoundary boundary, Size size, Offset? pos) {
+    // In debug, toImageSync ASSERTS when the boundary is marked needing paint
+    // (no valid layer yet). `_handleTick` captures in the transient phase —
+    // BEFORE this frame paints — and during interaction it captures every
+    // frame, so while the backdrop repaints the boundary is dirty and the
+    // assert throws on (almost) every frame, spamming the console with
+    // "[GlassEffect] toImageSync failed". Defer to the post-frame callback in
+    // that case: capture the freshly-painted frame once it's clean. (Asserts
+    // are stripped in release, so `debugNeedsPaint` must be read inside an
+    // assert closure — reading it in a release build throws.)
+    bool needsPaint = false;
+    assert(() {
+      needsPaint = boundary.debugNeedsPaint;
+      return true;
+    }());
+    if (needsPaint) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _captureBackgroundSync(boundary, size, pos);
+      });
+      return;
+    }
     try {
       // pixelRatio: 1.0 — logical resolution is sufficient for refraction.
       // Stays in GPU-accessible memory; handed directly to setImageSampler.

--- a/lib/widgets/shared/glass_scroll_edge_effect.dart
+++ b/lib/widgets/shared/glass_scroll_edge_effect.dart
@@ -5,6 +5,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
 import '../interactive/liquid_glass_scope.dart';
+import 'glass_content_aware_scope.dart';
 
 /// Edge effect style matching iOS 26's `.scrollEdgeEffectStyle`.
 ///
@@ -95,7 +96,15 @@ class GlassScrollEdgeEffect extends StatefulWidget {
     this.fadeBottom = true,
     this.style = GlassScrollEdgeStyle.soft,
     this.fadeColor,
-  });
+    this.contentAwareFade = false,
+    this.darkFadeColor,
+    this.luminanceDarkBelow = 0.45,
+    this.luminanceLightAbove = 0.72,
+    this.fadeDuration = const Duration(milliseconds: 280),
+  }) : assert(
+          luminanceDarkBelow < luminanceLightAbove,
+          'luminanceDarkBelow must be below luminanceLightAbove',
+        );
 
   /// The scrollable content to apply edge fading to.
   final Widget child;
@@ -144,15 +153,151 @@ class GlassScrollEdgeEffect extends StatefulWidget {
   /// current theme.
   final Color? fadeColor;
 
+  /// Whether each fade band darkens with the content scrolling beneath it.
+  ///
+  /// This is the continuous companion to the content-aware brightness
+  /// verdict — the App Store-style scrim lever. Each enabled edge registers
+  /// its own band with the enclosing [GlassContentAwareScope] and receives
+  /// the band's **mean content luminance** per sample. As the content under
+  /// a band moves through the medium range, a [darkFadeColor] gradient
+  /// cross-fades in over the normal fade (fully dark at
+  /// [luminanceDarkBelow], fully off at [luminanceLightAbove]) — so the
+  /// scrim darkens *early* over medium content while the bars' contrast
+  /// vote flips their appearance *late*, matching the native behavior.
+  ///
+  /// Requires an enclosing [GlassContentAwareScope] with the content wrapped
+  /// in a `GlassContentAwareContent` (one flag on `GlassScaffold` wires all
+  /// of it). Without a scope the bands keep their static appearance.
+  ///
+  /// Defaults to false.
+  final bool contentAwareFade;
+
+  /// The scrim colour the bands darken toward when [contentAwareFade] is on.
+  ///
+  /// Rendered as an additional gradient (same curve as the base fade) whose
+  /// opacity follows the band's content darkness. Defaults to black.
+  final Color? darkFadeColor;
+
+  /// Mean band luminance at or below which the dark scrim is fully opaque.
+  ///
+  /// Must be below [luminanceLightAbove]. Defaults to 0.45 — medium-dark
+  /// content already pulls the scrim fully dark, the early-darkening
+  /// behavior of the native bottom scrim.
+  final double luminanceDarkBelow;
+
+  /// Mean band luminance at or above which the dark scrim is fully off.
+  ///
+  /// Must be above [luminanceDarkBelow]. Defaults to 0.72.
+  final double luminanceLightAbove;
+
+  /// Duration of the scrim darkness animation between sampled targets.
+  ///
+  /// Defaults to 280 ms with an ease-out curve.
+  final Duration fadeDuration;
+
   @override
   State<GlassScrollEdgeEffect> createState() => _GlassScrollEdgeEffectState();
 }
 
-class _GlassScrollEdgeEffectState extends State<GlassScrollEdgeEffect> {
+class _GlassScrollEdgeEffectState extends State<GlassScrollEdgeEffect>
+    with TickerProviderStateMixin {
   GlobalKey? _backgroundKey;
   ui.Image? _backgroundImage;
   bool _hasAttemptedCapture = false;
   bool _capturePending = false;
+
+  // ── Content-aware fade (the scrim lever) ──────────────────────────────────
+  // Each enabled edge registers its own band rect with the enclosing
+  // GlassContentAwareScope and animates a darkness value from the band's
+  // sampled mean luminance. Independent per edge: the bottom band can sit
+  // over dark content while the top band is over light content.
+  final GlobalKey _topBandKey = GlobalKey();
+  final GlobalKey _bottomBandKey = GlobalKey();
+  // Created eagerly in initState — a lazy `late final` here would be
+  // first touched in dispose() when the adaptive fade was never used,
+  // and creating a vsync'd controller during teardown looks up TickerMode
+  // on a deactivated element.
+  late final AnimationController _topDarkness;
+  late final AnimationController _bottomDarkness;
+  GlassContentAwareScopeState? _scope;
+  GlassContentAwareSubscription? _topSub;
+  GlassContentAwareSubscription? _bottomSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _topDarkness = AnimationController(vsync: this);
+    _bottomDarkness = AnimationController(vsync: this);
+  }
+
+  /// Current darkness (0–1) of the top band's adaptive scrim.
+  @visibleForTesting
+  double get topDarkness => _topDarkness.value;
+
+  /// Current darkness (0–1) of the bottom band's adaptive scrim.
+  @visibleForTesting
+  double get bottomDarkness => _bottomDarkness.value;
+
+  /// Keeps the per-edge scope registrations in sync with the configuration.
+  ///
+  /// Runs at the top of build (inherited lookups are legal there and this is
+  /// where dependencies must be registered anyway) and is idempotent.
+  void _syncContentAware() {
+    final want = widget.contentAwareFade
+        ? GlassContentAwareScope.maybeOf(context)
+        : null;
+    final wantTop = want != null && widget.fadeTop;
+    final wantBottom = want != null && widget.fadeBottom;
+    if (_scope == want &&
+        (_topSub != null) == wantTop &&
+        (_bottomSub != null) == wantBottom) {
+      return;
+    }
+    _topSub?.cancel();
+    _bottomSub?.cancel();
+    _topSub = null;
+    _bottomSub = null;
+    _scope = want;
+    if (wantTop) {
+      _topSub = want.register(
+        controlBox: () => _bandBox(_topBandKey),
+        onLuminanceChanged: (luminance) =>
+            _onBandLuminance(_topDarkness, luminance),
+        gridColumns: 4,
+      );
+    }
+    if (wantBottom) {
+      _bottomSub = want.register(
+        controlBox: () => _bandBox(_bottomBandKey),
+        onLuminanceChanged: (luminance) =>
+            _onBandLuminance(_bottomDarkness, luminance),
+        gridColumns: 4,
+      );
+    }
+  }
+
+  RenderBox? _bandBox(GlobalKey key) {
+    if (!mounted) return null;
+    final ro = key.currentContext?.findRenderObject();
+    return ro is RenderBox ? ro : null;
+  }
+
+  void _onBandLuminance(AnimationController darkness, double luminance) {
+    // Map mean luminance to scrim darkness: fully dark at/below
+    // luminanceDarkBelow, fully off at/above luminanceLightAbove, smooth
+    // crossfade in between — darkens EARLY over medium content, unlike the
+    // late-flipping contrast vote.
+    final target = 1.0 -
+        ((luminance - widget.luminanceDarkBelow) /
+                (widget.luminanceLightAbove - widget.luminanceDarkBelow))
+            .clamp(0.0, 1.0);
+    if ((target - darkness.value).abs() < 0.01) return;
+    darkness.animateTo(
+      target,
+      duration: widget.fadeDuration,
+      curve: Curves.easeOut,
+    );
+  }
 
   @override
   void didChangeDependencies() {
@@ -230,6 +375,10 @@ class _GlassScrollEdgeEffectState extends State<GlassScrollEdgeEffect> {
 
   @override
   void dispose() {
+    _topSub?.cancel();
+    _bottomSub?.cancel();
+    _topDarkness.dispose();
+    _bottomDarkness.dispose();
     _backgroundImage?.dispose();
     _backgroundImage = null;
     super.dispose();
@@ -237,6 +386,8 @@ class _GlassScrollEdgeEffectState extends State<GlassScrollEdgeEffect> {
 
   @override
   Widget build(BuildContext context) {
+    _syncContentAware();
+
     // No fading needed — return child directly.
     if (!widget.fadeTop && !widget.fadeBottom) return widget.child;
 
@@ -276,6 +427,38 @@ class _GlassScrollEdgeEffectState extends State<GlassScrollEdgeEffect> {
     required Size screenSize,
     required bool hasTexture,
   }) {
+    // Adaptive path: the fade's target darkens toward darkFadeColor by the
+    // band's sampled content luminance, so over dark content it dissolves
+    // toward dark (invisible against dark content) instead of always toward
+    // the light page background. The band key marks the rect the scope samples
+    // (the scope reads the CONTENT behind the fade, not the fade itself — the
+    // GlassScaffold wrap order keeps the fade outside the captured region, so
+    // there's no feedback loop).
+    if (widget.contentAwareFade) {
+      final darkness = isTop ? _topDarkness : _bottomDarkness;
+      return Positioned(
+        top: isTop ? 0 : null,
+        bottom: isTop ? null : 0,
+        left: 0,
+        right: 0,
+        height: height,
+        child: IgnorePointer(
+          key: isTop ? _topBandKey : _bottomBandKey,
+          child: AnimatedBuilder(
+            animation: darkness,
+            builder: (context, _) => _fadeLayer(
+              isTop: isTop,
+              height: height,
+              screenSize: screenSize,
+              hasTexture: hasTexture,
+              darkness: darkness.value,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Non-adaptive path — unchanged behaviour (darkness fixed at 0).
     return Positioned(
       top: isTop ? 0 : null,
       bottom: isTop ? null : 0,
@@ -283,25 +466,53 @@ class _GlassScrollEdgeEffectState extends State<GlassScrollEdgeEffect> {
       right: 0,
       height: height,
       child: IgnorePointer(
-        child: hasTexture
-            ? CustomPaint(
-                size: Size(screenSize.width, height),
-                painter: _TextureFadePainter(
-                  image: _backgroundImage!,
-                  isTop: isTop,
-                  screenHeight: screenSize.height,
-                  style: widget.style,
-                ),
-              )
-            : _buildColorOverlay(isTop: isTop),
+        child: _fadeLayer(
+          isTop: isTop,
+          height: height,
+          screenSize: screenSize,
+          hasTexture: hasTexture,
+          darkness: 0.0,
+        ),
       ),
     );
   }
 
-  /// Fallback: solid-colour gradient overlay for use outside [GlassPage].
-  Widget _buildColorOverlay({required bool isTop}) {
-    final color =
+  /// Builds one edge's fade layer: the captured-texture painter inside a
+  /// [GlassPage], or the solid-colour gradient otherwise. [darkness] (0–1)
+  /// drives content-aware darkening on both paths (0 = the plain fade).
+  Widget _fadeLayer({
+    required bool isTop,
+    required double height,
+    required Size screenSize,
+    required bool hasTexture,
+    required double darkness,
+  }) {
+    return hasTexture
+        ? CustomPaint(
+            size: Size(screenSize.width, height),
+            painter: _TextureFadePainter(
+              image: _backgroundImage!,
+              isTop: isTop,
+              screenHeight: screenSize.height,
+              style: widget.style,
+              darkness: darkness,
+              darkColor: widget.darkFadeColor ?? const Color(0xFF000000),
+            ),
+          )
+        : _buildColorOverlay(isTop: isTop, darkness: darkness);
+  }
+
+  /// Solid-colour gradient overlay (used outside [GlassPage], and for the
+  /// adaptive path). When [darkness] > 0 the fade target is lerped toward
+  /// [GlassScrollEdgeEffect.darkFadeColor], so the whole gradient — including
+  /// the visible region above the bar — reflects the content's darkness.
+  Widget _buildColorOverlay({required bool isTop, double darkness = 0.0}) {
+    final base =
         widget.fadeColor ?? CupertinoTheme.of(context).scaffoldBackgroundColor;
+    final color = darkness > 0
+        ? Color.lerp(
+            base, widget.darkFadeColor ?? const Color(0xFF000000), darkness)!
+        : base;
     final curve = _kFadeCurves[widget.style]!;
     return DecoratedBox(
       decoration: BoxDecoration(
@@ -386,12 +597,21 @@ class _TextureFadePainter extends CustomPainter {
     required this.isTop,
     required this.screenHeight,
     required this.style,
+    this.darkness = 0.0,
+    this.darkColor = const Color(0xFF000000),
   });
 
   final ui.Image image;
   final bool isTop;
   final double screenHeight;
   final GlassScrollEdgeStyle style;
+
+  /// Content-aware darkening, 0–1. When > 0 the captured strip is blended
+  /// toward [darkColor] by this amount BEFORE the gradient mask, so the
+  /// adaptive fade dissolves toward dark over dark content instead of
+  /// revealing the (typically light) page background as a bright scrim.
+  final double darkness;
+  final Color darkColor;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -420,6 +640,18 @@ class _TextureFadePainter extends CustomPainter {
     // Draw the background texture slice.
     canvas.drawImageRect(image, srcRect, dstRect, Paint());
 
+    // Content-aware darkening: blend the whole strip toward darkColor by
+    // [darkness] BEFORE the alpha mask. Applying it pre-mask (uniform over the
+    // strip) means the darkening survives across the full visible band rather
+    // than concentrating at the occluded edge — so over dark content the fade
+    // reads dark, not as the light page background.
+    if (darkness > 0) {
+      canvas.drawRect(
+        dstRect,
+        Paint()..color = darkColor.withValues(alpha: darkness.clamp(0.0, 1.0)),
+      );
+    }
+
     // Apply gradient alpha mask: opaque at the edge, transparent towards
     // the content. Uses a multi-stop eased gradient to produce a
     // perceptually smooth fade without a visible seam at the boundary.
@@ -444,5 +676,9 @@ class _TextureFadePainter extends CustomPainter {
       image != oldDelegate.image ||
       isTop != oldDelegate.isTop ||
       screenHeight != oldDelegate.screenHeight ||
-      style != oldDelegate.style;
+      style != oldDelegate.style ||
+      darkColor != oldDelegate.darkColor ||
+      // darkness last: it changes every animation tick (other fields equal),
+      // so this clause is the one always reached/evaluated.
+      darkness != oldDelegate.darkness;
 }

--- a/lib/widgets/surfaces/glass_scaffold.dart
+++ b/lib/widgets/surfaces/glass_scaffold.dart
@@ -137,6 +137,7 @@ class GlassScaffold extends StatelessWidget {
     this.headerScrollController,
     this.headerFadeDistance = 60.0,
     this.contentAwareBrightness = false,
+    this.contentAwareEdgeFade = false,
   });
 
   // ===========================================================================
@@ -351,6 +352,20 @@ class GlassScaffold extends StatelessWidget {
   /// ```
   final bool contentAwareBrightness;
 
+  /// Whether the scroll-edge fades darken with the content beneath them —
+  /// the continuous scrim companion to [contentAwareBrightness].
+  ///
+  /// Forwarded to [GlassScrollEdgeEffect.contentAwareFade]: each fade band
+  /// registers its own rect with the content-aware scope and cross-fades a
+  /// dark scrim in as the content under it moves through the medium range —
+  /// darkening *early*, while the bars' contrast vote flips their appearance
+  /// *late*, matching the native App Store behavior.
+  ///
+  /// Requires [contentAwareBrightness] (which installs the scope and the
+  /// sampled content region) and the edge fades to be enabled; otherwise it
+  /// is inert. Defaults to false.
+  final bool contentAwareEdgeFade;
+
   // ===========================================================================
   // Build
   // ===========================================================================
@@ -386,7 +401,18 @@ class GlassScaffold extends StatelessWidget {
     // Build the body content.
     Widget bodyContent = body;
 
-    // Wrap with edge fading if enabled.
+    // Wrap in GlassContentAwareContent when content-aware brightness is on.
+    // This installs the RepaintBoundary that the scope captures. It must
+    // wrap the BODY ONLY — before the edge fade — so the fade overlays stay
+    // outside the captured region: the sampler must see the content, not
+    // the things reacting to it. (With the adaptive edge fade this is load-
+    // bearing: a scrim inside its own sampling input is a feedback loop —
+    // it would darken what it samples and run away.)
+    if (contentAwareBrightness) {
+      bodyContent = GlassContentAwareContent(child: bodyContent);
+    }
+
+    // Wrap with edge fading if enabled — outside the sampled region.
     if (extendBody && (doFadeTop || doFadeBottom)) {
       bodyContent = GlassScrollEdgeEffect(
         topFadeHeight: topFadeHeight,
@@ -394,14 +420,9 @@ class GlassScaffold extends StatelessWidget {
         fadeTop: doFadeTop,
         fadeBottom: doFadeBottom,
         style: edgeStyle,
+        contentAwareFade: contentAwareEdgeFade,
         child: bodyContent,
       );
-    }
-
-    // Wrap in GlassContentAwareContent when content-aware brightness is on.
-    // This installs the RepaintBoundary that the scope captures.
-    if (contentAwareBrightness) {
-      bodyContent = GlassContentAwareContent(child: bodyContent);
     }
 
     // Build the Stack with guaranteed z-ordering.

--- a/test/widgets/overlays/glass_modal_sheet_state_coverage_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_state_coverage_test.dart
@@ -281,4 +281,27 @@ void main() {
       expect(true, isTrue); // no exception
     });
   });
+
+  group('GlassModalSheet — handle-drag gesture lifecycle', () {
+    testWidgets('pointer down in the handle zone then cancel clears the '
+        'handle-drag state without stalling', (tester) async {
+      await tester.pumpWidget(_makeSheet());
+      await tester.pumpAndSettle();
+
+      final handleFinder = find.byElementPredicate(
+          (e) => e.widget.runtimeType.toString() == '_GlassDragIndicator');
+      expect(handleFinder, findsOneWidget);
+
+      // Pointer-down in the handle zone arms the handle drag (disables the
+      // inner scroll for the gesture); a cancel must clear it again
+      // (_onPointerCancel) so the sheet isn't left with its inner scroll
+      // permanently disabled.
+      final gesture =
+          await tester.startGesture(tester.getCenter(handleFinder));
+      await tester.pump();
+      await gesture.cancel();
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+    });
+  });
 }

--- a/test/widgets/shared/content_aware_fade_test.dart
+++ b/test/widgets/shared/content_aware_fade_test.dart
@@ -1,0 +1,359 @@
+// ignore_for_file: require_trailing_commas
+// Tests for the content-luminance scrim lever:
+//   - GlassContentAwareScope.computeMeanLuminance (perceptual mean,
+//     transparency substitution, degenerate inputs)
+//   - luminance delivery through register(onLuminanceChanged:) with the
+//     delta threshold, and brightness-callback-less registrations
+//   - GlassScrollEdgeEffect.contentAwareFade: per-band darkness over dark /
+//     light / medium content, inertness without a scope, sub lifecycle
+//   - GlassScaffold: contentAwareEdgeFade forwarding and the capture
+//     wrap-order (fade overlays must stay OUTSIDE the sampled region)
+
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+Uint8List _rowOf(int width, Color color, {int alpha = 255}) {
+  final bytes = Uint8List(width * 4);
+  final r = ((color.r * 255).round()) & 0xFF;
+  final g = ((color.g * 255).round()) & 0xFF;
+  final b = ((color.b * 255).round()) & 0xFF;
+  for (var x = 0; x < width; x++) {
+    bytes[x * 4] = r;
+    bytes[x * 4 + 1] = g;
+    bytes[x * 4 + 2] = b;
+    bytes[x * 4 + 3] = alpha;
+  }
+  return bytes;
+}
+
+double _meanLuma(
+  Uint8List rgba,
+  int width, {
+  Color background = const Color(0xFFFFFFFF),
+  List<Rect>? cells,
+}) {
+  return GlassContentAwareScope.computeMeanLuminance(
+    rgba: rgba,
+    width: width,
+    height: 1,
+    cellRects: cells ??
+        <Rect>[for (var i = 0; i < width; i++) Rect.fromLTWH(i.toDouble(), 0, 1, 1)],
+    background: background,
+  );
+}
+
+/// Runs one deterministic sample to completion (captures only complete
+/// inside runAsync; an in-flight registration sample holds the
+/// single-flight latch, so let it finish first).
+Future<void> _settleSample(
+  WidgetTester tester,
+  GlassContentAwareScopeState scope,
+) {
+  return tester.runAsync(() async {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await scope.sampleNow();
+  });
+}
+
+void main() {
+  group('computeMeanLuminance', () {
+    test('black is 0, white is 1, mid-gray is mid', () {
+      expect(_meanLuma(_rowOf(4, const Color(0xFF000000)), 4), closeTo(0, 1e-6));
+      expect(_meanLuma(_rowOf(4, const Color(0xFFFFFFFF)), 4), closeTo(1, 1e-6));
+      expect(
+        _meanLuma(_rowOf(4, const Color(0xFF808080)), 4),
+        closeTo(0.5, 0.01),
+      );
+    });
+
+    test('mixed content averages across cells', () {
+      final rgba = Uint8List.fromList([
+        ..._rowOf(2, const Color(0xFF000000)),
+        ..._rowOf(2, const Color(0xFFFFFFFF)),
+      ]);
+      expect(_meanLuma(rgba, 4), closeTo(0.5, 0.01));
+    });
+
+    test('transparent pixels read as the background', () {
+      final rgba = _rowOf(4, const Color(0xFFFFFFFF), alpha: 0);
+      expect(
+        _meanLuma(rgba, 4, background: const Color(0xFF000000)),
+        closeTo(0, 1e-6),
+      );
+      expect(
+        _meanLuma(rgba, 4, background: const Color(0xFFFFFFFF)),
+        closeTo(1, 1e-6),
+      );
+    });
+
+    test('degenerate inputs return 1.0 (light)', () {
+      expect(
+        GlassContentAwareScope.computeMeanLuminance(
+          rgba: Uint8List(0),
+          width: 0,
+          height: 0,
+          cellRects: const [Rect.fromLTWH(0, 0, 1, 1)],
+          background: const Color(0xFFFFFFFF),
+        ),
+        1.0,
+      );
+      expect(_meanLuma(_rowOf(4, const Color(0xFF000000)), 4, cells: const []),
+          1.0);
+    });
+  });
+
+  group('scope luminance delivery', () {
+    Widget host({required Color content}) => MaterialApp(
+          home: GlassContentAwareScope(
+            child: GlassContentAwareContent(
+              child: ColoredBox(color: content),
+            ),
+          ),
+        );
+
+    testWidgets('delivers mean luminance without a brightness callback',
+        (tester) async {
+      await tester.pumpWidget(host(content: const Color(0xFF000000)));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      final box = tester.renderObject(
+          find.byType(GlassContentAwareContent)) as RenderBox;
+      final received = <double>[];
+      final sub = scope.register(
+        controlBox: () => box,
+        onLuminanceChanged: received.add,
+      );
+      expect(sub.meanLuminance, isNull);
+      await _settleSample(tester, scope);
+      expect(received, hasLength(1));
+      expect(received.single, lessThan(0.05));
+      expect(sub.meanLuminance, received.single);
+
+      // Re-sampling identical content stays inside the delta threshold —
+      // no churn delivery.
+      await _settleSample(tester, scope);
+      expect(received, hasLength(1));
+      sub.cancel();
+    });
+
+    testWidgets('verdict still flips when both callbacks are registered',
+        (tester) async {
+      await tester.pumpWidget(host(content: const Color(0xFF000000)));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      final box = tester.renderObject(
+          find.byType(GlassContentAwareContent)) as RenderBox;
+      Brightness? verdict;
+      double? luminance;
+      final sub = scope.register(
+        controlBox: () => box,
+        onBrightnessChanged: (b) => verdict = b,
+        onLuminanceChanged: (l) => luminance = l,
+      );
+      await _settleSample(tester, scope);
+      expect(verdict, Brightness.dark);
+      expect(luminance, lessThan(0.05));
+      sub.cancel();
+    });
+  });
+
+  group('GlassScrollEdgeEffect.contentAwareFade', () {
+    Widget host({
+      required Color content,
+      bool contentAware = true,
+      bool fadeTop = true,
+      bool fadeBottom = true,
+      bool withScope = true,
+    }) {
+      final effect = GlassScrollEdgeEffect(
+        contentAwareFade: contentAware,
+        fadeTop: fadeTop,
+        fadeBottom: fadeBottom,
+        child: GlassContentAwareContent(
+          child: ColoredBox(color: content, child: const SizedBox.expand()),
+        ),
+      );
+      return MaterialApp(
+        home: withScope ? GlassContentAwareScope(child: effect) : effect,
+      );
+    }
+
+    testWidgets('bands darken over dark content and animate there',
+        (tester) async {
+      await tester.pumpWidget(host(content: const Color(0xFF000000)));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      final effectState =
+          tester.state(find.byType(GlassScrollEdgeEffect)) as dynamic;
+      expect(effectState.bottomDarkness, 0.0);
+
+      await _settleSample(tester, scope);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      // Mid-animation: strictly between the endpoints.
+      final mid = effectState.bottomDarkness as double;
+      expect(mid, greaterThan(0.0));
+      expect(mid, lessThan(1.0));
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(effectState.bottomDarkness, closeTo(1.0, 0.01));
+      expect(effectState.topDarkness, closeTo(1.0, 0.01));
+    });
+
+    testWidgets('bands stay light over light content', (tester) async {
+      await tester.pumpWidget(host(content: const Color(0xFFFFFFFF)));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      final effectState =
+          tester.state(find.byType(GlassScrollEdgeEffect)) as dynamic;
+      await _settleSample(tester, scope);
+      await tester.pump(const Duration(milliseconds: 350));
+      expect(effectState.bottomDarkness, 0.0);
+    });
+
+    testWidgets('medium content pulls the scrim mostly dark — early '
+        'darkening', (tester) async {
+      // Mid-gray ≈ 0.5 perceptual luminance → darkness ≈
+      // 1 - (0.5 - 0.45)/(0.72 - 0.45) ≈ 0.81: the scrim darkens over
+      // content the brightness vote would still call "light".
+      await tester.pumpWidget(host(content: const Color(0xFF808080)));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      final effectState =
+          tester.state(find.byType(GlassScrollEdgeEffect)) as dynamic;
+      await _settleSample(tester, scope);
+      await tester.pump(); // first tick anchors the ticker's start time
+      await tester.pump(const Duration(milliseconds: 350));
+      expect(effectState.bottomDarkness, closeTo(0.81, 0.06));
+    });
+
+    testWidgets('inert without a scope', (tester) async {
+      await tester.pumpWidget(
+          host(content: const Color(0xFF000000), withScope: false));
+      final effectState =
+          tester.state(find.byType(GlassScrollEdgeEffect)) as dynamic;
+      await tester.pump(const Duration(milliseconds: 350));
+      expect(effectState.bottomDarkness, 0.0);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('inert when contentAwareFade is off', (tester) async {
+      await tester.pumpWidget(
+          host(content: const Color(0xFF000000), contentAware: false));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      final effectState =
+          tester.state(find.byType(GlassScrollEdgeEffect)) as dynamic;
+      await _settleSample(tester, scope);
+      await tester.pump(const Duration(milliseconds: 350));
+      expect(effectState.bottomDarkness, 0.0);
+    });
+
+    testWidgets('single-edge config registers a single band',
+        (tester) async {
+      await tester.pumpWidget(host(
+        content: const Color(0xFF000000),
+        fadeTop: false,
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      final effectState =
+          tester.state(find.byType(GlassScrollEdgeEffect)) as dynamic;
+      await _settleSample(tester, scope);
+      await tester.pump(); // first tick anchors the ticker's start time
+      await tester.pump(const Duration(milliseconds: 350));
+      expect(effectState.bottomDarkness, closeTo(1.0, 0.01));
+      expect(effectState.topDarkness, 0.0);
+    });
+
+    testWidgets('toggling contentAwareFade off cancels the registrations',
+        (tester) async {
+      await tester.pumpWidget(host(content: const Color(0xFF000000)));
+      await tester.pumpWidget(
+          host(content: const Color(0xFF000000), contentAware: false));
+      // And tearing the whole tree down disposes cleanly mid-flight.
+      await tester.pumpWidget(Container());
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('texture-backed fade path', () {
+    testWidgets('adaptive scrim layers over the captured-texture fade',
+        (tester) async {
+      // Inside GlassPage the fade paints a slice of the captured background
+      // texture; the adaptive scrim must layer over that path too.
+      await tester.pumpWidget(MaterialApp(
+        home: GlassPage(
+          background: const ColoredBox(color: Color(0xFF101010)),
+          child: GlassContentAwareScope(
+            child: GlassScrollEdgeEffect(
+              contentAwareFade: true,
+              child: GlassContentAwareContent(
+                child: const ColoredBox(
+                  color: Color(0xFF101010),
+                  child: SizedBox.expand(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ));
+      final scope = tester.state<GlassContentAwareScopeState>(
+          find.byType(GlassContentAwareScope));
+      // Let the page's background capture (toImage) complete, then sample.
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+        await scope.sampleNow();
+      });
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+      // Texture path rendered with the dark scrim layered on top.
+      expect(find.byType(CustomPaint), findsWidgets);
+      final effectState =
+          tester.state(find.byType(GlassScrollEdgeEffect)) as dynamic;
+      expect(effectState.bottomDarkness, greaterThan(0.5));
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('GlassScaffold integration', () {
+    testWidgets(
+        'contentAwareEdgeFade forwards and the fade overlays stay outside '
+        'the sampled region', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: GlassScaffold(
+          contentAwareBrightness: true,
+          contentAwareEdgeFade: true,
+          bottomBar: const SizedBox(height: 60),
+          body: ListView(children: [Container(height: 2000)]),
+        ),
+      ));
+      await tester.pump();
+
+      final effect = tester.widget<GlassScrollEdgeEffect>(
+          find.byType(GlassScrollEdgeEffect));
+      expect(effect.contentAwareFade, isTrue);
+
+      // Wrap order: the sampled region must NOT contain the edge effect
+      // (the scrim cannot be allowed to feed back into its own sampling
+      // input), and the edge effect must contain the sampled region.
+      expect(
+        find.descendant(
+          of: find.byType(GlassContentAwareContent),
+          matching: find.byType(GlassScrollEdgeEffect),
+        ),
+        findsNothing,
+      );
+      expect(
+        find.descendant(
+          of: find.byType(GlassScrollEdgeEffect),
+          matching: find.byType(GlassContentAwareContent),
+        ),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
# Content-aware scroll-edge scrim (#102 fast-follow) + small GlassModalSheet / GlassEffect fixes

The fast-follow scrim lever from #103, plus a few small, independent fixes we'd been carrying app-side and wanted to upstream while we were in here. Kept as **separate commits** so they're reviewable (and splittable) individually:

1. `feat:` content-luminance scroll-edge scrim
2. `fix(GlassModalSheet):` handle-drag vs inner-scroll + `dragIndicatorColor`
3. `fix(GlassEffect):` defer backdrop capture when the boundary is mid-paint

If you'd rather take only some, the commits are independent — happy to split.

---

## 1. Content-luminance scroll-edge scrim (the #102 fast-follow)

The merged brightness machinery (#103) is the **discrete** lever — a WCAG contrast vote that flips a control's appearance *late*, only over genuinely dark content. This adds the **continuous** companion: the scroll-edge fade dissolves toward a color that tracks the content's luminance, so the edge stays seamless (and reduces edge contrast for floating controls) as content scrolls under the bars.

**What's added:**
- **`GlassContentAwareScope` exposes per-rect mean luminance.** `register()` gains `onLuminanceChanged` (and `onBrightnessChanged` becomes optional), delivered from the *same* single capture that serves the verdicts — N consumers, one readback. Deliveries are gated on >0.005 movement so consumer animations don't churn.
- **`GlassScrollEdgeEffect.contentAwareFade`.** Each enabled edge registers its own band with the scope and **lerps the fade's *target color* toward `darkFadeColor` by the band's content darkness** — fully dark at `luminanceDarkBelow` (0.45), off at `luminanceLightAbove` (0.72), animated over `fadeDuration` (280 ms). Over dark content the whole fade (including the strip above the bar) dissolves toward dark instead of toward the light page background; over light content it stays the light dissolve. Applied on **both** the captured-texture path (`GlassPage`) and the solid-color path. Bands are independent (top vs bottom), inert without a scope.
- **`GlassScaffold.contentAwareEdgeFade`** — one flag, composing with `contentAwareBrightness`.

> **Implementation note:** an earlier cut layered a separate dark gradient *over* the base fade, but the fade curve concentrates opacity at the bar edge (occluded by the bar), so the visible strip stayed light. Lerping the fade's target color instead darkens the whole band uniformly. Verified on-device (iOS, Impeller): over a black band the scrim dissolves to black (no light scrim); light↔dark cross-fades cleanly while the bar flips late.

**Also fixes a latent bug in shipped 0.16.0:** `GlassScaffold` wraps the body in the edge fade *first*, then in `GlassContentAwareContent` — so the fade overlays sit **inside** the captured region, and a `contentAwareBrightness` bar samples its own fade. This PR swaps the order (content-marker inside, fade outside) + a regression test. With the adaptive scrim that ordering is load-bearing (a scrim inside its own sampling input is a feedback loop).

The `content_aware_brightness_demo` turns the flag on so both levers show at once.

## 2. `fix(GlassModalSheet)` — two independent handle fixes

- **Handle drag no longer fights the inner scrollable.** A pointer-down in the top handle zone sets a `_handleDragActive` notifier (cleared on up/cancel), folded into the build's `AnimatedBuilder` listenable so it lands on pointer-down — before the inner `Scrollable`'s vertical-drag recognizer can claim the gesture. Gates a new `disableInnerScroll` on `_SheetLayout → _SheetContent`. Fixes a stall where, at the full state, grabbing the handle let the content overscroll and steal the pointer — acute over a PlatformView, which takes the touch natively mid-drag and freezes the sheet.
- **`dragIndicatorColor` now reaches the handle.** It was threaded into `_SheetLayout` but never passed to `_SheetHandleZone`/`_GlassDragIndicator` — a silent no-op. Wired through (`color ?? iOS-26 default`).

## 3. `fix(GlassEffect)` — defer capture when the boundary is mid-paint *(optional)*

`_captureBackgroundSync` runs `toImageSync` from `_handleTick` (transient phase, before paint), every frame during interaction. While the backdrop repaints, the boundary is dirty and `toImageSync` asserts in debug — caught, but it spams `[GlassEffect] toImageSync failed` nearly every interaction frame and drops that frame's capture. Guarded the same way `GlassScrollEdgeEffect` already does: if `boundary.debugNeedsPaint` (read inside an assert closure, so release never touches it), defer to a post-frame callback. ~20 lines, self-contained.

## Verification

- `flutter analyze` clean; full CI-equivalent suite **1926 tests** passing.
- Patch coverage **134/136**; the two uncovered lines are the GlassEffect deferred-capture branch — the headless test infra can't produce a mid-paint GPU capture (the same reason `lib/src/renderer/**` is excluded from the effective-coverage gate). Project effective coverage stays above the 90% gate. New/extended tests: the luminance output + adaptive fade (color + texture paths, early-darkening asserted directly), the wrap-order regression guard, and the modal-sheet handle-drag-cancel lifecycle.
- Golden failure set unchanged vs `main` (the known macOS-host set, CI-excluded).
- Scroll-edge scrim verified on-device; the GlassModalSheet fixes were validated in our app's map "park sheet" (the PlatformView stall they fix).

---

## Still open on our side (not blocking this PR)

Independent of all of the above, the two design questions in [this #103 comment](https://github.com/sdegenaar/liquid_glass_widgets/pull/103#issuecomment-4697884980) are still open — flagging again in case it got buried:

1. Now that `whitenStrength` exists, would you default achromatic tints to the luminosity (see-through) path — vs. the explicit `GlassTintBlend` enum we have staged?
2. Would you be open to a built-in control scrim/backer (light/dark + strength)?

No rush, and this PR doesn't depend on either.
