### PR TITLE
fix(GlassButton): guard press handlers on `mounted` before touching the controller

### DIFF
--- a/lib/widgets/interactive/glass_button.dart
+++ b/lib/widgets/interactive/glass_button.dart
@@ -550,20 +550,27 @@ class _GlassButtonState extends State<GlassButton>
   // ---------------------------------------------------------------------------
   // Tap-based pressed state (persistPressOnDrag: false)
   // Used by lock screen camera/torch buttons — cancels on drag.
+  //
+  // All press handlers below guard on `mounted` before touching
+  // [_saturationController]: a button can be DISPOSED mid-press — e.g. a
+  // collapsing nav mini-bar removed by the very tap that expands it — after which
+  // a queued pointerUp / pointerCancel still dispatches here and would call
+  // `.reverse()` on the disposed controller, throwing
+  // `AnimationController.reverse() called after dispose()` (assert `_ticker != null`).
   // ---------------------------------------------------------------------------
 
   void _handleTapDown(TapDownDetails details) {
-    if (!widget.enabled) return;
+    if (!mounted || !widget.enabled) return;
     _saturationController.forward();
   }
 
   void _handleTapUp(TapUpDetails details) {
-    if (!widget.enabled) return;
+    if (!mounted || !widget.enabled) return;
     _saturationController.reverse();
   }
 
   void _handleTapCancel() {
-    if (!widget.enabled) return;
+    if (!mounted || !widget.enabled) return;
     _saturationController.reverse();
   }
 
@@ -575,17 +582,17 @@ class _GlassButtonState extends State<GlassButton>
   // ---------------------------------------------------------------------------
 
   void _handlePointerDown(PointerDownEvent event) {
-    if (!widget.enabled) return;
+    if (!mounted || !widget.enabled) return;
     _saturationController.forward();
   }
 
   void _handlePointerUp(PointerUpEvent event) {
-    if (!widget.enabled) return;
+    if (!mounted || !widget.enabled) return;
     _saturationController.reverse();
   }
 
   void _handlePointerCancel(PointerCancelEvent event) {
-    if (!widget.enabled) return;
+    if (!mounted || !widget.enabled) return;
     _saturationController.reverse();
   }
 


### PR DESCRIPTION
## Problem

Tapping a `GlassButton` that is disposed *by the very tap that activates it* (e.g. a button in a bar that morphs/collapses on tap) can throw:

```
AnimationController.reverse() called after AnimationController.dispose()  (assert _ticker != null)
```

A queued `pointerUp`/`pointerCancel` is still dispatched to the now-disposed `RenderPointerListener`, and the press handler calls `_saturationController.forward()/reverse()` after `dispose()`.

## Fix

Guard every tap/pointer press handler on `!mounted` before touching the controller, so it bails when the `State` is already disposed. Small and self-contained — `glass_button.dart` only.

## Repro / context

Surfaced building an app with a `GlassButton` as the collapsed bottom-bar restore button: tapping it expands the bar, which disposes that button mid-press. Caught/non-fatal today but noisy in the logs. Related to the over-map bar work in #127 / #79.

## Testing

Verified on device (iPhone 16 Pro Max, Flutter 3.41): tapping the collapsing control mid-gesture no longer throws.
