### PR TITLE
platformViewBackdrop: backerColor fallback so premium glass doesn't go black over a PlatformView

### DIFF
--- a/lib/src/renderer/rendering/liquid_glass_render_object.dart
+++ b/lib/src/renderer/rendering/liquid_glass_render_object.dart
@@ -285,6 +285,15 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
               ..setFloat(settings.whitenGated ? 1.0 : 0.0)
               ..setFloat(settings.pinchStrength);
           })
+          // Slots 21-24: uBackgroundFallback (straight RGBA). An opaque stand-in
+          // for backdrop regions the engine can't capture (e.g. a PlatformView
+          // past the glass, which the lens would otherwise render black); a == 0
+          // (the default when no backerColor is set) disables it. See the
+          // over-composite in textureBilinear (liquid_glass_final_render.frag).
+          ..setFloatUniforms(initialIndex: 21, (value) {
+            final b = settings.backerColor ?? const Color(0x00000000);
+            value.setFloats(<double>[b.r, b.g, b.b, b.a]);
+          })
           ..setImageSampler(
             1,
             geometryImage,

--- a/lib/widgets/shared/animated_glass_indicator.dart
+++ b/lib/widgets/shared/animated_glass_indicator.dart
@@ -236,6 +236,12 @@ class AnimatedGlassIndicator extends StatelessWidget {
       whitenGated: override.whitenGated != _settingsDefaults.whitenGated
           ? override.whitenGated
           : null,
+      // backerColor was added to LiquidGlassSettings after this merge was
+      // written; without it the indicator silently drops any backerColor passed
+      // via indicatorSettings (e.g. the per-mode over-map stand-in colour).
+      backerColor: override.backerColor != _settingsDefaults.backerColor
+          ? override.backerColor
+          : null,
     );
   }
 

--- a/shaders/liquid_glass_final_render.frag
+++ b/shaders/liquid_glass_final_render.frag
@@ -57,6 +57,13 @@ uniform float uWhitenGated;
 // creating the iOS 26 "pinched through a lens" look. The centre is left flat.
 uniform float uPinchStrength;
 
+// Per-mode opaque stand-in for backdrop regions the engine can't capture: a
+// PlatformView past the glass reads as transparent black in the backdrop
+// texture, which otherwise renders as black through the lens. The sampled
+// backdrop is composited OVER this in textureBilinear, so empty regions read as
+// this colour instead. Straight (non-premultiplied) RGBA; a == 0 disables it.
+uniform vec4 uBackgroundFallback;
+
 uniform sampler2D uBackgroundTexture;
 uniform sampler2D uGeometryTexture;
 
@@ -102,7 +109,16 @@ vec4 textureBilinear(vec2 uv, vec2 size, vec2 invSize) {
 
     vec4 cTop = mix(c0, c1, f.x);
     vec4 cBot = mix(c2, c3, f.x);
-    return mix(cTop, cBot, f.y);
+    vec4 bg = mix(cTop, cBot, f.y);
+
+    // Composite the (premultiplied) backdrop sample OVER the fallback colour.
+    // Where the engine couldn't capture a backdrop (a PlatformView past the bar
+    // → transparent black, bg.a ≈ 0) this yields the fallback; where the
+    // backdrop is real (bg.a ≈ 1) it is left untouched. uBackgroundFallback is
+    // straight RGBA, so premultiply it by its own alpha before the over.
+    bg.rgb += uBackgroundFallback.rgb * uBackgroundFallback.a * (1.0 - bg.a);
+    bg.a += uBackgroundFallback.a * (1.0 - bg.a);
+    return bg;
 }
 
 void main() {

--- a/test/widgets/shared/animated_glass_indicator_coverage_test.dart
+++ b/test/widgets/shared/animated_glass_indicator_coverage_test.dart
@@ -15,6 +15,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/widgets/shared/glass_effect.dart';
 
 import '../../shared/test_helpers.dart';
 
@@ -131,6 +132,22 @@ void main() {
       )));
       await tester.pump();
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('non-default backerColor survives onto the built glass',
+        (tester) async {
+      // Regression: _mergeWithBase rebuilds settings field-by-field and used to
+      // OMIT backerColor, silently dropping any backerColor set via
+      // indicatorSettings. It must now reach the rendered GlassEffect.
+      const backer = Color(0xFF123456);
+      await tester.pumpWidget(_wrap(_make(
+        thickness: 0.5,
+        settings: const LiquidGlassSettings(backerColor: backer),
+      )));
+      await tester.pump();
+      final glass =
+          tester.widget<GlassEffect>(find.byType(GlassEffect).first);
+      expect(glass.settings.backerColor, backer);
     });
 
     testWidgets('non-default thickness exercises thickness branch',


### PR DESCRIPTION
The premium lens samples `uBackgroundTexture` = the engine's implicit `BackdropFilter` capture, which **excludes PlatformView pixels**. Where the lens extends over a region the engine can't capture (e.g. a tab indicator's jelly/morph overhang past the bar, over a map), the backdrop is empty → the lens renders **black**. No local widget can feed that engine-owned backdrop, so there's no consumer-side fix.

This adds a `uBackgroundFallback` vec4 uniform (float slot 21, from the recipe's `backerColor`) and composites the sampled backdrop *over* it in the shader's single sample helper (`textureBilinear`): empty backdrop (`a≈0`) → the fallback colour, real backdrop (`a≈1`) → untouched. So glass with `backerColor` set shows a solid stand-in where the engine can't capture, and the live backdrop everywhere else. It keeps the engine `BackdropFilter` path entirely — no hand-painted shader / `setImageSampler`. `backerColor == null` (the default) leaves rendering identical to today.

It also includes a prerequisite bug fix: `AnimatedGlassIndicator._mergeWithBase` rebuilds settings field-by-field and was **silently dropping `backerColor`** (a field added after that merge was written), so any `indicatorSettings.backerColor` never reached the lens. (Happy to split that into its own PR if you'd prefer.)

Developed and tested on 0.18.4 (a premium tab indicator over a Mapbox map now shows a per-mode solid backer instead of black on the overhang); the touched files are near-identical on `main`, so it applies cleanly. I couldn't build-test a 0.19.x branch locally (its `meta: ^1.18.0` doesn't resolve on my Flutter). You'll likely have a cleaner take on the shader composite — take whatever's useful.

**Tests:** added a `backerColor survives onto the built glass` case to `animated_glass_indicator_coverage_test.dart` (asserts the merge no longer drops it). The shader composite and the slot-21 uniform write are render-path/GPU code that isn't unit-testable here.
