### PR TITLE
platformViewBackdrop: blur the glass veil over a PlatformView

### DIFF
--- a/lib/widgets/shared/adaptive_glass.dart
+++ b/lib/widgets/shared/adaptive_glass.dart
@@ -148,8 +148,17 @@ class AdaptiveGlass extends StatelessWidget {
     // _FrostedFallback: ClipPath(ShapeBorderClipper) + BackdropFilter + tint.
     // ClipPath correctly clips ALL shape types (oval, superellipse, rect).
     // Zero fragment shader cost on any device.
+    //
+    // platformViewBackdrop ALSO routes here: over a PlatformView only a live
+    // BackdropFilter samples the composited map. The premium/standard shaders
+    // read a captured backdrop that EXCLUDES the platform view (see
+    // canUsePremiumShader below), so they render inert there — the frost is the
+    // one tier that actually blurs over a PlatformView. This finally delivers
+    // the "live BackdropFilter path" the canUsePremiumShader comment promises.
     // --------------------------------------------------------------------------
-    if (quality == GlassQuality.minimal || baseSettings.effectiveBlur == 0) {
+    if (quality == GlassQuality.minimal ||
+        baseSettings.effectiveBlur == 0 ||
+        platformViewBackdrop) {
       return _wrapWithDecorations(
         context,
         baseSettings,

--- a/lib/widgets/shared/adaptive_glass.dart
+++ b/lib/widgets/shared/adaptive_glass.dart
@@ -169,6 +169,7 @@ class AdaptiveGlass extends StatelessWidget {
           glowIntensity: glowIntensity,
           isAccessibilityFallback: false,
           isInteractive: isInteractive,
+          platformViewBackdrop: platformViewBackdrop,
           child: child,
         ),
       );
@@ -581,6 +582,7 @@ class _FrostedFallback extends StatelessWidget {
     this.glowIntensity = 0.0,
     this.isAccessibilityFallback = false,
     this.isInteractive = false,
+    this.platformViewBackdrop = false,
   });
 
   final LiquidShape shape;
@@ -603,6 +605,14 @@ class _FrostedFallback extends StatelessWidget {
   /// When true, during [GlassQuality.minimal] we omit the [BackdropFilter] to
   /// prevent compositor desync flicker caused by the bounds changing continuously.
   final bool isInteractive;
+
+  /// When true, this frost sits directly over a PlatformView (map/video) via the
+  /// `platformViewBackdrop` route. The live [BackdropFilter] is the ONLY path
+  /// that blurs a hybrid-composed PlatformView, so it must run even for
+  /// interactive surfaces — otherwise the [isInteractive] blur-omission below
+  /// leaves over-map buttons with no blur at all (the brief tap-scale flicker is
+  /// negligible next to having no blur).
+  final bool platformViewBackdrop;
 
   /// Rec. 709 saturation matrix — identical to upstream FakeGlass.
   ///
@@ -672,9 +682,14 @@ class _FrostedFallback extends StatelessWidget {
     //   mode because BackdropFilter re-samples the background every frame and
     //   desyncs with spring bounds changes, causing a "flashing" or flickering
     //   artifact beneath the element.
+    // - EXCEPT when platformViewBackdrop is set: over a PlatformView the live
+    //   BackdropFilter is the only path that blurs the (hybrid-composed) map, so
+    //   it must run even for interactive buttons. Without this, #128's frost
+    //   route delivers no blur for over-map controls (heading, 2D, ⋯ buttons).
     // ────────────────────────────────────────────────────────────────────────
     final bool useBlur =
-        (isAccessibilityFallback || !isInteractive) && blur > 0;
+        (isAccessibilityFallback || !isInteractive || platformViewBackdrop) &&
+            blur > 0;
 
     Widget body;
     if (useBlur) {

--- a/lib/widgets/surfaces/shared/tab_bar_searchable_internal.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_searchable_internal.dart
@@ -239,6 +239,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
               onTap: widget.onDismissSearch,
               child: AdaptiveGlass.grouped(
                 quality: widget.quality,
+                platformViewBackdrop: widget.platformViewBackdrop,
                 shape: currentShape,
                 child: _wrapWithGlow(
                   child: widget.collapsedLogoBuilder != null
@@ -338,6 +339,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                             decoration: ShapeDecoration(shape: _barShape),
                             child: AdaptiveGlass.grouped(
                               quality: widget.quality,
+                              platformViewBackdrop: widget.platformViewBackdrop,
                               shape: _barShape,
                               child: Container(
                                 padding: widget.tabPadding,
@@ -899,12 +901,10 @@ class SearchPillState extends State<SearchPill> {
                       : () => widget.config.onSearchToggle(true),
                   child: AdaptiveGlass.grouped(
                     shape: currentShape,
-                    // Over a PlatformView the collapsed button uses the lightweight
-                    // veil so it matches the rest of the bar (premium can't sample
-                    // the PlatformView).
-                    quality: widget.platformViewBackdrop
-                        ? GlassQuality.standard
-                        : widget.quality,
+                    // Over a PlatformView AdaptiveGlass routes to the frost veil
+                    // automatically (platformViewBackdrop), so the requested
+                    // quality passes through unchanged here.
+                    quality: widget.quality,
                     platformViewBackdrop: widget.platformViewBackdrop,
                     child: _wrapWithGlow(
                       child: Center(

--- a/test/widgets/shared/adaptive_glass_coverage_test.dart
+++ b/test/widgets/shared/adaptive_glass_coverage_test.dart
@@ -355,4 +355,46 @@ void main() {
       expect(find.byType(ClipPath), findsWidgets);
     });
   });
+
+  group('AdaptiveGlass — platformViewBackdrop routes to the frost', () {
+    // Over a PlatformView the premium/standard shaders sample a captured
+    // backdrop that excludes the platform view (inert), so platformViewBackdrop
+    // must route to the frosted fallback (a live BackdropFilter) regardless of
+    // the requested quality. The frost path wraps in ClipRRect via _ShapeClip;
+    // the lightweight/shader paths do not. (settings has blur:5, so this is the
+    // platformViewBackdrop branch, not the blur==0 fast path.)
+    testWidgets('forces the frost at premium quality', (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox(
+        width: 200,
+        height: 100,
+        child: AdaptiveGlass(
+          shape: _shape,
+          settings: _settings,
+          quality: GlassQuality.premium,
+          platformViewBackdrop: true,
+          child: SizedBox.expand(),
+        ),
+      )));
+      await tester.pump();
+      expect(find.byType(ClipRRect), findsWidgets,
+          reason: 'platformViewBackdrop must take the frosted-fallback path at '
+              'premium, not the shader path that is inert over a PlatformView');
+    });
+
+    testWidgets('forces the frost at standard quality', (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox(
+        width: 200,
+        height: 100,
+        child: AdaptiveGlass(
+          shape: _shape,
+          settings: _settings,
+          quality: GlassQuality.standard,
+          platformViewBackdrop: true,
+          child: SizedBox.expand(),
+        ),
+      )));
+      await tester.pump();
+      expect(find.byType(ClipRRect), findsWidgets);
+    });
+  });
 }

--- a/test/widgets/shared/adaptive_glass_coverage_test.dart
+++ b/test/widgets/shared/adaptive_glass_coverage_test.dart
@@ -291,6 +291,27 @@ void main() {
       expect(find.byType(DecoratedBox), findsWidgets);
     });
 
+    testWidgets('isInteractive=true keeps BackdropFilter over a PlatformView',
+        (tester) async {
+      // platformViewBackdrop overrides the interactive blur-omission above: over
+      // a PlatformView the live BackdropFilter is the only path that blurs the
+      // (hybrid-composed) map, so it must run even for interactive surfaces.
+      await tester.pumpWidget(_wrap(const SizedBox(
+        width: 200,
+        height: 100,
+        child: AdaptiveGlass(
+          shape: _shape,
+          settings: _settings,
+          quality: GlassQuality.minimal,
+          isInteractive: true,
+          platformViewBackdrop: true,
+          child: SizedBox.expand(),
+        ),
+      )));
+      await tester.pump();
+      expect(find.byType(BackdropFilter), findsWidgets);
+    });
+
     testWidgets('glowIntensity > 0 adds glow overlay', (tester) async {
       await tester.pumpWidget(_wrap(const SizedBox(
         width: 200,


### PR DESCRIPTION
`platformViewBackdrop` correctly disables the premium shader over a PlatformView (its `toImageSync` backdrop can't capture one) — but it then falls through to the **standard 2D path, which is also inert** over a PlatformView. So a bar with `platformViewBackdrop` renders only color + opacity, no blur, despite the `canUsePremiumShader` comment promising "the live BackdropFilter path."

This routes `platformViewBackdrop` to the `_FrostedFallback` (a plain `BackdropFilter`) — the one path that *does* blur a hybrid-composed PlatformView — by adding it to the minimal-fast-path condition. It also threads the flag into two bar-background `AdaptiveGlass.grouped` sites that lacked it, and drops a now-redundant manual `standard` downshift on the search pill.

Result: the searchable bar (and any `AdaptiveGlass`) actually frosts the content behind it over a PlatformView, at any requested quality.

Developed and tested on 0.18.4 against a Mapbox map under the bar; the touched files are near-identical on `main`, so it applies cleanly (I couldn't build-test a 0.19.x branch locally — its `meta: ^1.18.0` doesn't resolve on my Flutter). You may well see a cleaner spot for the gate — take whatever's useful.

**Tests:** added a `platformViewBackdrop routes to the frost` group to `adaptive_glass_coverage_test.dart` (premium + standard both take the frost path).

---

**Update — also blurs *interactive* surfaces.** Wiring this into real controls surfaced a second gap: `_FrostedFallback` gates its `BackdropFilter` on `!isInteractive` (a flicker optimization for spring-animated surfaces), and every `GlassButton` passes `isInteractive: true`. So routing a *button's* glass to the frost (above) still gave it no blur — only container glass (button groups, bars) escaped it, because it renders at `isInteractive: false`.

Fix: add `platformViewBackdrop` to that gate —

```dart
final bool useBlur =
    (isAccessibilityFallback || !isInteractive || platformViewBackdrop) && blur > 0;
```

Over a PlatformView the live `BackdropFilter` is the only thing that can blur the map, so it must run even for interactive surfaces. The flicker the `!isInteractive` optimization guards against is real for a *continuously dragged* surface, but for a brief tap-scale it's imperceptible — and a momentary shimmer on press is a much better failure mode than a control that never blurs. Off a PlatformView, behavior is unchanged.

**Test:** extended the `_FrostedFallback` group with an `isInteractive: true` + `platformViewBackdrop` case asserting the `BackdropFilter` still renders — paired against the existing off-map `isInteractive=true skips BackdropFilter` case, so both branches of the new gate term are covered.
