### PR TITLE
fix(GlassModalSheet): drop the interior BoxShadow that bleeds through the glass

### DIFF
--- a/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
@@ -190,28 +190,17 @@ class _SheetLayout extends StatelessWidget {
                 child: Stack(
                   clipBehavior: Clip.none,
                   children: [
-                    // 1. Shape outline + drop shadow (transparent fill —
-                    //    actual fill lives inside AdaptiveGlass below).
+                    // 1. Empty slot placeholder — kept so the glass surface below
+                    //    keeps its element identity (this Stack is sensitive to slot
+                    //    shifts re-initing the glass). It used to hold a BoxShadow
+                    //    for faux depth, but behind the transparent fill + the
+                    //    translucent frost it never read as a drop shadow: it bled
+                    //    THROUGH the glass as interior darkening (an inner-shadow /
+                    //    vignette), was invisible behind the opaque full state, and
+                    //    broke light mode. Apple's glass sheets don't darken their
+                    //    interior — removed.
                     Positioned.fill(
-                      child: DecoratedBox(
-                        decoration: ShapeDecoration(
-                          color: Colors.transparent,
-                          shape: RoundedSuperellipseBorder(
-                            borderRadius: BorderRadius.vertical(
-                              top: Radius.circular(currentTopRadius),
-                              bottom: Radius.circular(currentBottomRadius),
-                            ),
-                          ),
-                          shadows: [
-                            BoxShadow(
-                              color: Colors.black
-                                  .withValues(alpha: 0.2 * glassOpacity),
-                              blurRadius: 20,
-                              offset: const Offset(0, 10),
-                            ),
-                          ],
-                        ),
-                      ),
+                      child: const SizedBox.shrink(),
                     ),
                     // 2. Single unified glass surface — owns the SDF clip,
                     //    solid fill, glow, and content. Consolidating into one


### PR DESCRIPTION
Per discussion #130.

The legacy `BoxShadow` in `_SheetLayout` sits on a transparent-fill `DecoratedBox` *behind* the translucent `AdaptiveGlass`, so it bleeds **through** the surface as interior darkening (an inner-shadow / vignette) rather than casting beneath the sheet. Worst over a PlatformView in light mode, and amplified because the alpha is `× glassOpacity` — i.e. darkest exactly when the glass is most see-through.

Removes the hardcoded `BoxShadow`; a `SizedBox.shrink()` placeholder keeps the Stack slot's element identity (the sheet re-inits its glass on slot shifts). Elevation now flows through the sheet's `AdaptiveGlass` via `LiquidGlassSettings.shadowElevation` — inverse-clipped, light-mode-only, Apple-calibrated, as suggested in #130. Consumers wanting none pass `settings: LiquidGlassSettings(shadowElevation: 0)`.

Thanks @yukinoaruu for the original sheet and the hand-off. 🙏
