### PR TITLE
fix(AdaptiveLiquidGlassLayer): preserve indicator morph across a platformViewBackdrop toggle

### DIFF
--- a/lib/widgets/shared/adaptive_liquid_glass_layer.dart
+++ b/lib/widgets/shared/adaptive_liquid_glass_layer.dart
@@ -42,7 +42,7 @@ import 'inherited_liquid_glass.dart';
 ///   child: YourContent(), // Uses GlassTheme settings automatically
 /// )
 /// ```
-class AdaptiveLiquidGlassLayer extends StatelessWidget {
+class AdaptiveLiquidGlassLayer extends StatefulWidget {
   const AdaptiveLiquidGlassLayer({
     required this.child,
     this.shape = const LiquidRoundedSuperellipse(borderRadius: 0),
@@ -89,6 +89,23 @@ class AdaptiveLiquidGlassLayer extends StatelessWidget {
   static bool get _canUseImpeller => ui.ImageFilter.isShaderFilterSupported;
 
   @override
+  State<AdaptiveLiquidGlassLayer> createState() =>
+      _AdaptiveLiquidGlassLayerState();
+}
+
+class _AdaptiveLiquidGlassLayerState extends State<AdaptiveLiquidGlassLayer> {
+  // Stable identity for the child subtree across the structural wrapper toggle
+  // in build(). `useFullRenderer` (which flips with [platformViewBackdrop])
+  // decides whether the child is wrapped in a [LiquidGlassBlendGroup]. Without a
+  // stable key, toggling the flag changes the child's depth in the element tree,
+  // so Flutter REMOUNTS the whole subtree — re-running initState on any
+  // animation controllers inside it. For a bottom bar that re-seeds the
+  // selected-indicator springs at their settled value, so the indicator SNAPS
+  // to the new tab instead of morphing. A GlobalKey lets Flutter reparent the
+  // subtree across the wrapper change (preserving the live controllers) instead.
+  final GlobalKey _contentKey = GlobalKey();
+
+  @override
   Widget build(BuildContext context) {
     // Resolve settings: start with base defaults, apply theme partial override
     // (only non-null fields), then let explicit widget settings win entirely.
@@ -96,9 +113,9 @@ class AdaptiveLiquidGlassLayer extends StatelessWidget {
     const baseSettings = LiquidGlassSettings();
     final themeOverride = themeData.settingsFor(context);
     final withTheme = themeOverride?.applyTo(baseSettings) ?? baseSettings;
-    final effectiveSettings = settings ?? withTheme;
+    final effectiveSettings = widget.settings ?? withTheme;
     final effectiveQuality =
-        quality ?? themeData.qualityFor(context) ?? GlassQuality.standard;
+        widget.quality ?? themeData.qualityFor(context) ?? GlassQuality.standard;
 
     // ---- MINIMAL FAST-PATH --------------------------------------------------
     // GlassQuality.minimal skips LiquidGlassLayer entirely.
@@ -124,15 +141,15 @@ class AdaptiveLiquidGlassLayer extends StatelessWidget {
           settings: effectiveSettings,
           quality: effectiveQuality,
           isBlurProvidedByAncestor: false,
-          child: child,
+          child: KeyedSubtree(key: _contentKey, child: widget.child),
         ),
       );
     }
 
     // Detect if we should use the full Impeller-native rendering pipeline
-    final bool useFullRenderer = _canUseImpeller &&
+    final bool useFullRenderer = AdaptiveLiquidGlassLayer._canUseImpeller &&
         effectiveQuality == GlassQuality.premium &&
-        !platformViewBackdrop;
+        !widget.platformViewBackdrop;
 
     // Resolve shadow for SDF rendering. Shadows only apply in light mode.
     final bool isDark =
@@ -140,9 +157,10 @@ class AdaptiveLiquidGlassLayer extends StatelessWidget {
     final List<BoxShadow> resolvedShadows =
         isDark ? const <BoxShadow>[] : effectiveSettings.effectiveShadow;
 
-    // On Skia/Web, we want to provide a single BackdropFilter for the whole layer
-    // to avoid each child doing its own expensive blur.
-    Widget content = child;
+    // Keep the child subtree's element identity stable across the wrapper toggle
+    // below (see [_contentKey]) so its animation controllers survive.
+    final Widget keyedContent =
+        KeyedSubtree(key: _contentKey, child: widget.child);
 
     return PremiumGlassTracker(
       child: LiquidGlassLayer(
@@ -157,10 +175,10 @@ class AdaptiveLiquidGlassLayer extends StatelessWidget {
                 false, // Root never provides the blur; containers do.
             child: useFullRenderer
                 ? LiquidGlassBlendGroup(
-                    blend: blendAmount,
-                    child: content,
+                    blend: widget.blendAmount,
+                    child: keyedContent,
                   )
-                : content,
+                : keyedContent,
           ),
         ),
       ),

--- a/test/widgets/shared/adaptive_liquid_glass_layer_test.dart
+++ b/test/widgets/shared/adaptive_liquid_glass_layer_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/src/renderer/liquid_glass_renderer.dart';
+import 'package:liquid_glass_widgets/types/glass_quality.dart';
 import 'package:liquid_glass_widgets/widgets/shared/adaptive_liquid_glass_layer.dart';
 import 'package:liquid_glass_widgets/widgets/shared/inherited_liquid_glass.dart';
 
@@ -73,4 +74,77 @@ void main() {
 
     expect(find.byType(AdaptiveLiquidGlassLayer), findsOneWidget);
   });
+
+  // Regression: the selected-indicator morph must survive a platformViewBackdrop
+  // toggle. Toggling the flag flips `useFullRenderer`, which adds/removes a
+  // LiquidGlassBlendGroup wrapper around the child. Without a stable key the
+  // child subtree remounts on that toggle — re-seeding any animation controllers
+  // inside it (e.g. a bottom bar's selected-indicator springs), so the indicator
+  // snaps instead of morphing. The layer wraps its child in a KeyedSubtree with a
+  // State-held GlobalKey so Flutter reparents the subtree instead of rebuilding
+  // it. (The wrapper only physically toggles under Impeller; on the headless
+  // Skia runner this asserts the stable keying that makes the reparent possible,
+  // which is the actual fix.)
+  KeyedSubtree probeWrapper(WidgetTester tester) =>
+      tester.widgetList<KeyedSubtree>(find.byType(KeyedSubtree)).firstWhere(
+            (w) => w.child is _MorphProbe,
+            orElse: () => throw StateError(
+              'child is not wrapped in a KeyedSubtree — the morph-preservation '
+              'fix is missing',
+            ),
+          );
+
+  testWidgets(
+      'keeps a stable-keyed child wrapper across a platformViewBackdrop toggle',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AdaptiveLiquidGlassLayer(
+          quality: GlassQuality.premium,
+          child: _MorphProbe(),
+        ),
+      ),
+    );
+    final keyBefore = probeWrapper(tester).key;
+    final elementBefore = tester.element(find.byType(_MorphProbe));
+    expect(keyBefore, isA<GlobalKey>());
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AdaptiveLiquidGlassLayer(
+          quality: GlassQuality.premium,
+          platformViewBackdrop: true,
+          child: _MorphProbe(),
+        ),
+      ),
+    );
+    final keyAfter = probeWrapper(tester).key;
+    final elementAfter = tester.element(find.byType(_MorphProbe));
+
+    // Same GlobalKey instance → the wrapper is stable, so Flutter reparents the
+    // subtree rather than remounting it, and the child element is preserved.
+    expect(keyAfter, same(keyBefore));
+    expect(elementAfter, same(elementBefore));
+  });
+
+  testWidgets('wraps its child in a keyed subtree on the minimal path too',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AdaptiveLiquidGlassLayer(
+          quality: GlassQuality.minimal,
+          child: _MorphProbe(),
+        ),
+      ),
+    );
+    expect(probeWrapper(tester).key, isA<GlobalKey>());
+  });
+}
+
+/// A findable marker widget used to locate the layer's keyed child wrapper.
+class _MorphProbe extends StatelessWidget {
+  const _MorphProbe();
+
+  @override
+  Widget build(BuildContext context) => const SizedBox(width: 10, height: 10);
 }


### PR DESCRIPTION
## Summary
Toggling `platformViewBackdrop` tears down the selected-tab indicator's morph — it snaps to the new tab instead of sliding.

## Root cause
`platformViewBackdrop` gates `useFullRenderer` in `AdaptiveLiquidGlassLayer`, which conditionally wraps the child in a `LiquidGlassBlendGroup`. Toggling the flag adds/removes that wrapper, changing the child's depth in the element tree. Because the child isn't behind a stable key, Flutter discards and re-inflates the whole child subtree, re-running `initState` on every animation controller inside it. In a bottom bar, the selected-indicator springs (`VelocitySpringBuilder`) are re-seeded at their already-settled value → no animation → snap.

(The indicator's `backgroundKey` swap, also driven by the flag, was a red herring — its setter only calls `markNeedsPaint()`.)

## Fix
Give the child a stable identity across the wrapper toggle: hold a `GlobalKey` in `State` and wrap the child in a `KeyedSubtree`. Flutter then reparents the subtree across the wrapper change instead of rebuilding it, so the live controllers survive and the morph plays. `AdaptiveLiquidGlassLayer` becomes a `StatefulWidget` to hold the key.

## Testing
Verified on a `GlassSearchableBottomBar` whose `platformViewBackdrop` toggles on tab change (over a Mapbox PlatformView vs Flutter content): before, the indicator snapped crossing that boundary; after, it morphs. Tabs that don't toggle the flag are unchanged.
