### PR TITLE
feat(LiquidGlassSettings): add platformViewFallbackColor (split from backerColor's dual-use)

### DIFF
--- a/lib/src/renderer/liquid_glass_settings.dart
+++ b/lib/src/renderer/liquid_glass_settings.dart
@@ -36,6 +36,7 @@ class LiquidGlassSettings with EquatableMixin {
     this.whitenStrength = 0.0,
     this.whitenGated = true,
     this.backerColor,
+    this.platformViewFallbackColor,
   }) : pinchStrength = 0.0;
 
   /// Private constructor used exclusively by [copyWithPinch].
@@ -62,6 +63,7 @@ class LiquidGlassSettings with EquatableMixin {
     required this.whitenStrength,
     required this.whitenGated,
     this.backerColor,
+    this.platformViewFallbackColor,
     required this.pinchStrength,
   });
 
@@ -320,6 +322,7 @@ class LiquidGlassSettings with EquatableMixin {
         whitenStrength: whitenStrength,
         whitenGated: whitenGated,
         backerColor: backerColor,
+        platformViewFallbackColor: platformViewFallbackColor,
         pinchStrength: value,
       );
 
@@ -342,6 +345,21 @@ class LiquidGlassSettings with EquatableMixin {
   ///
   /// Defaults to null: no backer, and no change to existing rendering.
   final Color? backerColor;
+
+  /// Solid stand-in color the lens composites where the engine can't capture the
+  /// backdrop — i.e. behind a PlatformView past the glass, which the lens would
+  /// otherwise render black (see `platformViewBackdrop` on the glass widgets).
+  ///
+  /// Distinct from [backerColor]: [backerColor] is an *aesthetic* dimming pad
+  /// painted behind the glass everywhere; this is the *fallback fill* used only
+  /// where the shader has no backdrop to sample. Splitting them lets a control
+  /// have one without the other (e.g. a transparent over-map fill with no dim, or
+  /// a dim pad off-PlatformView with no fill).
+  ///
+  /// Defaults to null, in which case it falls back to [backerColor] — so existing
+  /// recipes that relied on `backerColor` doubling as the PlatformView fill are
+  /// unchanged.
+  final Color? platformViewFallbackColor;
 
   /// The effective saturation taking visibility into account.
   double get effectiveSaturation => 1 + (saturation - 1) * visibility;
@@ -388,6 +406,8 @@ class LiquidGlassSettings with EquatableMixin {
         // Lerp the color so the backer fades smoothly (from/to transparent when
         // one side is null), rather than popping at the midpoint.
         backerColor: Color.lerp(a.backerColor, b.backerColor, t),
+        platformViewFallbackColor: Color.lerp(
+            a.platformViewFallbackColor, b.platformViewFallbackColor, t),
         // pinchStrength is interaction state — lerp it so transitions are smooth
         // when the indicator fades between active/resting states.
         pinchStrength: lerpDouble(a.pinchStrength, b.pinchStrength, t)!);
@@ -422,6 +442,7 @@ class LiquidGlassSettings with EquatableMixin {
     double? whitenStrength,
     bool? whitenGated,
     Color? backerColor,
+    Color? platformViewFallbackColor,
   }) =>
       LiquidGlassSettings._withPinch(
         visibility: visibility ?? this.visibility,
@@ -443,6 +464,8 @@ class LiquidGlassSettings with EquatableMixin {
         whitenStrength: whitenStrength ?? this.whitenStrength,
         whitenGated: whitenGated ?? this.whitenGated,
         backerColor: backerColor ?? this.backerColor,
+        platformViewFallbackColor:
+            platformViewFallbackColor ?? this.platformViewFallbackColor,
         // Preserve current pinchStrength — copyWith is called by AnimatedGlassIndicator
         // to change visibility while keeping the live pinch value alive.
         // To set a new pinch value, call copyWithPinch() instead.
@@ -469,6 +492,7 @@ class LiquidGlassSettings with EquatableMixin {
         whitenStrength,
         whitenGated,
         backerColor,
+        platformViewFallbackColor,
         pinchStrength,
       ];
 }

--- a/lib/src/renderer/rendering/liquid_glass_render_object.dart
+++ b/lib/src/renderer/rendering/liquid_glass_render_object.dart
@@ -288,10 +288,17 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
           // Slots 21-24: uBackgroundFallback (straight RGBA). An opaque stand-in
           // for backdrop regions the engine can't capture (e.g. a PlatformView
           // past the glass, which the lens would otherwise render black); a == 0
-          // (the default when no backerColor is set) disables it. See the
-          // over-composite in textureBilinear (liquid_glass_final_render.frag).
+          // (the default) disables it. See the over-composite in textureBilinear
+          // (liquid_glass_final_render.frag).
+          //
+          // Sourced from platformViewFallbackColor, falling back to backerColor
+          // when unset — so backerColor keeps doubling as the fill for existing
+          // recipes, while platformViewFallbackColor lets callers decouple the
+          // PlatformView fill from the aesthetic backer.
           ..setFloatUniforms(initialIndex: 21, (value) {
-            final b = settings.backerColor ?? const Color(0x00000000);
+            final b = settings.platformViewFallbackColor ??
+                settings.backerColor ??
+                const Color(0x00000000);
             value.setFloats(<double>[b.r, b.g, b.b, b.a]);
           })
           ..setImageSampler(


### PR DESCRIPTION
Per discussion #79 — splitting `backerColor`'s dual role.

`backerColor` currently feeds two unrelated things:
1. the **aesthetic** dimming pad behind the glass (`_wrapWithBacker` — works anywhere), and
2. the **PlatformView fallback fill** — the opaque stand-in the lens composites where it can't sample the backdrop (the `uBackgroundFallback` shader uniform, behind a PlatformView past the glass).

As you flagged on #79, overloading one field for both surprises consumers — you can't have, say, a transparent over-map fill without also dropping the dim pad, or vice versa.

**This adds `platformViewFallbackColor`** to `LiquidGlassSettings`. The shader uniform now sources `platformViewFallbackColor ?? backerColor`:
- `backerColor` stays the aesthetic backer pad.
- `platformViewFallbackColor` is the PlatformView fill.
- **Fully backwards-compatible** — `platformViewFallbackColor` defaults to `null`, in which case it falls back to `backerColor`, so existing recipes that relied on `backerColor` doubling as the fill are unchanged.

Mirrors `backerColor` end-to-end (both constructors, `copyWith`, `lerp`, `props`, plus a docstring). No behavior change unless `platformViewFallbackColor` is set.

(Both touched files are under `lib/src/renderer/**`, which codecov ignores.)
