### PR TITLE
Fix: bottom bar freezes when dragged/tapped over an iOS PlatformView

### DIFF
--- a/lib/widgets/shared/animated_glass_indicator.dart
+++ b/lib/widgets/shared/animated_glass_indicator.dart
@@ -373,18 +373,29 @@ class AnimatedGlassIndicator extends StatelessWidget {
       children: [
         // Rest-blur: an Apple-style backdrop frost behind the RESTING pill.
         // Sigma is scaled by backgroundOpacity so it is full when settled and
-        // fades out as the pill morphs into the glass lens (motion stays crisp).
-        // Sits at the bottom of the stack so the (translucent) pill + icons read
-        // on top of the frosted backdrop.
-        if (paintBackground && innerBlur > 0 && backgroundOpacity > 0)
+        // fades toward zero as the pill morphs into the glass lens (motion stays
+        // crisp). Sits at the bottom of the stack so the (translucent) pill +
+        // icons read on top of the frosted backdrop.
+        //
+        // The ClipRRect + BackdropFilter stay MOUNTED for the whole gesture — we
+        // gate only on [innerBlur] > 0, never on backgroundOpacity. Adding or
+        // removing a clip layer over an iOS PlatformView mid-gesture makes the
+        // engine reconstruct the platform-view clip-view chain, which cancels
+        // the in-flight touch and freezes an interactive bar overlaid on it.
+        // Fading the sigma (rather than unmounting the layer) keeps the look
+        // without the churn; a small sigma floor keeps it a real backdrop layer
+        // so the engine can't drop it on its own either.
+        if (paintBackground && innerBlur > 0)
           Positioned.fromRelativeRect(
             rect: rect!,
             child: ClipRRect(
               borderRadius: BorderRadius.circular(borderRadius),
               child: BackdropFilter(
                 filter: ImageFilter.blur(
-                  sigmaX: innerBlur * backgroundOpacity,
-                  sigmaY: innerBlur * backgroundOpacity,
+                  sigmaX:
+                      (innerBlur * backgroundOpacity).clamp(0.001, double.infinity),
+                  sigmaY:
+                      (innerBlur * backgroundOpacity).clamp(0.001, double.infinity),
                 ),
                 child: const SizedBox.expand(),
               ),

--- a/lib/widgets/surfaces/shared/tab_bar_drag_gesture_mixin.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_drag_gesture_mixin.dart
@@ -7,6 +7,7 @@
 //
 // NOT part of the public API — do not export from liquid_glass_widgets.dart.
 
+import 'package:flutter/scheduler.dart' show SchedulerBinding, SchedulerPhase;
 import 'package:flutter/widgets.dart';
 
 import '../../../utils/draggable_indicator_physics.dart';
@@ -48,6 +49,20 @@ mixin TabDragGestureMixin<T extends StatefulWidget> on State<T> {
 
   /// True while a horizontal drag gesture is in progress.
   bool tabIsDragging = false;
+
+  /// Bumped to force the interactive [GestureDetector] — and its underlying
+  /// framework gesture recognizer — to be torn down and recreated. Used by
+  /// [recoverIfGestureStuck] to clear a recognizer left wedged after a dropped
+  /// terminal callback over a PlatformView. Concrete classes must key the
+  /// detector on this value.
+  int gestureEpoch = 0;
+
+  /// True from [onBarDragDown] until a terminal callback ([onBarDragEnd] or
+  /// [onBarDragCancel]) runs. If the raw pointer-up/cancel arrives with this
+  /// still set, the terminal callback was dropped (PlatformView gesture-arena
+  /// race) and the recognizer is wedged — covers both the `down`-without-cancel
+  /// (tap) and `START`-without-end (drag) freeze signatures.
+  bool _gestureActive = false;
 
   /// Current horizontal alignment of the indicator in the range [-1, 1].
   double tabXAlign = 0.0;
@@ -107,6 +122,7 @@ mixin TabDragGestureMixin<T extends StatefulWidget> on State<T> {
   /// `onHorizontalDragDown` — marks pointer as pressed for jelly activation.
   void onBarDragDown(DragDownDetails d) {
     if (!mounted) return;
+    _gestureActive = true;
     setState(() => tabIsDown = true);
   }
 
@@ -142,6 +158,29 @@ mixin TabDragGestureMixin<T extends StatefulWidget> on State<T> {
     });
   }
 
+  /// Applies a drag-resolution state change safely.
+  ///
+  /// [onBarDragEnd]/[onBarDragCancel] can be invoked synchronously while the
+  /// element tree is locked — specifically when the indicator's
+  /// [RawGestureDetector] is disposed mid-gesture as its subtree is torn down
+  /// during a rebuild (the press-hold freeze observed at non-premium quality,
+  /// where the fallback render path reparents the interactive subtree). In that
+  /// window the [State] is still `mounted` but `setState()` is illegal, so
+  /// calling it throws, the cancel cleanup aborts, and the drag state is left
+  /// stuck (the bar freezes). Defer to the next frame when invoked during the
+  /// build/finalize phase; a genuinely disposing State no-ops via `mounted`.
+  void _applyDragResolution(VoidCallback body) {
+    if (!mounted) return;
+    if (SchedulerBinding.instance.schedulerPhase ==
+        SchedulerPhase.persistentCallbacks) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted) body();
+      });
+    } else {
+      body();
+    }
+  }
+
   /// `onHorizontalDragEnd` — snap to target tab with velocity fling support.
   ///
   /// Uses the alignment-coordinate inverse formula (issue #23 fix):
@@ -167,22 +206,8 @@ mixin TabDragGestureMixin<T extends StatefulWidget> on State<T> {
       target = positionIndex - 1;
     }
 
-    if (!mounted) return;
-    setState(() {
-      tabIsDragging = false;
-      tabIsDown = false;
-      tabXAlign = computeTabAlignment(target);
-      barSwayOffset = 0.0; // spring back to center
-    });
-    notifyTabChanged(target);
-  }
-
-  /// `onHorizontalDragCancel` — snap to nearest tab without velocity.
-  void onBarDragCancel() {
-    if (tabIsDragging) {
-      final relX = (tabXAlign + 1) / 2;
-      final target = (relX * (tabCount - 1)).round().clamp(0, tabCount - 1);
-      if (!mounted) return;
+    _gestureActive = false;
+    _applyDragResolution(() {
       setState(() {
         tabIsDragging = false;
         tabIsDown = false;
@@ -190,10 +215,28 @@ mixin TabDragGestureMixin<T extends StatefulWidget> on State<T> {
         barSwayOffset = 0.0; // spring back to center
       });
       notifyTabChanged(target);
+    });
+  }
+
+  /// `onHorizontalDragCancel` — snap to nearest tab without velocity.
+  void onBarDragCancel() {
+    _gestureActive = false;
+    if (tabIsDragging) {
+      final relX = (tabXAlign + 1) / 2;
+      final target = (relX * (tabCount - 1)).round().clamp(0, tabCount - 1);
+      _applyDragResolution(() {
+        setState(() {
+          tabIsDragging = false;
+          tabIsDown = false;
+          tabXAlign = computeTabAlignment(target);
+          barSwayOffset = 0.0; // spring back to center
+        });
+        notifyTabChanged(target);
+      });
     } else {
       // Not dragging (e.g. same-tab tap): reset indicator to exact tab center.
-      if (!mounted) return;
-      setState(() => tabXAlign = computeTabAlignment(tabIndex));
+      _applyDragResolution(
+          () => setState(() => tabXAlign = computeTabAlignment(tabIndex)));
     }
   }
 
@@ -207,5 +250,50 @@ mixin TabDragGestureMixin<T extends StatefulWidget> on State<T> {
     final relX = (alignment + 1) / 2;
     final index = (relX * tabCount).floor().clamp(0, tabCount - 1);
     notifyTabChanged(index);
+  }
+
+  /// Safety net for a dropped gesture terminal callback while the bar floats
+  /// over an iOS PlatformView.
+  ///
+  /// Over a PlatformView (e.g. a map), an interactive Flutter widget's gesture
+  /// recognizer can have its terminal callback dropped in a race with the
+  /// platform view's native gesture handling — a long-standing iOS
+  /// PlatformView gesture-arena limitation, reproducible with this indicator
+  /// dragged/tapped over a Mapbox map. The recognizer is then left wedged with
+  /// [_gestureActive] still set and the bar stops receiving touches until
+  /// something disposes it. Two signatures: `down` with no `onCancel` (a tap)
+  /// and `START` with no `onEnd` (a drag).
+  ///
+  /// The raw [Listener] in the concrete class fires `onPointerUp` /
+  /// `onPointerCancel` regardless of arena resolution, so it calls this on each
+  /// with the [upPosition] (the lift point). If a gesture is still flagged
+  /// active on the next frame (its real terminal callback never ran), dispose
+  /// the wedged recognizer via [gestureEpoch] (a state reset alone won't clear
+  /// it — only disposal does, which is why the search morph un-freezes) and
+  /// select the tab **under the lift point**.
+  ///
+  /// We resolve to [upPosition], never [tabXAlign]: a gesture that wedged
+  /// mid-drag stops reporting finger movement, so [tabXAlign] is frozen at the
+  /// press point and would snap the user back to where they started. The lift
+  /// point is the only trustworthy signal for where they actually intended to
+  /// go. (Recovery is a correctness backstop, not a substitute for smooth
+  /// drag-tracking — which over a PlatformView requires a native pointer
+  /// barrier the framework can't provide from Dart.)
+  void recoverIfGestureStuck(Offset upPosition) {
+    if (!_gestureActive) return;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_gestureActive) return;
+      final relX = (alignmentFromGlobal(upPosition) + 1) / 2;
+      final target = (relX * tabCount).floor().clamp(0, tabCount - 1);
+      setState(() {
+        _gestureActive = false;
+        tabIsDragging = false;
+        tabIsDown = false;
+        tabXAlign = computeTabAlignment(target);
+        barSwayOffset = 0.0;
+        gestureEpoch++; // dispose the wedged recognizer
+      });
+      notifyTabChanged(target);
+    });
   }
 }

--- a/lib/widgets/surfaces/shared/tab_bar_searchable_internal.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_searchable_internal.dart
@@ -293,17 +293,22 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
               onPointerDown: (_) {
                 if (mounted) setState(() => tabIsDown = true);
               },
-              onPointerUp: (_) {
-                if (!tabIsDragging && mounted) {
-                  setState(() => tabIsDown = false);
-                }
+              onPointerUp: (e) {
+                if (!mounted) return;
+                if (!tabIsDragging) setState(() => tabIsDown = false);
+                // If a gesture is still flagged active after the pointer lifts,
+                // its terminal callback was dropped (PlatformView arena race) —
+                // self-heal on the next frame, honoring the lift position so a
+                // recovering tap also navigates. No-ops on a clean gesture.
+                recoverIfGestureStuck(e.position);
               },
-              onPointerCancel: (_) {
-                if (!tabIsDragging && mounted) {
-                  setState(() => tabIsDown = false);
-                }
+              onPointerCancel: (e) {
+                if (!mounted) return;
+                if (!tabIsDragging) setState(() => tabIsDown = false);
+                recoverIfGestureStuck(e.position);
               },
               child: GestureDetector(
+                key: ValueKey(gestureEpoch),
                 behavior: HitTestBehavior.opaque,
                 onHorizontalDragDown: onBarDragDown,
                 onHorizontalDragStart: onBarDragStart,

--- a/lib/widgets/surfaces/shared/tab_bar_searchable_layout.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_searchable_layout.dart
@@ -182,6 +182,14 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
   late SearchableBottomBarController _controller;
   bool _ownsController = false;
 
+  // Stable identity for the tab indicator. Without it the indicator's State is
+  // torn down + recreated on every rebuild — which orphans a live press-hold
+  // gesture mid-flight and freezes the bar (reproduced at standard/minimal over
+  // an iOS PlatformView; the premium render path happens to avoid the churn). A
+  // GlobalKey preserves the State across rebuilds AND across the
+  // AdaptiveLiquidGlassLayer wrapper's quality-path reparenting.
+  final GlobalKey _indicatorKey = GlobalKey();
+
   void _onControllerChanged() => setState(() {});
 
   // D1: whitenBoostCtrl still uses setState — it fires at most once per scroll-to-bottom
@@ -633,6 +641,7 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                             width: math.max(0.01, curTabW),
                             height: animH,
                             child: SearchableTabIndicator(
+                              key: _indicatorKey,
                               quality: effectiveQuality,
                               visible: widget.showIndicator && !searching,
                               tabIndex: widget.selectedIndex,

--- a/test/widgets/surfaces/tab_bar_indicator_press_freeze_test.dart
+++ b/test/widgets/surfaces/tab_bar_indicator_press_freeze_test.dart
@@ -1,0 +1,166 @@
+// Regression tests for the "bottom bar freezes over an iOS PlatformView" fix.
+//
+// The freeze is iOS clip-chain reconstruction: a clip layer added/removed over a
+// PlatformView mid-gesture makes the engine cancel the touch. Three parts of the
+// fix are covered here (the full end-to-end freeze needs an on-device
+// PlatformView, but each mechanism is checked deterministically):
+//
+//  1. clip-mount — the indicator's `innerBlur` frost (a ClipRRect+BackdropFilter)
+//     stays MOUNTED across the morph instead of unmounting, which is the clip
+//     add/remove that cancels the gesture. (Primary fix.)
+//  2. recovery — if a terminal callback is dropped, the mixin self-heals:
+//     disposes the wedged recognizer (gestureEpoch key bump) and selects a tab.
+//  3. disposal-safety — a terminal callback firing while the gesture subtree is
+//     torn down during a rebuild must not setState() during the locked phase.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/widgets/surfaces/shared/tab_bar_drag_gesture_mixin.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      home: Scaffold(body: LiquidGlassWidgets.wrap(child: child)),
+    );
+
+Widget _box(Widget child) => SizedBox(height: 140, child: child);
+
+GlassTab _tab(String label) =>
+    GlassTab(label: label, icon: const Icon(Icons.circle));
+
+Widget _bar(GlassQuality quality) => GlassTabBar.searchable(
+      tabs: [_tab('Home'), _tab('Browse'), _tab('Me')],
+      selectedIndex: 0,
+      onTabSelected: (_) {},
+      quality: quality,
+      innerBlur: 2.25,
+      platformViewBackdrop: true,
+      magnification: 1.0,
+      searchConfig:
+          GlassSearchBarConfig(hintText: 'Search', onSearchToggle: (_) {}),
+    );
+
+// Minimal host for [TabDragGestureMixin] so the recovery path can be driven
+// directly, without needing a real PlatformView to drop a callback.
+class _RecoverHarness extends StatefulWidget {
+  const _RecoverHarness({required this.onChange, required this.onState});
+  final ValueChanged<int> onChange;
+  final void Function(_RecoverHarnessState) onState;
+  @override
+  State<_RecoverHarness> createState() => _RecoverHarnessState();
+}
+
+class _RecoverHarnessState extends State<_RecoverHarness>
+    with TabDragGestureMixin<_RecoverHarness> {
+  @override
+  int get tabCount => 3;
+  @override
+  int get tabIndex => 0;
+  @override
+  void notifyTabChanged(int index) => widget.onChange(index);
+
+  @override
+  void initState() {
+    super.initState();
+    widget.onState(this);
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox(width: 300, height: 60);
+}
+
+void main() {
+  testWidgets(
+      'innerBlur frost stays mounted while the pill morphs (clip-mount fix)',
+      (tester) async {
+    // `backgroundOpacity` derives from `thickness`: 1.0 at rest (thickness 0),
+    // 0 once thickness >= 0.15 (mid-morph). The fix keeps the frost's
+    // ClipRRect+BackdropFilter MOUNTED across the morph (fading the sigma)
+    // rather than unmounting it — the unmount is a clip add/remove over a
+    // PlatformView that cancels the gesture (the freeze). Isolate the frost by
+    // diffing innerBlur on vs off at the SAME (fully morphing) state.
+    Future<int> backdropsAtMorph(double innerBlur) async {
+      await tester.pumpWidget(_wrap(_box(Stack(children: [
+        AnimatedGlassIndicator(
+          velocity: 0,
+          itemCount: 3,
+          alignment: Alignment.centerLeft,
+          thickness: 1.0, // -> backgroundOpacity == 0 (fully morphing)
+          quality: GlassQuality.standard,
+          indicatorColor: const Color(0xFFFFFFFF),
+          isBackgroundIndicator: false,
+          borderRadius: 20,
+          innerBlur: innerBlur,
+        ),
+      ]))));
+      await tester.pump();
+      return find.byType(BackdropFilter).evaluate().length;
+    }
+
+    final withFrost = await backdropsAtMorph(4);
+    final withoutFrost = await backdropsAtMorph(0);
+    expect(
+      withFrost,
+      greaterThan(withoutFrost),
+      reason: 'the innerBlur frost BackdropFilter must remain mounted while the '
+          'pill morphs; re-gating it on backgroundOpacity would drop the clip '
+          'and re-introduce the PlatformView gesture-cancel freeze',
+    );
+  });
+
+  testWidgets(
+      'recoverIfGestureStuck disposes the wedged recognizer and selects a tab '
+      'when a terminal callback is dropped', (tester) async {
+    int? changedTo;
+    late _RecoverHarnessState st;
+    await tester.pumpWidget(_wrap(_box(
+      _RecoverHarness(
+        onChange: (i) => changedTo = i,
+        onState: (s) => st = s,
+      ),
+    )));
+    await tester.pump();
+
+    final box = find.byType(_RecoverHarness);
+    // A gesture began (recognizer live) but its terminal callback is dropped —
+    // onBarDragDown with no matching end/cancel.
+    st.onBarDragDown(DragDownDetails(globalPosition: tester.getCenter(box)));
+    final epochBefore = st.gestureEpoch;
+
+    // The raw Listener calls this on the real pointer-up; with the terminal
+    // callback gone, it must self-heal on the next frame.
+    st.recoverIfGestureStuck(tester.getCenter(box));
+    await tester.pump();
+
+    expect(st.gestureEpoch, epochBefore + 1,
+        reason: 'wedged recognizer disposed via a gestureEpoch key bump');
+    expect(changedTo, isNotNull,
+        reason: 'recovery selects the tab under the lift point');
+  });
+
+  testWidgets(
+      'indicator drag recognizer disposed mid-gesture cancels without throwing',
+      (tester) async {
+    await tester.pumpWidget(_wrap(_box(_bar(GlassQuality.standard))));
+    await tester.pump();
+
+    // Begin a drag on the selected indicator (tab 0) so the recognizer is live.
+    final center = tester.getCenter(find.text('Home').first);
+    final gesture = await tester.startGesture(center);
+    await tester.pump();
+    await gesture.moveBy(const Offset(24, 0));
+    await tester.pump();
+
+    // Dispose the bar's gesture subtree mid-drag — exactly what the non-premium
+    // press rebuild does on-device. The recognizer is torn down while active.
+    await tester.pumpWidget(_wrap(_box(const SizedBox.shrink())));
+    await tester.pump();
+    await gesture.up();
+
+    expect(
+      tester.takeException(),
+      isNull,
+      reason: 'a drag recognizer disposed mid-gesture must cancel silently, '
+          'not setState() during the locked teardown',
+    );
+  });
+}


### PR DESCRIPTION
## TL;DR

A `GlassTabBar.searchable` (and the bottom bar generally) **freezes** when the
draggable indicator is dragged or pressed while the bar floats over an iOS
**PlatformView** (e.g. a map). The gesture is silently cancelled and the bar
stops responding until something rebuilds/disposes its gesture recognizer.

This PR contains the fix we developed and tested. **It works well for us, but
you'll almost certainly see a cleaner approach with your knowledge of the
internals — please take whatever's useful and rework the rest.** Hope it helps
either way.

## Where we hit it

- **Our app** (a Mapbox map with the searchable bottom bar floating over it):
  froze constantly at standard/minimal quality when dragging the indicator
  between tabs over the map.
- **A minimal, all-defaults repro** (no app-specific config): a `GlassTabBar.searchable`
  positioned over a Mapbox `MapWidget`, `platformViewBackdrop: true`, otherwise
  package defaults. Dragging/pressing the indicator over the map froze it
  intermittently — frequently enough to hit within a handful of tries. (Happy to
  share this repro; it's ~80 lines.)

So it reproduces with zero app-specific settings — it's a package-level
interaction with iOS PlatformViews, not something in our app.

## Root cause

It's the iOS **clip-chain reconstruction** behavior (the mechanism described in
flutter/flutter#46167 — that issue is closed/fixed, so we're citing it only as
the *mechanism*, not as an open bug): when a **clip layer is added or removed
over a PlatformView during an active gesture**, the engine reconstructs the
platform-view clip-view chain (removes + re-adds the platform view), and iOS
sends a **touch-cancel**. An interactive Flutter widget overlaid on the platform
view loses its in-flight gesture — the terminal callback (`onEnd`/`onCancel`) is
dropped and the recognizer is left wedged.

We found two contributing clip-churn sources in the indicator render:

1. **Dominant / deterministic — the `innerBlur` rest-frost.** In
   `animated_glass_indicator.dart`, the frost's `ClipRRect`+`BackdropFilter` was
   gated on `backgroundOpacity > 0`, so it **unmounted the moment the pill
   started to morph** (the frost fades during motion). That unmount is a clip
   add/remove over the platform view → reconstruction → cancel. With `innerBlur`
   set, this fired on essentially every drag.

2. **Secondary / diffuse — the std & minimal indicator render itself**
   (`_InteractiveIndicatorEffect` / the `AdaptiveGlass` frosted fallback). Even
   with `innerBlur: 0` (the all-defaults repro), the indicator's own clip/backdrop
   interacting with the platform view during the per-frame capture/morph still
   cancelled the gesture intermittently. We could not pin this to a single clean
   mount/unmount — it reads as a transient/racy clip-chain change. (This is the
   part you may be able to fix more surgically at the source.)

## What we tried that did *not* pan out (so you can skip them)

- **`PointerInterceptor` behind the bar** — doesn't stop clip reconstruction; it
  also makes the bar's glass render opaque over off-map Flutter content (its
  native view occludes the backdrop). No help.
- **Custom `gestureRecognizers` on the MapWidget / removing `EagerGestureRecognizer`**
  — no effect; the cancel is from the clip chain, not arena competition.
- **A watchdog timer** that force-resolves a stuck drag — fires mid-drag (it
  can't tell "released" from "paused", and the update stream stops at the
  platform-view edge so there's no finger position to resolve to). Caused wrong
  landings. Removed.
- **Forcing the engine `LiquidGlass.withOwnLayer` layer at all tiers** over a
  platform view — fixes the gesture but changes the look (ports the premium
  render to std/minimal). Rejected.

## The fix in this PR

**1. Keep the `innerBlur` frost layer mounted; fade the sigma, not the layer.**
`animated_glass_indicator.dart` — gate the `ClipRRect`+`BackdropFilter` only on
`innerBlur > 0` (never on `backgroundOpacity`), and fade the blur via the sigma
(floored at a tiny value so it stays a real backdrop). A clip that *changes value
or moves* doesn't reconstruct the chain; only **add/remove** does. This removed
the dominant trigger **and** — because the gesture is no longer cancelled mid-drag
— let drag-to-switch actually *complete* over the map. The look (frost at rest,
crisp in motion) is unchanged.

**2. A gesture-recovery backstop for the diffuse residual.**
`tab_bar_drag_gesture_mixin.dart` + `tab_bar_searchable_internal.dart` +
`tab_bar_searchable_layout.dart`:
- A `_gestureActive` flag set on `onBarDragDown`, cleared only by a terminal
  callback. The raw `Listener` (which fires `onPointerUp`/`onPointerCancel`
  regardless of arena resolution) checks it: if a gesture is still active a frame
  after the pointer lifts, the terminal callback was dropped → recover.
- Recovery **disposes the wedged recognizer** by bumping a `gestureEpoch`
  `ValueKey` on the interactive `GestureDetector` (a plain state reset doesn't
  clear it — only disposing the recognizer does) and selects the tab **under the
  lift point**.
- A `GlobalKey` on the indicator (preserves its State across rebuilds) and a
  small defer-guard so a terminal callback arriving during a locked frame doesn't
  throw.

We kept (2) because it's what covers the secondary/diffuse source — without it,
the all-defaults repro (`innerBlur: 0`) still freezes occasionally. If you fix
that render-clip churn at the source, the backstop may become unnecessary.

## Result

- Our app: freeze gone, drag-to-switch works across tabs over the map, indicator
  look unchanged.
- All-defaults repro: could not reproduce a freeze after the fix.

## Files changed

- `lib/widgets/shared/animated_glass_indicator.dart` — innerBlur layer stays mounted.
- `lib/widgets/surfaces/shared/tab_bar_drag_gesture_mixin.dart` — recovery + `_gestureActive` + `gestureEpoch` + defer-guard.
- `lib/widgets/surfaces/shared/tab_bar_searchable_internal.dart` — raw `Listener` recovery hooks + keyed detector.
- `lib/widgets/surfaces/shared/tab_bar_searchable_layout.dart` — `GlobalKey` on the indicator.

## Open questions / your call

- The clean, contained part is fix **#1** (innerBlur). It's the one we'd most
  confidently recommend.
- Fix **#2** (recovery) is pragmatic insurance against the diffuse render-clip
  churn. You may prefer to address that churn at the source (keeping the
  std/minimal render's clip mounted, similar to #1) and drop the backstop — we
  just couldn't isolate a single clean toggle for it.

Thanks again for the great package — happy to adjust, split this up, or hand over
the repro, whatever's most useful.
