### PR TITLE
GlassTintBlend — selectable tint blending path (auto/luminosity/flat)

### DIFF
--- a/lib/liquid_glass_widgets.dart
+++ b/lib/liquid_glass_widgets.dart
@@ -16,6 +16,7 @@ export 'src/renderer/liquid_glass_renderer.dart'
 export 'src/renderer/liquid_shape.dart'; // all shapes are public
 export 'src/renderer/internal/interaction_notification.dart'; // public for Smart Silence support
 export 'types/glass_specular_sharpness.dart'; // GlassSpecularSharpness enum
+export 'types/glass_tint_blend.dart'; // GlassTintBlend enum
 
 // Setup and Configuration
 export 'liquid_glass_setup.dart';

--- a/lib/src/renderer/liquid_glass_settings.dart
+++ b/lib/src/renderer/liquid_glass_settings.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import '../../constants/glass_defaults.dart';
 import '../../constants/glass_shadow.dart';
 import '../../types/glass_specular_sharpness.dart';
+import '../../types/glass_tint_blend.dart';
 import 'liquid_glass_renderer.dart';
 import 'liquid_glass_render_scope.dart';
 
@@ -29,6 +30,7 @@ class LiquidGlassSettings with EquatableMixin {
     this.shadow,
     this.whitenStrength = 0.0,
     this.whitenGated = true,
+    this.tintBlend = GlassTintBlend.auto,
   });
 
   /// Creates [LiquidGlassSettings] using Figma-inspired parameter names.
@@ -251,6 +253,20 @@ class LiquidGlassSettings with EquatableMixin {
   /// approximations are always uniform.
   final bool whitenGated;
 
+  /// How [glassColor] blends with the refracted backdrop.
+  ///
+  /// [GlassTintBlend.auto] (the default) picks the path from the tint's
+  /// chroma — colorful tints preserve backdrop luminosity, achromatic tints
+  /// use the flat blend — which is the historical behavior. Force
+  /// [GlassTintBlend.luminosity] for near-neutral tints that must keep the
+  /// glassy look (e.g. a light-mode recipe with the color dialed almost
+  /// out), or [GlassTintBlend.flat] when imposing the tint's brightness is
+  /// the point (dimming layers, shape-matched backing scrims).
+  ///
+  /// Applies to the Premium and Standard paths; the Frosted fallback tier
+  /// renders a flat tint by construction and ignores this setting.
+  final GlassTintBlend tintBlend;
+
   /// The effective saturation taking visibility into account.
   double get effectiveSaturation => 1 + (saturation - 1) * visibility;
 
@@ -293,6 +309,7 @@ class LiquidGlassSettings with EquatableMixin {
       shadow: t < 0.5 ? a.shadow : b.shadow,
       whitenStrength: lerpDouble(a.whitenStrength, b.whitenStrength, t)!,
       whitenGated: t < 0.5 ? a.whitenGated : b.whitenGated,
+      tintBlend: t < 0.5 ? a.tintBlend : b.tintBlend,
     );
   }
 
@@ -324,6 +341,7 @@ class LiquidGlassSettings with EquatableMixin {
     List<BoxShadow>? shadow,
     double? whitenStrength,
     bool? whitenGated,
+    GlassTintBlend? tintBlend,
   }) =>
       LiquidGlassSettings(
         visibility: visibility ?? this.visibility,
@@ -344,6 +362,7 @@ class LiquidGlassSettings with EquatableMixin {
         shadow: shadow ?? this.shadow,
         whitenStrength: whitenStrength ?? this.whitenStrength,
         whitenGated: whitenGated ?? this.whitenGated,
+        tintBlend: tintBlend ?? this.tintBlend,
       );
 
   @override
@@ -365,5 +384,6 @@ class LiquidGlassSettings with EquatableMixin {
         shadow,
         whitenStrength,
         whitenGated,
+        tintBlend,
       ];
 }

--- a/lib/src/renderer/rendering/liquid_glass_render_object.dart
+++ b/lib/src/renderer/rendering/liquid_glass_render_object.dart
@@ -145,10 +145,13 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
     });
     // Slot 18: uWhiten (whitening amount); slot 19: uWhitenGated
     // (1 = luminance-gated, the light-mode behaviour; 0 = uniform lift).
+    // Slot 20: uTintBlend (0 = auto chroma gate, 1 = force luminosity-
+    // preserving, 2 = force flat blend — see GlassTintBlend).
     renderShader.setFloatUniforms(initialIndex: 18, (value) {
       value
         ..setFloat(settings.whitenStrength)
-        ..setFloat(settings.whitenGated ? 1.0 : 0.0);
+        ..setFloat(settings.whitenGated ? 1.0 : 0.0)
+        ..setFloat(settings.tintBlend.glslValue);
     });
   }
 

--- a/lib/types/glass_tint_blend.dart
+++ b/lib/types/glass_tint_blend.dart
@@ -1,0 +1,57 @@
+/// How a glass surface blends its tint (`glassColor`) with the refracted
+/// backdrop.
+///
+/// Liquid glass has two tint blending paths with different jobs:
+///
+/// - **Flat blend** — every backdrop pixel is pulled toward the tint's color
+///   *and brightness*, like a colored film. This is the only path that can
+///   impose luminance: a white tint frosts dark content toward white (the
+///   dark-mode sheen), a dark tint dims bright content (dimming sheets,
+///   backing scrims). Its cost is that it compresses the backdrop's own
+///   light/dark detail — over bright content a white film reads as fog
+///   rather than glass.
+/// - **Luminosity-preserving blend** — only the *color* shifts toward the
+///   tint; every backdrop pixel keeps its own brightness, so content
+///   structure stays crisp under the glass. This is what reads as "real
+///   glass", but by construction it can never brighten or darken: a white
+///   tint over dark content adjusts itself down to the content's darkness
+///   and effectively disappears.
+///
+/// By default ([auto]) the renderer picks the path from the tint's chroma:
+/// colorful tints take the luminosity-preserving path, achromatic
+/// (white/gray/black) tints take the flat blend. That heuristic matches
+/// most recipes, but some intents need an explicit choice — most notably a
+/// **near-neutral tint that should still render as glass** (a light-mode
+/// bar whose blue has been dialed out), which the chroma gate would
+/// otherwise flatten into a film. The reverse intent also exists: a
+/// *colorful* dimming layer that should impose its brightness.
+///
+/// Applies to the Premium (Impeller) and Standard tint paths. The Frosted
+/// fallback tier renders a flat tint overlay by construction and ignores
+/// this setting.
+enum GlassTintBlend {
+  /// Pick the blend from the tint's chroma (the default).
+  ///
+  /// Colorful tints preserve backdrop luminosity; achromatic tints use the
+  /// flat blend. This is the historical behavior — existing recipes render
+  /// identically.
+  auto,
+
+  /// Always preserve backdrop luminosity, regardless of tint chroma.
+  ///
+  /// Use for near-neutral tints that must keep the glassy look — e.g. a
+  /// light-mode bar recipe with the color dialed almost out, paired with
+  /// `whitenStrength` for legibility.
+  luminosity,
+
+  /// Always use the flat blend, regardless of tint chroma.
+  ///
+  /// Use when imposing the tint's brightness is the point — dimming
+  /// surfaces, shape-matched backing scrims behind controls over busy
+  /// content, or a deliberate frosted-film look.
+  flat;
+
+  /// Value passed to the fragment shaders (0 = auto, 1 = luminosity,
+  /// 2 = flat).
+  double get glslValue => index.toDouble();
+}

--- a/lib/widgets/shared/adaptive_glass.dart
+++ b/lib/widgets/shared/adaptive_glass.dart
@@ -280,6 +280,9 @@ class AdaptiveGlass extends StatelessWidget {
               // surfaces such as bars.
               whitenStrength: normalizedSettings.whitenStrength,
               whitenGated: normalizedSettings.whitenGated,
+              // Preserve the tint blend for the same reason — a forced
+              // luminosity/flat path must survive grouping/elevation.
+              tintBlend: normalizedSettings.tintBlend,
             )
           : normalizedSettings;
 

--- a/lib/widgets/shared/lightweight_liquid_glass.dart
+++ b/lib/widgets/shared/lightweight_liquid_glass.dart
@@ -1022,5 +1022,10 @@ class _RenderLightweightGlass extends RenderProxyBox {
     shader.setFloat(index++, bgOrigin.dy);
     shader.setFloat(index++, bgSize.width);
     shader.setFloat(index++, bgSize.height);
+
+    // 32: uTintBlend — how the tint blends with the body (0 = auto chroma
+    // gate, 1 = force luminosity-preserving, 2 = force flat blend). See
+    // GlassTintBlend.
+    shader.setFloat(index++, _settings.tintBlend.glslValue);
   }
 }

--- a/shaders/lightweight_glass.frag
+++ b/shaders/lightweight_glass.frag
@@ -20,6 +20,10 @@ uniform vec4 uData5; // 20..23 (densityFactor, indicatorWeight, specularSharpnes
 // cornerRadius < 0 → asymmetric mode; per-corner radii come from uData6.
 uniform vec4 uData6; // 24..27 (topLeft, topRight, bottomRight, bottomLeft) — asymmetric only
 uniform vec4 uData7; // 28..31 (bgOrigin.x, bgOrigin.y, bgSize.width, bgSize.height)
+// Slot 32: how the tint blends with the body (mirrors GlassTintBlend).
+// 0 = auto (chroma gate, historical), 1 = force luminosity-preserving,
+// 2 = force flat blend.
+uniform float uTintBlend;
 
 uniform sampler2D uBackground; // The captured background texture
 // Slot 22 (uData5.z): specular sharpness level — passed as float 0.0/1.0/2.0, cast to int.
@@ -91,7 +95,10 @@ vec3 applyGlassColorLW(vec3 liquidColor, vec4 glassColor) {
     // Sharp ramp so anything with meaningful colour uses the luminosity path.
     float chroma = max(max(glassColor.r, glassColor.g), glassColor.b)
                  - min(min(glassColor.r, glassColor.g), glassColor.b);
-    float chromaWeight = clamp(chroma * 8.0, 0.0, 1.0);
+    float autoWeight = clamp(chroma * 8.0, 0.0, 1.0);
+    // Tri-state select (uTintBlend): auto → chroma gate; 1 → 1.0; 2 → 0.0.
+    float chromaWeight = uTintBlend < 0.5 ? autoWeight
+                       : (uTintBlend < 1.5 ? 1.0 : 0.0);
 
     vec3 directMix     = mix(liquidColor, glassColor.rgb, glassColor.a); // achromatic: lift toward glass
     vec3 luminosityMix = mix(liquidColor, tinted,         glassColor.a); // chromatic:  hue-shift, brightness held

--- a/shaders/liquid_glass_final_render.frag
+++ b/shaders/liquid_glass_final_render.frag
@@ -28,6 +28,7 @@ precision highp float; // mediump causes colour banding (10-bit mantissa on mobi
 // Slots 16-17: uLightDirection
 // Slot 18: uWhiten
 // Slot 19: uWhitenGated
+// Slot 20: uTintBlend
 uniform vec2 uSize;          // physical-pixel size of the backdrop capture
 uniform vec2 uGeometryOffset;
 uniform vec2 uGeometrySize;
@@ -50,6 +51,14 @@ uniform float uWhiten;
 // 0 = ungated, uniform whiten across the whole control (the dark-mode
 // behaviour, gives dark glass a small even lift toward white).
 uniform float uWhitenGated;
+
+// Slot 20: uTintBlend — how uGlassColor blends with the refracted backdrop
+// (mirrors GlassTintBlend in Dart). 0 = auto: pick the path from the tint's
+// chroma (the historical behavior). 1 = always luminosity-preserving — for
+// near-neutral tints that must keep the glassy look instead of falling to
+// the flat film. 2 = always flat blend — for dimming layers and backing
+// scrims, where imposing the tint's brightness is the point.
+uniform float uTintBlend;
 
 uniform sampler2D uBackgroundTexture;
 uniform sampler2D uGeometryTexture;
@@ -177,7 +186,7 @@ void main() {
         refractColor = vec4(red, greenSample.g, blue, greenSample.a);
     }
 
-    vec4 finalColor = applyGlassColor(refractColor, uGlassColor);
+    vec4 finalColor = applyGlassColor(refractColor, uGlassColor, uTintBlend);
 
     // VQ4: Content-adaptive glass strength.
     //

--- a/shaders/render.glsl
+++ b/shaders/render.glsl
@@ -158,7 +158,12 @@ vec3 applySaturation(vec3 color, float saturation) {
 // whites collapse to a luminance-matched grey and can never frost the surface.
 // The chroma factor blends smoothly between the two paths — fully branchless.
 // glassColor.a = 0 naturally returns liquidColor via mix() in both paths.
-vec4 applyGlassColor(vec4 liquidColor, vec4 glassColor) {
+//
+// tintBlend selects the blending path (mirrors GlassTintBlend in Dart):
+//   0 = auto — pick from the tint's chroma (the historical behavior)
+//   1 = always luminosity-preserving (near-neutral tints that must stay glassy)
+//   2 = always flat blend (dimming layers, backing scrims, frost films)
+vec4 applyGlassColor(vec4 liquidColor, vec4 glassColor, float tintBlend) {
     float backdropLuminance = dot(liquidColor.rgb, LUMA_WEIGHTS);
     float glassLuminance    = dot(glassColor.rgb, LUMA_WEIGHTS);
 
@@ -169,7 +174,10 @@ vec4 applyGlassColor(vec4 liquidColor, vec4 glassColor) {
     // Use a sharp ramp so anything with meaningful colour uses the luminosity path.
     float chroma = max(max(glassColor.r, glassColor.g), glassColor.b)
                  - min(min(glassColor.r, glassColor.g), glassColor.b);
-    float chromaWeight = clamp(chroma * 8.0, 0.0, 1.0);
+    float autoWeight = clamp(chroma * 8.0, 0.0, 1.0);
+    // Tri-state select: auto → chroma gate; 1 → force 1.0; 2 → force 0.0.
+    float chromaWeight = tintBlend < 0.5 ? autoWeight
+                       : (tintBlend < 1.5 ? 1.0 : 0.0);
 
     // achromatic path: direct mix toward the glass colour (white lifts to white)
     vec3 directMix     = mix(liquidColor.rgb, glassColor.rgb, glassColor.a);
@@ -194,8 +202,9 @@ vec4 renderLiquidGlass(vec2 screenUV, vec2 p, vec2 uSize, float sd, float thickn
     // Calculate lighting effects using background color
     vec3 lighting = calculateLighting(screenUV, normal, sd, thickness, height, lightDirection, lightIntensity, ambientStrength, backgroundColor);
     
-    // Apply glass color tint
-    vec4 finalColor = applyGlassColor(refractColor, glassColor);
+    // Apply glass color tint (auto blend — the historical behavior; the live
+    // pipeline in liquid_glass_final_render.frag passes the configured mode).
+    vec4 finalColor = applyGlassColor(refractColor, glassColor, 0.0);
 
     // Saturation before lighting — specular highlights should remain white/neutral,
     // not be pushed towards the desaturated midpoint. Matches liquid_glass_final_render.frag.

--- a/test/renderer/liquid_glass_settings_test.dart
+++ b/test/renderer/liquid_glass_settings_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/constants/glass_defaults.dart';
 import 'package:liquid_glass_widgets/src/renderer/liquid_glass_settings.dart';
+import 'package:liquid_glass_widgets/types/glass_tint_blend.dart';
 
 void main() {
   group('LiquidGlassSettings', () {
@@ -388,6 +389,48 @@ void main() {
         const s = LiquidGlassSettings(whitenStrength: 0.4, whitenGated: false);
         expect(s.props, contains(0.4));
         expect(s.props, contains(false));
+      });
+    });
+
+    group('tintBlend', () {
+      test('defaults to GlassTintBlend.auto (no behavior change)', () {
+        const s = LiquidGlassSettings();
+        expect(s.tintBlend, GlassTintBlend.auto);
+      });
+
+      test('copyWith round-trips tintBlend', () {
+        const base = LiquidGlassSettings();
+        final copy = base.copyWith(tintBlend: GlassTintBlend.luminosity);
+        expect(copy.tintBlend, GlassTintBlend.luminosity);
+        // Other fields untouched.
+        expect(copy.whitenStrength, base.whitenStrength);
+        expect(copy.blur, base.blur);
+        // Round-trip back.
+        expect(copy.copyWith(tintBlend: GlassTintBlend.auto), equals(base));
+      });
+
+      test('lerp switches tintBlend at t=0.5', () {
+        const a = LiquidGlassSettings(tintBlend: GlassTintBlend.luminosity);
+        const b = LiquidGlassSettings(tintBlend: GlassTintBlend.flat);
+        expect(LiquidGlassSettings.lerp(a, b, 0.49).tintBlend,
+            GlassTintBlend.luminosity);
+        expect(
+            LiquidGlassSettings.lerp(a, b, 0.5).tintBlend, GlassTintBlend.flat);
+        expect(
+            LiquidGlassSettings.lerp(a, b, 1.0).tintBlend, GlassTintBlend.flat);
+      });
+
+      test('equality includes tintBlend', () {
+        const a = LiquidGlassSettings(tintBlend: GlassTintBlend.flat);
+        const b = LiquidGlassSettings(tintBlend: GlassTintBlend.flat);
+        const c = LiquidGlassSettings();
+        expect(a, equals(b));
+        expect(a, isNot(equals(c)));
+      });
+
+      test('props contains tintBlend', () {
+        const s = LiquidGlassSettings(tintBlend: GlassTintBlend.luminosity);
+        expect(s.props, contains(GlassTintBlend.luminosity));
       });
     });
   });

--- a/test/types/glass_types_test.dart
+++ b/test/types/glass_types_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/types/glass_button_style.dart';
 import 'package:liquid_glass_widgets/types/glass_quality.dart';
 import 'package:liquid_glass_widgets/types/glass_specular_sharpness.dart';
+import 'package:liquid_glass_widgets/types/glass_tint_blend.dart';
 
 void main() {
   // ──────────────────────────────────────────────────────────────────────────
@@ -198,6 +199,28 @@ void main() {
         expect(GlassSpecularSharpness.medium.index,
             lessThan(GlassSpecularSharpness.sharp.index));
       });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GlassTintBlend enum
+  // ──────────────────────────────────────────────────────────────────────────
+
+  group('GlassTintBlend', () {
+    test('has exactly 3 values in shader order', () {
+      expect(GlassTintBlend.values, hasLength(3));
+      expect(GlassTintBlend.values, [
+        GlassTintBlend.auto,
+        GlassTintBlend.luminosity,
+        GlassTintBlend.flat,
+      ]);
+    });
+
+    test('glslValue matches the shader tri-state encoding', () {
+      // The shaders select: <0.5 -> auto gate, <1.5 -> luminosity, else flat.
+      expect(GlassTintBlend.auto.glslValue, 0.0);
+      expect(GlassTintBlend.luminosity.glslValue, 1.0);
+      expect(GlassTintBlend.flat.glslValue, 2.0);
     });
   });
 }


### PR DESCRIPTION
# `GlassTintBlend` — selectable tint blending path (auto / luminosity / flat)

Small, fully backward-compatible knob that makes the tint blending path an explicit per-recipe choice instead of an automatic-only heuristic.

> This is the staged enum from the [#103 design questions](https://github.com/sdegenaar/liquid_glass_widgets/pull/103#issuecomment-4697884980) — you preferred keeping the achromatic case explicit (`GlassTintBlend.auto` on the enum) over silently flipping the default, so here it is. Defaults are byte-for-byte unchanged.

## The two paths, and what the auto gate can't express

`applyGlassColor` blends `glassColor` with the refracted backdrop via one of two paths, picked today by the tint's chroma (`chromaWeight = clamp(chroma * 8, 0, 1)`):

- **Luminosity-preserving** (colorful tints): shift hue toward the tint, keep every backdrop pixel's own brightness. Content structure stays crisp — what reads as *glass*.
- **Flat blend** (achromatic tints): pull pixels toward the tint's color *and brightness*. The only path that can impose luminance — white frost sheen over dark content, dimming behind dark surfaces.

The auto gate matches most recipes (your defaults ride it well — the slightly blue light-theme tint lands ~0.94 on the luminosity path, and `white24` bars get their dark-mode frost from the flat path). But it forbids two legitimate intents:

1. **A near-neutral tint that must still render as glass.** Our light-mode bar recipe dials the blue almost completely out; the chroma gate flattens it into a fog film over light content. (This is the one divergence we've been carrying as a vendored shader patch since the whiten work — with this knob, our fork finally dies.)
2. **A colorful tint that should impose its brightness** — a tinted dimming layer or a shape-matched backing scrim behind a mid-page control (segmented control, search pill) sitting over busy content. The gate forces those glassy, so the backdrop bleeds through exactly where you wanted calm.

## The API

```dart
LiquidGlassSettings(
  glassColor: const Color(0x14F2F4F6),       // near-neutral
  tintBlend: GlassTintBlend.luminosity,       // …but still real glass
  whitenStrength: 0.55,                       // legibility from whiten
)

LiquidGlassSettings(
  glassColor: const Color(0x66202830),        // blue-gray dimmer
  tintBlend: GlassTintBlend.flat,             // impose its darkness
)
```

- `GlassTintBlend.auto` — the default. The existing chroma gate, byte-for-byte: **zero behavior change for every existing recipe.**
- `GlassTintBlend.luminosity` — always preserve backdrop luminance.
- `GlassTintBlend.flat` — always impose the tint.

An enum rather than a nullable bool so `copyWith` composes cleanly and the default is non-null, mirroring `GlassSpecularSharpness`.

## Plumbing

Follows the `whitenStrength` template end to end:

- Settings field with lerp (midpoint switch), `copyWith`, `props`.
- Premium: uniform slot 20 (`uTintBlend`), threaded into `render.glsl::applyGlassColor` as a parameter; the legacy `renderLiquidGlass` pipeline pins `auto`.
- Standard: uniform slot 32, consumed by `applyGlassColorLW` with the same tri-state select.
- Preserved through the `AdaptiveGlass` elevation rebuild (same reason as whiten — grouped/elevated surfaces must not silently drop it).
- Frosted fallback renders a flat tint by construction; the docs state it ignores the setting.

## Verification

- `flutter analyze` clean.
- Full suite passing apart from the known macOS host-golden set — **verified byte-identical to `main`** (same 26 `variant: macOS` goldens, same sub-pixel diffs): with `auto` as the default, the renderer goldens don't shift, confirming zero behavior change.
- New tests: defaults, `copyWith` round-trips, lerp midpoint switching, equality/`props`, and the shader tri-state encoding (`glslValue` ↔ the `<0.5 / <1.5` selects in both shaders).
- Effective patch coverage 100%. The only uncovered added lines are the GPU uniform upload (`setFloat(settings.tintBlend.glslValue)`) in `lib/src/renderer/**` — the headless-untestable renderer path your `.codecov.yml` already excludes.
- Visually validated in our app across all three modes on the same screen: neutral-glassy bar (`luminosity`), dark dimming bar over a map (`flat` is today's behavior for it), defaults untouched (`auto`).
