### PR TITLE
backerColor — Apple-style dimming layer behind the glass

### DIFF
--- a/lib/src/renderer/liquid_glass_settings.dart
+++ b/lib/src/renderer/liquid_glass_settings.dart
@@ -31,6 +31,7 @@ class LiquidGlassSettings with EquatableMixin {
     this.whitenStrength = 0.0,
     this.whitenGated = true,
     this.tintBlend = GlassTintBlend.auto,
+    this.backerColor,
   });
 
   /// Creates [LiquidGlassSettings] using Figma-inspired parameter names.
@@ -267,6 +268,26 @@ class LiquidGlassSettings with EquatableMixin {
   /// renders a flat tint by construction and ignores this setting.
   final GlassTintBlend tintBlend;
 
+  /// Optional dimming "backer" painted directly behind the glass.
+  ///
+  /// A shape-matched, color-filled pad composited *behind* the glass surface —
+  /// the inverse of [shadow], which sits outside the boundary. It provides
+  /// contrast for a control's content over rich or colorful backdrops where the
+  /// glass tint alone can't: video, maps, photography, or any control floating
+  /// over busy content. This is Apple's "dimming layer" guidance for keeping
+  /// glass controls legible (see the Materials section of the Human Interface
+  /// Guidelines, and SwiftUI's clear `Glass` variant).
+  ///
+  /// The color's alpha *is* the dimming opacity. Apple suggests roughly 35% as
+  /// a starting point — e.g. `Color(0x59000000)` for a neutral dark dim.
+  ///
+  /// Rendered at the widget level (like [shadow]), clipped to the glass shape,
+  /// so it composites correctly even over a PlatformView — where a shader-side
+  /// tint cannot reach.
+  ///
+  /// Defaults to null: no backer, and no change to existing rendering.
+  final Color? backerColor;
+
   /// The effective saturation taking visibility into account.
   double get effectiveSaturation => 1 + (saturation - 1) * visibility;
 
@@ -310,6 +331,9 @@ class LiquidGlassSettings with EquatableMixin {
       whitenStrength: lerpDouble(a.whitenStrength, b.whitenStrength, t)!,
       whitenGated: t < 0.5 ? a.whitenGated : b.whitenGated,
       tintBlend: t < 0.5 ? a.tintBlend : b.tintBlend,
+      // Lerp the color so the backer fades smoothly (from/to transparent when
+      // one side is null), rather than popping at the midpoint.
+      backerColor: Color.lerp(a.backerColor, b.backerColor, t),
     );
   }
 
@@ -342,6 +366,7 @@ class LiquidGlassSettings with EquatableMixin {
     double? whitenStrength,
     bool? whitenGated,
     GlassTintBlend? tintBlend,
+    Color? backerColor,
   }) =>
       LiquidGlassSettings(
         visibility: visibility ?? this.visibility,
@@ -363,6 +388,7 @@ class LiquidGlassSettings with EquatableMixin {
         whitenStrength: whitenStrength ?? this.whitenStrength,
         whitenGated: whitenGated ?? this.whitenGated,
         tintBlend: tintBlend ?? this.tintBlend,
+        backerColor: backerColor ?? this.backerColor,
       );
 
   @override
@@ -385,5 +411,6 @@ class LiquidGlassSettings with EquatableMixin {
         whitenStrength,
         whitenGated,
         tintBlend,
+        backerColor,
       ];
 }

--- a/lib/widgets/shared/adaptive_glass.dart
+++ b/lib/widgets/shared/adaptive_glass.dart
@@ -150,7 +150,7 @@ class AdaptiveGlass extends StatelessWidget {
     // Zero fragment shader cost on any device.
     // --------------------------------------------------------------------------
     if (quality == GlassQuality.minimal || baseSettings.effectiveBlur == 0) {
-      return _wrapWithLightModeShadow(
+      return _wrapWithDecorations(
         context,
         baseSettings,
         _FrostedFallback(
@@ -180,7 +180,7 @@ class AdaptiveGlass extends StatelessWidget {
     // --------------------------------------------------------------------------
     final accessibilityData = GlassAccessibilityData.of(context);
     if (accessibilityData.reduceTransparency) {
-      return _wrapWithLightModeShadow(
+      return _wrapWithDecorations(
         context,
         baseSettings,
         _FrostedFallback(
@@ -289,7 +289,7 @@ class AdaptiveGlass extends StatelessWidget {
       // If this is a container (allowElevation=false), we are providing a blur
       // for all our children to use. We update the InheritedLiquidGlass tree.
       if (!allowElevation) {
-        return _wrapWithLightModeShadow(
+        return _wrapWithDecorations(
           context,
           baseSettings,
           LightweightLiquidGlass(
@@ -318,7 +318,7 @@ class AdaptiveGlass extends StatelessWidget {
         child: child,
       );
 
-      return _wrapWithLightModeShadow(context, baseSettings, lightweightWidget);
+      return _wrapWithDecorations(context, baseSettings, lightweightWidget);
     }
 
     // Impeller + Premium Path: Use the renderer's native path.
@@ -365,8 +365,11 @@ class AdaptiveGlass extends StatelessWidget {
         ),
       );
 
-      return PremiumGlassTracker(
-        child: premium,
+      return _wrapWithBacker(
+        baseSettings,
+        PremiumGlassTracker(
+          child: premium,
+        ),
       );
     } else {
       // Grouped elements (e.g. inside GlassBottomBar) rely on the ancestor's
@@ -436,6 +439,57 @@ class AdaptiveGlass extends StatelessWidget {
             ),
           ),
         ),
+      ],
+    );
+  }
+
+  /// Applies the backer (behind the glass) and the light-mode drop shadow
+  /// (outside the glass) to [glass]. Both are no-ops when their respective
+  /// settings are unset, so existing recipes are unaffected. Same signature as
+  /// [_wrapWithLightModeShadow] so the non-premium call sites just swap names.
+  Widget _wrapWithDecorations(
+      BuildContext context, LiquidGlassSettings baseSettings, Widget glass) {
+    return _wrapWithBacker(
+      baseSettings,
+      _wrapWithLightModeShadow(context, baseSettings, glass),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Backer — Apple "dimming layer" behind the glass
+  //
+  // A shape-matched color pad composited BEHIND the glass (the inverse of the
+  // drop shadow, which sits OUTSIDE the boundary). Gives a control's content
+  // contrast over rich/colorful backdrops — video, maps, photography — where
+  // the glass tint alone can't. Rendered at the widget level via [_ShapeClip]
+  // (ClipRRect for superellipses, so the clip forwards to the iOS PlatformView
+  // mutator stack), independent of the shader tier — so it works over a
+  // PlatformView, where a shader-side tint cannot reach.
+  //
+  // Unlike the shadow, it applies in BOTH brightnesses and for flat-edge shapes
+  // (a bar over a map is a primary use case). NOT applied on the grouped path:
+  // like the shadow, inserting a Stack between a grouped glass and its shared
+  // layer would break metaball morphing.
+  // ---------------------------------------------------------------------------
+  Widget _wrapWithBacker(LiquidGlassSettings baseSettings, Widget glass) {
+    final backerColor = baseSettings.backerColor;
+    if (backerColor == null || backerColor.a == 0) return glass;
+
+    return Stack(
+      fit: StackFit.passthrough,
+      clipBehavior: Clip.none,
+      children: [
+        // 1. The dimming pad — BEHIND the glass, clipped to the glass shape.
+        Positioned.fill(
+          child: IgnorePointer(
+            child: _ShapeClip(
+              shape: shape,
+              child: ColoredBox(color: backerColor),
+            ),
+          ),
+        ),
+        // 2. The glass on top; its translucency lets the pad dim it through.
+        glass,
       ],
     );
   }

--- a/test/renderer/liquid_glass_settings_test.dart
+++ b/test/renderer/liquid_glass_settings_test.dart
@@ -433,5 +433,56 @@ void main() {
         expect(s.props, contains(GlassTintBlend.luminosity));
       });
     });
+
+    group('backerColor', () {
+      test('defaults to null (no backer, no behavior change)', () {
+        const s = LiquidGlassSettings();
+        expect(s.backerColor, isNull);
+      });
+
+      test('copyWith sets backerColor without touching other fields', () {
+        const base = LiquidGlassSettings();
+        final copy = base.copyWith(backerColor: const Color(0x59000000));
+        expect(copy.backerColor, const Color(0x59000000));
+        expect(copy.glassColor, base.glassColor);
+        expect(copy.blur, base.blur);
+      });
+
+      test('lerp fades backerColor smoothly (not a midpoint switch)', () {
+        const a = LiquidGlassSettings(backerColor: Color(0x00000000));
+        const b = LiquidGlassSettings(backerColor: Color(0xFF000000));
+        expect(LiquidGlassSettings.lerp(a, b, 0.25).backerColor!.a,
+            closeTo(0.25, 0.02));
+        expect(LiquidGlassSettings.lerp(a, b, 0.75).backerColor!.a,
+            closeTo(0.75, 0.02));
+      });
+
+      test('lerp from null fades in from transparent (Color.lerp semantics)',
+          () {
+        const a = LiquidGlassSettings(); // backerColor null
+        const b = LiquidGlassSettings(backerColor: Color(0xFF000000));
+        expect(LiquidGlassSettings.lerp(a, b, 0.5).backerColor!.a,
+            closeTo(0.5, 0.02));
+      });
+
+      test('lerp of two null backers stays null', () {
+        const a = LiquidGlassSettings();
+        const b = LiquidGlassSettings();
+        expect(LiquidGlassSettings.lerp(a, b, 0.5).backerColor, isNull);
+      });
+
+      test('equality includes backerColor', () {
+        const a = LiquidGlassSettings(backerColor: Color(0x59000000));
+        const b = LiquidGlassSettings(backerColor: Color(0x59000000));
+        const c = LiquidGlassSettings();
+        expect(a, equals(b));
+        expect(a, isNot(equals(c)));
+      });
+
+      test('props contains backerColor', () {
+        const s = LiquidGlassSettings(backerColor: Color(0x59000000));
+        expect(s.props, contains(const Color(0x59000000)));
+      });
+    });
   });
 }

--- a/test/widgets/shared/adaptive_glass_coverage_test.dart
+++ b/test/widgets/shared/adaptive_glass_coverage_test.dart
@@ -77,6 +77,98 @@ void main() {
     });
   });
 
+  group('AdaptiveGlass — backer (dimming layer)', () {
+    // A distinctive color nothing else in the glass stack uses, so the
+    // backer's ColoredBox is unambiguous to find.
+    const backer = Color(0x80FF00FF);
+    Finder backerFinder() =>
+        find.byWidgetPredicate((w) => w is ColoredBox && w.color == backer);
+
+    testWidgets('renders a clipped dimming pad behind the glass when set',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox(
+        width: 200,
+        height: 100,
+        child: AdaptiveGlass(
+          shape: _shape,
+          settings: LiquidGlassSettings(blur: 5, backerColor: backer),
+          quality: GlassQuality.standard,
+          child: SizedBox.expand(),
+        ),
+      )));
+      await tester.pump();
+      expect(backerFinder(), findsOneWidget);
+    });
+
+    testWidgets('no backer when backerColor is null', (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox(
+        width: 200,
+        height: 100,
+        child: AdaptiveGlass(
+          shape: _shape,
+          settings: _settings, // no backerColor
+          quality: GlassQuality.standard,
+          child: SizedBox.expand(),
+        ),
+      )));
+      await tester.pump();
+      expect(backerFinder(), findsNothing);
+    });
+
+    testWidgets('a fully-transparent backer is treated as no backer',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox(
+        width: 200,
+        height: 100,
+        child: AdaptiveGlass(
+          shape: _shape,
+          settings:
+              LiquidGlassSettings(blur: 5, backerColor: Color(0x00FF00FF)),
+          quality: GlassQuality.standard,
+          child: SizedBox.expand(),
+        ),
+      )));
+      await tester.pump();
+      expect(
+        find.byWidgetPredicate(
+            (w) => w is ColoredBox && w.color == const Color(0x00FF00FF)),
+        findsNothing,
+      );
+    });
+
+    testWidgets('backer also applies on the minimal/frosted path',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox(
+        width: 200,
+        height: 100,
+        child: AdaptiveGlass(
+          shape: _shape,
+          settings: LiquidGlassSettings(backerColor: backer),
+          quality: GlassQuality.minimal,
+          child: SizedBox.expand(),
+        ),
+      )));
+      await tester.pump();
+      expect(backerFinder(), findsOneWidget);
+    });
+
+    testWidgets('backer applies on the premium own-layer path', (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox(
+        width: 200,
+        height: 100,
+        child: AdaptiveGlass(
+          shape: _shape,
+          settings: LiquidGlassSettings(blur: 5, backerColor: backer),
+          quality: GlassQuality.premium,
+          useOwnLayer: true,
+          child: SizedBox.expand(),
+        ),
+      )));
+      await tester.pump();
+      expect(backerFinder(), findsOneWidget);
+    });
+  });
+
   group('AdaptiveGlass — accessibility path', () {
     testWidgets('reduce transparency triggers frosted fallback',
         (tester) async {


### PR DESCRIPTION
Implements the control backer from #108 — the dimming layer we landed on there: a single `backerColor` on `LiquidGlassSettings`, settings-level (not a wrapper), opt-in.

## What it adds

```dart
LiquidGlassSettings(
  glassColor: Color(0x20FFFFFF),
  backerColor: Color(0x59000000), // ~35% black — Apple's dimming-layer starting point
)
```

- **`backerColor`** (`Color?`, default `null`): a shape-matched color pad composited *behind* the glass — the inverse of `shadow`, which sits *outside* the boundary. The color's alpha **is** the dimming opacity. Null = no backer, so existing recipes are untouched.
- It gives a control's content contrast over rich/colorful backdrops where the glass tint alone can't — video, maps, photography — which is Apple's "dimming layer" guidance ([HIG → Materials](https://developer.apple.com/design/human-interface-guidelines/materials#:~:text=For%20optimal%20contrast,a%20dimming%20layer.), and SwiftUI's clear [`Glass`](https://developer.apple.com/documentation/SwiftUI/Glass/clear) variant, which is built to pair with one).

Per the #108 discussion, this is the single-color shape (no separate `backerStrength` — folding opacity into the alpha keeps one source of truth; a scalar can land later without a breaking change).

## How it works

Rendered at the **widget level**, exactly like `shadow` (`_wrapWithLightModeShadow` → here `_wrapWithBacker`): a `_ShapeClip(ColoredBox)` in a passthrough `Stack` behind the glass. Because `_ShapeClip` uses `ClipRRect` for superellipses, the clip forwards to the iOS PlatformView mutator stack — so the pad composites cleanly **over a PlatformView** (a map, a video), where a shader-side tint can't reach.

- Applies in **both brightnesses** and for **flat-edge** shapes (a bar over a map is a primary use case) — unlike the shadow, which is light-mode / rounded only.
- **Skipped on the grouped path**: like the shadow, inserting a `Stack` between a grouped glass and its shared layer would break metaball morphing.

## Demo

Three identical pills on **package-default** glass over deliberately busy stripes — bar 1 has no backer, bars 2 & 3 at 35% / 65%. The backer carries the legibility load and clips to the pill shape; in light mode it flips to a white dim.

| Dark | Light |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/b5b9cbf5-390a-4a22-a14d-0f2ca8b7a3be" width="300" alt="backer dark"> | <img src="https://github.com/user-attachments/assets/04b4f733-8f6f-4a31-b155-8e14f8db5a88" width="300" alt="backer light"> |

## Verification

- `flutter analyze` clean.
- Full suite passing apart from the known macOS host-golden set — **verified byte-identical to `main`** (null default ⇒ the renderer goldens don't move).
- New tests: the settings field (default/copyWith/lerp incl. fade-from-null/equality/props) and the widget wrap (renders behind glass when set, no-op when null, transparent treated as no-op, minimal + premium-own-layer paths).
- Effective patch coverage: the only uncovered added lines are the premium-own-layer wrap (`adaptive_glass.dart`), which needs Impeller and so can't run in the headless test VM — the same class as the GPU-upload line in #107 and the capture-defer branch in #106. Project gate (≥90%) holds.

Closes #108.

