### PR TITLE
fix(adaptive_glass): clip LiquidOval via ClipRRect over a PlatformView (frost halo)

### DIFF
--- a/lib/widgets/shared/adaptive_glass.dart
+++ b/lib/widgets/shared/adaptive_glass.dart
@@ -730,7 +730,11 @@ class _FrostedFallback extends StatelessWidget {
           // around rounded glass surfaces stacked over PlatformViews
           // (e.g. mapbox_maps_flutter, video_player on iOS).
           Positioned.fill(
-            child: _ShapeClip(shape: shape, child: body),
+            child: _ShapeClip(
+              shape: shape,
+              platformViewBackdrop: platformViewBackdrop,
+              child: body,
+            ),
           ),
 
         if (!useBlur)
@@ -760,7 +764,11 @@ class _FrostedFallback extends StatelessWidget {
         // Text and contents MUST be strictly clipped to corner radii.
         // Same ClipRRect-over-ClipPath rationale as the blur body
         // above — see the [_ShapeClip] doc comment.
-        _ShapeClip(shape: shape, child: child),
+        _ShapeClip(
+          shape: shape,
+          platformViewBackdrop: platformViewBackdrop,
+          child: child,
+        ),
 
         // Specular Rim: drawn as a pure native overlay vector perfectly on top.
         // Wrapped in _ShapeClip because canvas.drawPath draws a center-aligned
@@ -933,10 +941,27 @@ class _SpecularRimPainter extends CustomPainter {
 /// renders identically to a circle on a square widget and triggers the
 /// engine fix.
 class _ShapeClip extends StatelessWidget {
-  const _ShapeClip({required this.shape, required this.child});
+  const _ShapeClip({
+    required this.shape,
+    required this.child,
+    this.platformViewBackdrop = false,
+  });
 
   final LiquidShape shape;
   final Widget child;
+
+  /// When the clipped subtree sits over an iOS PlatformView, force a
+  /// [ClipRRect]-based clip even for shapes that would otherwise fall through to
+  /// a [ClipPath] (e.g. [LiquidOval], [LiquidRoundedRectangle]).
+  ///
+  /// Flutter's clip forwarding (#177551, 3.41+) only sends ClipRRect clip data
+  /// to the iOS PlatformView mutator stack — a ClipPath leaves a descendant
+  /// [BackdropFilter] unclipped, so the frost leaks a rectangular halo around
+  /// the (visually round) surface. A ClipRRect with a full radius renders the
+  /// same circle/stadium but IS forwarded, bounding the frost to the shape.
+  /// Off a PlatformView the ClipPath path is exact (a true ellipse), so the swap
+  /// is gated on this flag.
+  final bool platformViewBackdrop;
 
   @override
   Widget build(BuildContext context) {
@@ -955,6 +980,17 @@ class _ShapeClip extends StatelessWidget {
         ),
         child: child,
       );
+    }
+    // Over a PlatformView, route any radius-expressible shape (oval →
+    // circle/stadium, rounded rect, vertical variants) through ClipRRect so the
+    // clip is forwarded to the PlatformView mutator and a descendant
+    // BackdropFilter is bounded to the shape — eliminating the rectangular halo.
+    // #177551 only forwards ClipRRect, never ClipPath.
+    if (platformViewBackdrop) {
+      final borderRadius = AdaptiveGlass._borderRadiusFromShape(shape);
+      if (borderRadius != null) {
+        return ClipRRect(borderRadius: borderRadius, child: child);
+      }
     }
     return ClipPath(
       clipper: ShapeBorderClipper(shape: shape),


### PR DESCRIPTION
## Problem

Over an iOS `PlatformView` (e.g. a map), any glass surface that resolves to a `LiquidOval` renders a **rectangular blur halo** when `platformViewBackdrop` routes it to the frosted `BackdropFilter` fallback. This includes the **default shape of `GlassButton`/`GlassIconButton`**, the collapsed search trigger and dismiss pill (`tab_bar_searchable_internal.dart`), the bottom-bar collapsed indicator, and the `GlassBottomBarExtraButton` — i.e. the rectangular blur background reported in #79.

Root cause: Flutter's clip forwarding (#177551, 3.41+) only forwards `ClipRRect` clip data to the iOS PlatformView mutator stack — **not** the `ClipPath` that `LiquidOval` (and `LiquidRoundedRectangle`) use. So the descendant `BackdropFilter` is left unclipped over the PlatformView and leaks a square. `_ShapeClip` already special-cased superellipses to `ClipRRect` for exactly this reason; ovals/rects fell through to `ClipPath`.

## Fix

In `_ShapeClip`, when the clipped subtree is over a PlatformView (`platformViewBackdrop`), route any shape with an expressible border radius (`LiquidOval` → circle/stadium via `circular(9999)`, rounded rects, vertical variants) through `ClipRRect` instead of `ClipPath`, reusing the existing `AdaptiveGlass._borderRadiusFromShape`. Visually identical (a full-radius RRect renders the same circle/stadium), but the clip is now forwarded, bounding the frost to the shape.

The swap is gated on `platformViewBackdrop` — off a PlatformView, ovals keep their exact `ClipPath` (true ellipse). `_FrostedFallback` passes the flag through to both its `_ShapeClip` calls (the blur body and the content clip).

## Why central (not per-call-site)

`GlassButton`/`GlassIconButton` **default** to `LiquidOval`, so any consumer passing `platformViewBackdrop` with the default shape leaks — and that can't be fixed from a call site. Fixing `_ShapeClip` once covers every current and future caller.

Follow-up to #128 / #129, and fixes the rectangular-blur on `GlassBottomBarExtraButton` reported in #79.

## Testing

Verified on device (iPhone 16 Pro Max, Flutter 3.41) with a Mapbox `MapWidget` behind a `GlassSearchableBottomBar(platformViewBackdrop: true)`: the collapsed search button's blur now clips cleanly to the circle, matching the (already-superellipse) over-map controls. Off-PlatformView rendering is unchanged.
