### PR TITLE
feat: add bottomFadeInset to GlassScrollEdgeEffect

### DIFF
--- a/lib/widgets/shared/glass_scroll_edge_effect.dart
+++ b/lib/widgets/shared/glass_scroll_edge_effect.dart
@@ -101,6 +101,7 @@ class GlassScrollEdgeEffect extends StatefulWidget {
     this.luminanceDarkBelow = 0.45,
     this.luminanceLightAbove = 0.72,
     this.fadeDuration = const Duration(milliseconds: 280),
+    this.bottomFadeInset = 0.0,
   }) : assert(
           luminanceDarkBelow < luminanceLightAbove,
           'luminanceDarkBelow must be below luminanceLightAbove',
@@ -125,6 +126,18 @@ class GlassScrollEdgeEffect extends StatefulWidget {
   ///
   /// Defaults to 60.0.
   final double bottomFadeHeight;
+
+  /// Distance (logical px) to lift the BOTTOM fade up from this widget's
+  /// bottom edge. `0` (the default) anchors it to the bottom edge as usual.
+  ///
+  /// Use this when the scroll viewport extends below the visible area — e.g. a
+  /// bottom sheet whose content box "sinks" past the screen bottom at full
+  /// expansion. Without it the bottom fade rides the box's true (off-screen)
+  /// bottom and never appears; setting this to the overflow amount re-anchors
+  /// the fade to the visible bottom. Has no effect on the top fade.
+  ///
+  /// Defaults to 0.0.
+  final double bottomFadeInset;
 
   /// Whether to fade content at the top edge.
   ///
@@ -438,7 +451,7 @@ class _GlassScrollEdgeEffectState extends State<GlassScrollEdgeEffect>
       final darkness = isTop ? _topDarkness : _bottomDarkness;
       return Positioned(
         top: isTop ? 0 : null,
-        bottom: isTop ? null : 0,
+        bottom: isTop ? null : widget.bottomFadeInset,
         left: 0,
         right: 0,
         height: height,
@@ -461,7 +474,7 @@ class _GlassScrollEdgeEffectState extends State<GlassScrollEdgeEffect>
     // Non-adaptive path — unchanged behaviour (darkness fixed at 0).
     return Positioned(
       top: isTop ? 0 : null,
-      bottom: isTop ? null : 0,
+      bottom: isTop ? null : widget.bottomFadeInset,
       left: 0,
       right: 0,
       height: height,

--- a/test/widgets/shared/glass_scroll_edge_effect_test.dart
+++ b/test/widgets/shared/glass_scroll_edge_effect_test.dart
@@ -72,6 +72,7 @@ void main() {
       expect(widget.fadeTop, isTrue);
       expect(widget.fadeBottom, isTrue);
       expect(widget.style, equals(GlassScrollEdgeStyle.soft));
+      expect(widget.bottomFadeInset, equals(0.0));
     });
 
     test('GlassScrollEdgeStyle has soft and hard values', () {
@@ -154,6 +155,32 @@ void main() {
       );
 
       expect(find.text('Custom heights'), findsOneWidget);
+    });
+
+    testWidgets('bottomFadeInset lifts the bottom fade off the bottom edge',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: GlassScrollEdgeEffect(
+            fadeTop: false,
+            fadeBottom: true,
+            bottomFadeInset: 24,
+            child: ListView(
+              children: const [Text('Inset bottom')],
+            ),
+          ),
+        ),
+      );
+
+      // Bottom-only fade => a single Positioned overlay; its `bottom` is
+      // lifted off the box edge by bottomFadeInset (default would be 0).
+      final positioned = tester.widget<Positioned>(
+        find.descendant(
+          of: find.byType(GlassScrollEdgeEffect),
+          matching: find.byType(Positioned),
+        ),
+      );
+      expect(positioned.bottom, equals(24));
     });
   });
 }


### PR DESCRIPTION
## What
Adds an optional `bottomFadeInset` (logical px, default `0.0`) to `GlassScrollEdgeEffect` that lifts the **bottom** fade up from the widget's bottom edge.

## Why
When the scroll viewport extends below the visible area, the bottom fade anchors to the box's *true* bottom — which is off-screen — so it never appears. Concrete case: a bottom sheet whose content box "sinks" past the screen bottom at full expansion (safe-area + corner-radius overflow). Setting `bottomFadeInset` to that overflow amount re-anchors the fade to the visible bottom.

## Change
- One new param/field `bottomFadeInset` (default `0.0`).
- Threaded into the bottom fade's `Positioned.bottom` in **both** the content-aware and non-adaptive paths (`bottom: isTop ? null : widget.bottomFadeInset`).
- No effect on the top fade; default `0.0` preserves existing behavior (fully backward-compatible).

## Tests
- `defaults are correct` now asserts `bottomFadeInset == 0.0`.
- New `bottomFadeInset lifts the bottom fade off the bottom edge` verifies the bottom `Positioned.bottom == bottomFadeInset`.

`flutter analyze` clean; all `glass_scroll_edge_effect_test.dart` tests pass.
