### PR TITLE
feat: GlassLargeTitle + GlassLargeTitleController — iOS 26 two-phase large-title + search-bar collapse (0.19.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,51 @@
+# 0.19.6
+
+## ✨ New — `GlassLargeTitle` + `GlassLargeTitleController`
+
+First-class iOS 26 large-title + search-bar collapse. Replaces manual
+`ScrollController` + `setState` wiring with a single controller and two
+widgets.
+
+### Two-phase collapse
+
+- **Phase 1** — large title fades out (`Curves.easeIn`, rubber-band overscroll stretch).
+- **Phase 2** — optional inline search bar collapses under the nav bar immediately after.
+
+### New API
+
+- `GlassLargeTitle` — sliver widget. Drop it as the first sliver in any `CustomScrollView`.
+  - `searchBar: Widget?` — Phase 2 collapse (e.g. `GlassSearchBar`).
+  - `trailing`, `fontSize`, `fontWeight`, `letterSpacing`, `padding`, `searchBarPadding`, `color`.
+- `GlassLargeTitleController` — owns the `ScrollController`, exposes `collapseProgress` and `searchBarCollapseProgress`. Self-calibrates to Dynamic Type via `reportMeasuredHeight` / `reportSearchBarHeight`.
+- `GlassAppBar.largeTitleController` — new optional param. Bar title cross-fades in as the large title collapses. Non-breaking.
+
+```dart
+final _ctrl = GlassLargeTitleController(); // dispose in State.dispose()
+
+// Phase 1 only
+GlassLargeTitle(text: 'Chats', controller: _ctrl)
+
+// Phase 1 + 2
+GlassLargeTitle(
+  text: 'Messages',
+  controller: _ctrl,
+  searchBar: GlassSearchBar(placeholder: 'Search', onChanged: (_) {}),
+)
+```
+
+### Demo
+
+- Pattern 2 updated to new API. Pattern 7 (Large Title + Search Bar) added.
+- Apple Messages demo migrated from manual `AnimatedOpacity` to `GlassLargeTitle`.
+
++10 tests. **2,291 total, all passing.**
+
+
+
+
 # 0.19.5
+
+
 
 - **`LiquidGlassSettings`** — adds `platformViewFallbackColor` (#138, @jfhair). Splits
   `backerColor`'s dual role: `backerColor` remains the aesthetic backer pad; the new

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -396,6 +396,18 @@ Ideas for consideration after stable. None of these are committed.
   tabs, matching iOS tab bar customisation.
 - [ ] `GlassSheet` snap points — configurable detent heights (peek / half /
   full) matching `UISheetPresentationController.Detent`.
+- [ ] **`GlassAppBar` Phase 3 compact search icon** — when both
+  `GlassLargeTitle.searchBar` and `GlassAppBar.largeTitleController` are in use
+  and `searchBarCollapseProgress == 1.0`, the navigation bar should grow slightly
+  and show a compact search affordance (a pill or icon button) that re-expands
+  the search bar when tapped. This matches iOS 26's `UINavigationItem.searchController`
+  end-state in apps like Mail and Contacts.
+  **Blocked by:** `GlassAppBar` currently implements `ObstructingPreferredSizeWidget`
+  with a fixed `preferredSize`. Phase 3 requires the bar to change height
+  dynamically, which touches the layout contract with `Scaffold` /
+  `CupertinoPageScaffold`. This needs careful architecture work and its own
+  breaking-change release plan. **Phase 1 + 2 (shipped in 0.19.6) deliver 90%
+  of the value; Phase 3 is a polish milestone.**
 
 ### Ecosystem
 - [ ] Dedicated documentation site (GitHub Pages or similar).

--- a/example/lib/apple_messages/apple_messages_demo.dart
+++ b/example/lib/apple_messages/apple_messages_demo.dart
@@ -266,31 +266,14 @@ class MessagesScreen extends StatefulWidget {
 }
 
 class _MessagesScreenState extends State<MessagesScreen> {
-  final _scrollController = ScrollController();
-  bool _headerCollapsed = false;
+  final _titleController = GlassLargeTitleController();
 
   // Tracks which filter is selected in the right menu
   String _activeFilter = 'Messages';
 
   @override
-  void initState() {
-    super.initState();
-    _scrollController.addListener(_onScroll);
-  }
-
-  void _onScroll() {
-    final collapsed =
-        _scrollController.hasClients && _scrollController.offset > 60;
-    if (collapsed != _headerCollapsed) {
-      setState(() => _headerCollapsed = collapsed);
-    }
-  }
-
-  @override
   void dispose() {
-    _scrollController
-      ..removeListener(_onScroll)
-      ..dispose();
+    _titleController.dispose();
     super.dispose();
   }
 
@@ -311,35 +294,22 @@ class _MessagesScreenState extends State<MessagesScreen> {
       bottomBarHeight: 60,
       appBar: _NavBar(
         topPad: topPad,
-        headerCollapsed: _headerCollapsed,
+        titleController: _titleController,
         activeFilter: _activeFilter,
         onFilterChanged: (filter) => setState(() => _activeFilter = filter),
       ),
       bottomBar: _SearchBar(bottomPad: botPad),
       body: CustomScrollView(
-        controller: _scrollController,
+        controller: _titleController.scrollController,
         slivers: [
           // Status bar space + nav bar height
           SliverToBoxAdapter(child: SizedBox(height: topPad + 52)),
 
-          // Large "Messages" title (collapses on scroll)
-          SliverToBoxAdapter(
-            child: AnimatedOpacity(
-              duration: const Duration(milliseconds: 200),
-              opacity: _headerCollapsed ? 0 : 1,
-              child: Padding(
-                padding: EdgeInsets.fromLTRB(16, 4, 16, 8),
-                child: Text(
-                  'Messages',
-                  style: TextStyle(
-                    color: CupertinoColors.label.resolveFrom(context),
-                    fontSize: 34,
-                    fontWeight: FontWeight.w700,
-                    letterSpacing: -0.5,
-                  ),
-                ),
-              ),
-            ),
+          // Large "Messages" title (collapses on scroll automatically)
+          GlassLargeTitle(
+            text: 'Messages',
+            controller: _titleController,
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
           ),
 
           // Conversation rows
@@ -367,56 +337,37 @@ class _MessagesScreenState extends State<MessagesScreen> {
 class _NavBar extends StatelessWidget {
   const _NavBar({
     required this.topPad,
-    required this.headerCollapsed,
+    required this.titleController,
     required this.activeFilter,
     required this.onFilterChanged,
   });
 
   final double topPad;
-  final bool headerCollapsed;
+  final GlassLargeTitleController titleController;
   final String activeFilter;
   final ValueChanged<String> onFilterChanged;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        SizedBox(height: topPad),
-        SizedBox(
-          height: 52,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                // ── Edit menu (top-left) ─────────────────────────────────
-                const _EditMenu(),
-                const Spacer(),
-
-                // Inline "Messages" title when scrolled
-                AnimatedOpacity(
-                  duration: const Duration(milliseconds: 200),
-                  opacity: headerCollapsed ? 1 : 0,
-                  child: Text(
-                    'Messages',
-                    style: TextStyle(
-                      color: CupertinoColors.label.resolveFrom(context),
-                      fontSize: 17,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-                const Spacer(),
-
-                // ── Filter menu (top-right) ──────────────────────────────
-                _FilterMenu(
-                  activeFilter: activeFilter,
-                  onFilterChanged: onFilterChanged,
-                ),
-              ],
-            ),
-          ),
+    return GlassAppBar(
+      preferredSize: const Size.fromHeight(52),
+      // Bar title fades in automatically when large title collapses
+      title: Text(
+        'Messages',
+        style: TextStyle(
+          color: CupertinoColors.label.resolveFrom(context),
+          fontSize: 17,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      largeTitleController: titleController,
+      // The menus get their own paddings so we override the default AppBar insets
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      leading: const _EditMenu(),
+      actions: [
+        _FilterMenu(
+          activeFilter: activeFilter,
+          onFilterChanged: onFilterChanged,
         ),
       ],
     );

--- a/example/lib/demos/nav_bar_patterns_demo.dart
+++ b/example/lib/demos/nav_bar_patterns_demo.dart
@@ -8,6 +8,7 @@
 ///   4. Transparent fade-only (no title in bar)
 ///   5. Tab bar with bottom fade
 ///   6. Fade header (no app bar) — Apple Music / Podcasts style
+///   7. Large title + Search Bar — two-phase iOS 26 collapse
 ///
 /// Run standalone:
 ///   flutter run -t lib/demos/nav_bar_patterns_demo.dart
@@ -130,6 +131,14 @@ class NavBarPatternsDemo extends StatelessWidget {
                   subtitle: 'Fixed title fades on scroll — Apple Music style',
                   icon: CupertinoIcons.music_note_2,
                   onTap: () => _push(context, const _FadeHeaderDemo()),
+                ),
+                const SizedBox(height: 16),
+                _PatternTile(
+                  title: 'Large Title + Search Bar',
+                  subtitle:
+                      'Two-phase collapse: title then search — iOS 26 Messages/Mail style',
+                  icon: CupertinoIcons.search,
+                  onTap: () => _push(context, const _LargeTitleSearchDemo()),
                 ),
                 const SizedBox(height: 100),
               ],
@@ -354,30 +363,13 @@ class _LargeTitleCollapseDemo extends StatefulWidget {
 }
 
 class _LargeTitleCollapseDemoState extends State<_LargeTitleCollapseDemo> {
-  final _scrollController = ScrollController();
-  double _scrollOffset = 0;
-
-  static const _largeTitleHeight = 52.0;
-
-  @override
-  void initState() {
-    super.initState();
-    _scrollController.addListener(_onScroll);
-  }
+  final _titleController = GlassLargeTitleController();
 
   @override
   void dispose() {
-    _scrollController.removeListener(_onScroll);
-    _scrollController.dispose();
+    _titleController.dispose();
     super.dispose();
   }
-
-  void _onScroll() {
-    setState(() => _scrollOffset = _scrollController.offset);
-  }
-
-  double get _collapseProgress =>
-      (_scrollOffset / _largeTitleHeight).clamp(0.0, 1.0);
 
   @override
   Widget build(BuildContext context) {
@@ -388,17 +380,16 @@ class _LargeTitleCollapseDemoState extends State<_LargeTitleCollapseDemo> {
       settings: RecommendedGlassSettings.standard,
       statusBarStyle: GlassStatusBarStyle.auto,
       appBar: GlassAppBar(
-        title: Opacity(
-          opacity: _collapseProgress,
-          child: Text(
-            'Chats',
-            style: TextStyle(
-              fontSize: 20,
-              fontWeight: FontWeight.bold,
-              color: CupertinoColors.label.resolveFrom(context),
-            ),
+        // Bar title fades in automatically as the large title scrolls away.
+        title: Text(
+          'Chats',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: CupertinoColors.label.resolveFrom(context),
           ),
         ),
+        largeTitleController: _titleController,
         leading: GlassButton(
           quality: GlassQuality.premium,
           icon: const Icon(CupertinoIcons.back),
@@ -425,27 +416,15 @@ class _LargeTitleCollapseDemoState extends State<_LargeTitleCollapseDemo> {
         ],
       ),
       body: CustomScrollView(
-        controller: _scrollController,
+        controller: _titleController.scrollController,
         slivers: [
           SliverToBoxAdapter(
             child: SizedBox(height: topPad + 44),
           ),
-          // Large title that scrolls away
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(24, 0, 24, 16),
-              child: Text(
-                'Chats',
-                style: TextStyle(
-                  fontSize: 34,
-                  fontWeight: FontWeight.w700,
-                  letterSpacing: -0.5,
-                  color: CupertinoColors.label.resolveFrom(context).withValues(
-                        alpha: 1.0 - _collapseProgress,
-                      ),
-                ),
-              ),
-            ),
+          // Large title fades out as user scrolls — zero boilerplate.
+          GlassLargeTitle(
+            text: 'Chats',
+            controller: _titleController,
           ),
           _buildDummyContent(),
           const SliverToBoxAdapter(child: SizedBox(height: 100)),
@@ -756,6 +735,95 @@ class _FadeHeaderDemoState extends State<_FadeHeaderDemo> {
           ),
           _buildDummyContent(),
           const SliverToBoxAdapter(child: SizedBox(height: 120)),
+        ],
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// 7. Large Title + Search Bar — Two-Phase iOS 26 Collapse
+// =============================================================================
+//
+// iOS 26 Messages / Mail pattern:
+//   Phase 1 (0 → ~52pt): Large title fades out.
+//   Phase 2 (~52pt → ~96pt): Search bar collapses under the nav bar.
+//
+// GlassLargeTitleController drives both phases from a single ScrollController.
+
+class _LargeTitleSearchDemo extends StatefulWidget {
+  const _LargeTitleSearchDemo();
+
+  @override
+  State<_LargeTitleSearchDemo> createState() => _LargeTitleSearchDemoState();
+}
+
+class _LargeTitleSearchDemoState extends State<_LargeTitleSearchDemo> {
+  final _titleController = GlassLargeTitleController();
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final topPad = MediaQuery.paddingOf(context).top;
+
+    return GlassScaffold(
+      background: const ShowcaseBackground(),
+      settings: RecommendedGlassSettings.standard,
+      statusBarStyle: GlassStatusBarStyle.auto,
+      appBar: GlassAppBar(
+        // Bar title fades in automatically in Phase 1.
+        title: Text(
+          'Messages',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: CupertinoColors.label.resolveFrom(context),
+          ),
+        ),
+        largeTitleController: _titleController,
+        leading: GlassButton(
+          quality: GlassQuality.premium,
+          icon: const Icon(CupertinoIcons.back),
+          onTap: () => Navigator.of(context).pop(),
+          width: 40,
+          height: 40,
+          iconSize: 20,
+        ),
+        actions: [
+          GlassButton(
+            icon: const Icon(CupertinoIcons.pencil),
+            onTap: () {},
+            width: 40,
+            height: 40,
+            iconSize: 20,
+          ),
+        ],
+      ),
+      body: CustomScrollView(
+        controller: _titleController.scrollController,
+        slivers: [
+          SliverToBoxAdapter(
+            child: SizedBox(height: topPad + 44),
+          ),
+          // Phase 1: large title fades out.
+          // Phase 2: search bar collapses under nav bar.
+          // Both driven automatically by GlassLargeTitleController.
+          GlassLargeTitle(
+            text: 'Messages',
+            controller: _titleController,
+            searchBar: GlassSearchBar(
+              placeholder: 'Search',
+              useOwnLayer: true,
+              onChanged: (_) {},
+            ),
+          ),
+          _buildDummyContent(),
+          const SliverToBoxAdapter(child: SizedBox(height: 100)),
         ],
       ),
     );

--- a/lib/liquid_glass_widgets.dart
+++ b/lib/liquid_glass_widgets.dart
@@ -113,6 +113,7 @@ export 'widgets/overlays/glass_toast.dart';
 export 'widgets/overlays/glass_popover.dart';
 // Widgets - Surfaces
 export 'widgets/surfaces/glass_app_bar.dart';
+export 'widgets/surfaces/glass_large_title.dart';
 export 'widgets/shared/glass_isolation_scope.dart';
 export 'widgets/surfaces/glass_scaffold.dart';
 export 'widgets/surfaces/glass_bottom_bar.dart';

--- a/lib/widgets/surfaces/glass_app_bar.dart
+++ b/lib/widgets/surfaces/glass_app_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import '../../src/renderer/liquid_glass_renderer.dart';
 import '../../types/glass_quality.dart';
 import '../shared/glass_isolation_scope.dart';
+import 'glass_large_title.dart' show GlassLargeTitleController;
 
 /// A navigation bar layout widget following Apple's iOS 26 design patterns.
 ///
@@ -12,6 +13,30 @@ import '../shared/glass_isolation_scope.dart';
 /// individual interactive elements (buttons, pills) — not the bar surface
 /// itself. This matches iOS 26's navigation bar where the bar is a simple
 /// layout container and glass is reserved for buttons.
+///
+/// ## Large-title collapse (iOS 26 pattern)
+///
+/// Pair with [GlassLargeTitle] and [GlassLargeTitleController] to get
+/// automatic cross-fade between the large title (in the scroll view) and the
+/// inline bar title — with zero boilerplate:
+///
+/// ```dart
+/// final _titleController = GlassLargeTitleController();
+///
+/// GlassScaffold(
+///   appBar: GlassAppBar(
+///     title: Text('Chats'),
+///     largeTitleController: _titleController,   // ← fades in as user scrolls
+///   ),
+///   body: CustomScrollView(
+///     controller: _titleController.scrollController,
+///     slivers: [
+///       GlassLargeTitle(text: 'Chats', controller: _titleController),
+///       // ... content slivers
+///     ],
+///   ),
+/// )
+/// ```
 ///
 /// ## Transparent (default — iOS 26 style)
 ///
@@ -70,6 +95,7 @@ class GlassAppBar extends StatelessWidget
     this.preferredSize = const Size.fromHeight(44.0),
     this.padding = const EdgeInsets.symmetric(horizontal: 8),
     this.buttonSettings,
+    this.largeTitleController,
   });
 
   // ===========================================================================
@@ -136,6 +162,17 @@ class GlassAppBar extends StatelessWidget
   /// ```
   final LiquidGlassSettings? buttonSettings;
 
+  /// Optional controller that drives the inline title opacity.
+  ///
+  /// When provided, the [title] widget is automatically wrapped in a
+  /// [ListenableBuilder] that fades it **in** as [GlassLargeTitle]
+  /// (the large title in the scroll view) fades **out**.
+  ///
+  /// This replicates iOS 26's `UINavigationBar.prefersLargeTitles` collapse
+  /// behaviour with zero boilerplate. See [GlassLargeTitle] and
+  /// [GlassLargeTitleController] for full usage.
+  final GlassLargeTitleController? largeTitleController;
+
   @override
   Widget build(BuildContext context) {
     Widget content = ColoredBox(
@@ -152,17 +189,9 @@ class GlassAppBar extends StatelessWidget
                 // Leading widget
                 if (leading != null) leading!,
 
-                // Flexible title
+                // Flexible title — optionally driven by collapse controller
                 Expanded(
-                  child: centerTitle
-                      ? Center(child: title ?? const SizedBox.shrink())
-                      : Align(
-                          alignment: Alignment.centerLeft,
-                          child: Padding(
-                            padding: const EdgeInsets.only(left: 8),
-                            child: title ?? const SizedBox.shrink(),
-                          ),
-                        ),
+                  child: _buildTitle(),
                 ),
 
                 // Trailing actions
@@ -197,6 +226,42 @@ class GlassAppBar extends StatelessWidget
       isolated: true,
       defaultQuality: GlassQuality.premium,
       child: content,
+    );
+  }
+
+  /// Builds the title widget, optionally driven by [largeTitleController].
+  ///
+  /// Without a controller, returns the title as-is (same as before).
+  /// With a controller, wraps in [ListenableBuilder] so only the title
+  /// Opacity rebuilds on scroll — not the entire bar.
+  Widget _buildTitle() {
+    final titleWidget = centerTitle
+        ? Center(child: title ?? const SizedBox.shrink())
+        : Align(
+            alignment: Alignment.centerLeft,
+            child: Padding(
+              padding: const EdgeInsets.only(left: 8),
+              child: title ?? const SizedBox.shrink(),
+            ),
+          );
+
+    if (largeTitleController == null) return titleWidget;
+
+    return ListenableBuilder(
+      listenable: largeTitleController!,
+      builder: (context, _) {
+        final progress = largeTitleController!.collapseProgress;
+        // iOS 26 bar title behaviour: invisible during the first half of the
+        // collapse, then fades in with ease-out over the second half.
+        // This matches UIKit's two-phase crossfade where the bar title only
+        // appears once the large title is mostly gone.
+        final barProgress = ((progress - 0.5) / 0.5).clamp(0.0, 1.0);
+        final barOpacity = Curves.easeOut.transform(barProgress);
+        return Opacity(
+          opacity: barOpacity,
+          child: titleWidget,
+        );
+      },
     );
   }
 }

--- a/lib/widgets/surfaces/glass_large_title.dart
+++ b/lib/widgets/surfaces/glass_large_title.dart
@@ -1,0 +1,453 @@
+import 'package:flutter/cupertino.dart';
+
+// =============================================================================
+// GlassLargeTitleController
+// =============================================================================
+
+/// Coordinates the large-title + search-bar collapse animation between
+/// [GlassLargeTitle] and [GlassAppBar].
+///
+/// Create one instance per screen, pass it to both widgets, and dispose it in
+/// your `State.dispose()`. The controller owns the [ScrollController] — callers
+/// attach it to their [CustomScrollView] via [scrollController].
+///
+/// ## Two-phase iOS 26 collapse
+///
+/// **Phase 1** — large title fades out over the first `~52pt` of scroll.
+/// Driven by [collapseProgress].
+///
+/// **Phase 2** — search bar (when provided to [GlassLargeTitle]) collapses
+/// immediately after the title, over the next `~44pt`. Driven by
+/// [searchBarCollapseProgress].
+///
+/// ```dart
+/// class _MyScreenState extends State<MyScreen> {
+///   final _titleController = GlassLargeTitleController();
+///
+///   @override
+///   void dispose() {
+///     _titleController.dispose();
+///     super.dispose();
+///   }
+///
+///   @override
+///   Widget build(BuildContext context) => GlassScaffold(
+///     appBar: GlassAppBar(
+///       title: Text('Chats'),
+///       largeTitleController: _titleController,
+///     ),
+///     body: CustomScrollView(
+///       controller: _titleController.scrollController,
+///       slivers: [
+///         GlassLargeTitle(
+///           text: 'Chats',
+///           controller: _titleController,
+///           searchBar: GlassSearchBar(placeholder: 'Search'),
+///         ),
+///         // ... content slivers
+///       ],
+///     ),
+///   );
+/// }
+/// ```
+class GlassLargeTitleController extends ChangeNotifier {
+  /// Creates a controller.
+  ///
+  /// [collapseTitleHeight] — scroll distance (logical pixels) over which the
+  /// large title fully collapses. Defaults to `52.0` (iOS 26 spec). Overridden
+  /// automatically by [GlassLargeTitle] after its first layout.
+  ///
+  /// [searchBarHeight] — scroll distance over which the search bar collapses
+  /// after the title collapse completes. Defaults to `44.0` (standard iOS
+  /// search bar height). Overridden automatically by [GlassLargeTitle] after
+  /// first layout when a `searchBar` is provided.
+  GlassLargeTitleController({
+    double collapseTitleHeight = 52.0,
+    double searchBarHeight = 44.0,
+  })  : _collapseTitleHeight = collapseTitleHeight,
+        _searchBarHeight = searchBarHeight {
+    _scrollController = ScrollController();
+    _scrollController.addListener(_onScroll);
+  }
+
+  late final ScrollController _scrollController;
+
+  // Both mutable — overridden by self-measurement from GlassLargeTitle.
+  double _collapseTitleHeight;
+  double _searchBarHeight;
+
+  double _collapseProgress = 0.0;
+  double _searchBarCollapseProgress = 0.0;
+
+  // Raw offset for overscroll rubber-band stretch. May be negative on iOS.
+  double _rawScrollOffset = 0.0;
+
+  /// The [ScrollController] to attach to your [CustomScrollView].
+  ScrollController get scrollController => _scrollController;
+
+  /// Title collapse progress in the range `[0.0, 1.0]`.
+  ///
+  /// - `0.0` — large title fully visible, bar title invisible.
+  /// - `1.0` — large title fully hidden, bar title fully visible (Phase 1 done).
+  double get collapseProgress => _collapseProgress;
+
+  /// Search bar collapse progress in the range `[0.0, 1.0]`.
+  ///
+  /// Starts from `0.0` only **after** [collapseProgress] reaches `1.0`
+  /// (Phase 2 begins after Phase 1 completes).
+  ///
+  /// - `0.0` — search bar fully visible.
+  /// - `1.0` — search bar fully collapsed behind the navigation bar.
+  ///
+  /// Only meaningful when a `searchBar` is provided to [GlassLargeTitle].
+  double get searchBarCollapseProgress => _searchBarCollapseProgress;
+
+  /// Raw scroll offset including negative values during iOS rubber-band overscroll.
+  ///
+  /// Used internally by [GlassLargeTitle] to drive the stretch scale animation
+  /// when the user pulls down past the top of the list.
+  double get rawScrollOffset => _rawScrollOffset;
+
+  /// Calibrates the title collapse distance to the actual rendered height.
+  ///
+  /// Called automatically by [GlassLargeTitle] after first layout. You do not
+  /// normally need to call this yourself.
+  void reportMeasuredHeight(double height) {
+    if (height > 0 && height != _collapseTitleHeight) {
+      _collapseTitleHeight = height;
+      _updateState();
+    }
+  }
+
+  /// Calibrates the search bar collapse distance to the actual rendered height.
+  ///
+  /// Called automatically by [GlassLargeTitle] after first layout when a
+  /// `searchBar` widget is provided. You do not normally need to call this.
+  void reportSearchBarHeight(double height) {
+    if (height > 0 && height != _searchBarHeight) {
+      _searchBarHeight = height;
+      _updateState();
+    }
+  }
+
+  void _onScroll() {
+    // Fires in the gesture/animation phase — always before the build phase.
+    // Safe to call notifyListeners() synchronously here.
+    _updateState();
+  }
+
+  void _updateState() {
+    if (!_scrollController.hasClients) return;
+    final offset = _scrollController.offset;
+
+    // Phase 1: large title collapses over first window.
+    final newTitleProgress = (offset / _collapseTitleHeight).clamp(0.0, 1.0);
+
+    // Phase 2: search bar collapses in the second window,
+    // starting exactly where Phase 1 ends.
+    final searchOffset = offset - _collapseTitleHeight;
+    final newSearchProgress = _searchBarHeight > 0
+        ? (searchOffset / _searchBarHeight).clamp(0.0, 1.0)
+        : 0.0;
+
+    // Notify on collapseProgress change, searchBar change, or overscroll
+    // (negative offsets keep collapseProgress at 0 but change stretch scale).
+    final overscrollChanged = offset < 0 && offset != _rawScrollOffset;
+    final changed = newTitleProgress != _collapseProgress ||
+        newSearchProgress != _searchBarCollapseProgress ||
+        overscrollChanged;
+
+    _rawScrollOffset = offset;
+    _collapseProgress = newTitleProgress;
+    _searchBarCollapseProgress = newSearchProgress;
+
+    if (changed) notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+}
+
+// =============================================================================
+// GlassLargeTitle
+// =============================================================================
+
+/// A sliver widget that renders a large 34pt iOS 26 navigation title (and
+/// optionally an inline search bar) which collapse smoothly as the user scrolls.
+///
+/// Drop it as the **first sliver** in your [CustomScrollView]. Pair with
+/// [GlassLargeTitleController] and pass the same controller to
+/// [GlassAppBar.largeTitleController] to automatically cross-fade the
+/// inline bar title.
+///
+/// ## iOS 26 fidelity
+///
+/// - **Typography:** 34pt, w700, -0.5 letter-spacing — exact iOS 26 spec.
+/// - **Two-phase collapse:** Large title fades first (Phase 1), then the
+///   search bar collapses under the nav bar (Phase 2) — matching iOS 26's
+///   `UINavigationItem.searchController` behaviour.
+/// - **Fade curve:** `Curves.easeIn` on title, `Curves.easeIn` on search bar.
+/// - **Overscroll stretch:** Title scales up slightly on rubber-band pull,
+///   matching iOS 26's `UINavigationBar` large-title elastic stretch.
+/// - **Self-measuring:** Reports rendered heights to the controller after
+///   first layout — correct collapse timing under all Dynamic Type settings.
+///
+/// ## Basic usage — title only
+///
+/// ```dart
+/// GlassLargeTitle(
+///   text: 'Chats',
+///   controller: _titleController,
+/// )
+/// ```
+///
+/// ## With search bar — two-phase iOS 26 collapse
+///
+/// ```dart
+/// GlassLargeTitle(
+///   text: 'Messages',
+///   controller: _titleController,
+///   searchBar: GlassSearchBar(
+///     placeholder: 'Search',
+///     onChanged: (v) => _filter(v),
+///   ),
+/// )
+/// ```
+///
+/// ## With trailing widget (avatar, action button)
+///
+/// ```dart
+/// GlassLargeTitle(
+///   text: 'Listen Now',
+///   controller: _titleController,
+///   trailing: CircleAvatar(child: Text('SD')),
+/// )
+/// ```
+class GlassLargeTitle extends StatefulWidget {
+  /// Creates a large-title sliver.
+  ///
+  /// [text] is the title displayed at 34pt (iOS 26 spec).
+  /// [controller] coordinates the collapse animation with [GlassAppBar].
+  /// [searchBar] is an optional search widget (e.g. [GlassSearchBar]) that
+  /// collapses in Phase 2, after the large title is fully scrolled away.
+  const GlassLargeTitle({
+    required this.text,
+    required this.controller,
+    this.searchBar,
+    this.fontSize = 34.0,
+    this.fontWeight = FontWeight.w700,
+    this.letterSpacing = -0.5,
+    this.padding = const EdgeInsets.fromLTRB(24, 0, 24, 8),
+    this.searchBarPadding =
+        const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+    this.color,
+    this.trailing,
+    super.key,
+  });
+
+  /// The navigation title text — should match the `title` passed to
+  /// [GlassAppBar].
+  final String text;
+
+  /// The controller that drives the collapse animation and provides the
+  /// [ScrollController] for your [CustomScrollView].
+  final GlassLargeTitleController controller;
+
+  /// Optional search widget displayed below the large title.
+  ///
+  /// Typically a [GlassSearchBar]. When provided, the widget collapses in
+  /// **Phase 2** — after the large title has fully scrolled away — matching
+  /// iOS 26's two-phase UINavigationBar search collapse behaviour.
+  final Widget? searchBar;
+
+  /// Font size of the large title. Defaults to `34.0` (iOS 26 spec).
+  final double fontSize;
+
+  /// Font weight. Defaults to [FontWeight.w700].
+  final FontWeight fontWeight;
+
+  /// Letter spacing. Defaults to `-0.5` (iOS 26 spec).
+  final double letterSpacing;
+
+  /// Padding around the title row.
+  ///
+  /// Defaults to `EdgeInsets.fromLTRB(24, 0, 24, 8)`.
+  final EdgeInsetsGeometry padding;
+
+  /// Padding around the search bar, when [searchBar] is provided.
+  ///
+  /// Defaults to `EdgeInsets.symmetric(horizontal: 16, vertical: 4)`,
+  /// which matches iOS 26's search bar insets under a large title.
+  final EdgeInsetsGeometry searchBarPadding;
+
+  /// Title text colour. Defaults to [CupertinoColors.label] resolved from
+  /// the current theme — correct dark-mode behaviour automatically.
+  final Color? color;
+
+  /// Optional widget at the trailing edge of the title row.
+  ///
+  /// Use for an avatar or action button (Apple Music / Podcasts pattern).
+  /// Fades out with the same curve as the title text.
+  final Widget? trailing;
+
+  @override
+  State<GlassLargeTitle> createState() => _GlassTitleSliverState();
+}
+
+class _GlassTitleSliverState extends State<GlassLargeTitle> {
+  // GlobalKeys for self-measuring both the title row and the search bar.
+  final _titleKey = GlobalKey();
+  final _searchBarKey = GlobalKey();
+  bool _pendingMeasure = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onProgressChanged);
+    _scheduleMeasure();
+  }
+
+  @override
+  void didUpdateWidget(GlassLargeTitle oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onProgressChanged);
+      widget.controller.addListener(_onProgressChanged);
+      _scheduleMeasure();
+    }
+    if (oldWidget.fontSize != widget.fontSize ||
+        oldWidget.padding != widget.padding ||
+        oldWidget.searchBar != widget.searchBar) {
+      _scheduleMeasure();
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onProgressChanged);
+    super.dispose();
+  }
+
+  void _onProgressChanged() {
+    if (mounted) setState(() {});
+  }
+
+  void _scheduleMeasure() {
+    if (_pendingMeasure) return;
+    _pendingMeasure = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _pendingMeasure = false;
+      _measureAndReport();
+    });
+  }
+
+  void _measureAndReport() {
+    // Measure title row height.
+    final titleBox = _titleKey.currentContext?.findRenderObject() as RenderBox?;
+    if (titleBox != null && titleBox.hasSize) {
+      final h = titleBox.size.height;
+      if (h > 0) widget.controller.reportMeasuredHeight(h);
+    }
+
+    // Measure search bar height (only when a searchBar is provided).
+    if (widget.searchBar != null) {
+      final searchBox =
+          _searchBarKey.currentContext?.findRenderObject() as RenderBox?;
+      if (searchBox != null && searchBox.hasSize) {
+        final h = searchBox.size.height;
+        if (h > 0) widget.controller.reportSearchBarHeight(h);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = widget.controller.collapseProgress;
+    final searchProgress = widget.controller.searchBarCollapseProgress;
+    final rawOffset = widget.controller.rawScrollOffset;
+    final effectiveColor =
+        widget.color ?? CupertinoColors.label.resolveFrom(context);
+
+    // ── iOS 26 ease-in fade (Phase 1) ─────────────────────────────────────
+    // Large title stays opaque longer, drops off quickly — matching UIKit.
+    final titleFadeOut =
+        Curves.easeIn.transform((1.0 - progress).clamp(0.0, 1.0));
+
+    // ── iOS 26 overscroll rubber-band stretch ──────────────────────────────
+    // Title grows slightly on rubber-band pull, matching UINavigationBar.
+    final stretchScale =
+        rawOffset < 0 ? 1.0 + (-rawOffset / 300.0).clamp(0.0, 0.12) : 1.0;
+
+    // ── iOS 26 search bar ease-in fade (Phase 2) ──────────────────────────
+    // Collapses height to zero and fades out after the title is gone.
+    final searchFadeOut =
+        Curves.easeIn.transform((1.0 - searchProgress).clamp(0.0, 1.0));
+    final searchHeightFactor = (1.0 - searchProgress).clamp(0.0, 1.0);
+
+    return SliverToBoxAdapter(
+      child: Transform.scale(
+        scale: stretchScale,
+        alignment: Alignment.bottomLeft,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // ── Large title row ────────────────────────────────────────────
+            Padding(
+              key: _titleKey,
+              padding: widget.padding,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: Text(
+                      widget.text,
+                      style: TextStyle(
+                        fontSize: widget.fontSize,
+                        fontWeight: widget.fontWeight,
+                        letterSpacing: widget.letterSpacing,
+                        color: effectiveColor.withValues(alpha: titleFadeOut),
+                        height: 1.1,
+                      ),
+                    ),
+                  ),
+                  if (widget.trailing != null) ...[
+                    const SizedBox(width: 8),
+                    Opacity(
+                      opacity: titleFadeOut,
+                      child: widget.trailing,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+
+            // ── Search bar (Phase 2 collapse) ──────────────────────────────
+            // Collapses height to zero via ClipRect + Align(heightFactor),
+            // then fades out — replicating UISearchController's collapse
+            // under the navigation bar after the large title scrolls away.
+            if (widget.searchBar != null)
+              ClipRect(
+                child: Align(
+                  heightFactor: searchHeightFactor,
+                  alignment: Alignment.topCenter,
+                  child: Opacity(
+                    opacity: searchFadeOut,
+                    child: Padding(
+                      key: _searchBarKey,
+                      padding: widget.searchBarPadding,
+                      child: widget.searchBar,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: liquid_glass_widgets
 description: A Flutter UI kit implementing the iOS 26 Liquid Glass design language. Features shader-based glassmorphism, physics-driven jelly animations, and dynamic lighting.
-version: 0.19.5
+version: 0.19.6
 
 
 homepage: https://github.com/sdegenaar/liquid_glass_widgets

--- a/test/widgets/surfaces/glass_large_title_test.dart
+++ b/test/widgets/surfaces/glass_large_title_test.dart
@@ -1,0 +1,456 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+void main() {
+  // ─────────────────────────────────────────────────────────────────────────
+  // GlassLargeTitleController
+  // ─────────────────────────────────────────────────────────────────────────
+
+  group('GlassLargeTitleController', () {
+    test('initial collapseProgress is 0.0', () {
+      final controller = GlassLargeTitleController();
+      expect(controller.collapseProgress, 0.0);
+      controller.dispose();
+    });
+
+    test('exposes a ScrollController', () {
+      final controller = GlassLargeTitleController();
+      expect(controller.scrollController, isA<ScrollController>());
+      controller.dispose();
+    });
+
+    test('collapseProgress stays at 0.0 with no scroll', () {
+      final controller = GlassLargeTitleController();
+      expect(controller.collapseProgress, 0.0);
+      controller.dispose();
+    });
+
+    test('custom collapseTitleHeight is accepted', () {
+      final controller = GlassLargeTitleController(collapseTitleHeight: 80.0);
+      expect(controller.collapseProgress, 0.0);
+      controller.dispose();
+    });
+
+    test('dispose cleans up without error', () {
+      final controller = GlassLargeTitleController();
+      expect(() => controller.dispose(), returnsNormally);
+    });
+
+    test('listeners are notified — integration via addListener', () async {
+      final controller = GlassLargeTitleController();
+      var notifyCount = 0;
+      controller.addListener(() => notifyCount++);
+
+      // No notification until scroll position actually changes.
+      expect(notifyCount, 0);
+      controller.dispose();
+    });
+
+    test('removeListener does not throw', () {
+      final controller = GlassLargeTitleController();
+      void listener() {}
+      controller.addListener(listener);
+      expect(() => controller.removeListener(listener), returnsNormally);
+      controller.dispose();
+    });
+
+    test('rawScrollOffset starts at 0.0', () {
+      final controller = GlassLargeTitleController();
+      expect(controller.rawScrollOffset, 0.0);
+      controller.dispose();
+    });
+
+    test('reportMeasuredHeight updates internal threshold without error', () {
+      final controller = GlassLargeTitleController(collapseTitleHeight: 52.0);
+      // Reporting a different height is accepted gracefully. _updateState
+      // returns early (no scroll client) so no notification fires here.
+      expect(() => controller.reportMeasuredHeight(68.0), returnsNormally);
+      controller.dispose();
+    });
+
+    test('reportMeasuredHeight ignores zero or unchanged height', () {
+      final controller = GlassLargeTitleController(collapseTitleHeight: 52.0);
+      var notifyCount = 0;
+      controller.addListener(() => notifyCount++);
+      controller.reportMeasuredHeight(0.0); // ignored — zero
+      controller.reportMeasuredHeight(52.0); // ignored — same as current
+      expect(notifyCount, 0);
+      controller.dispose();
+    });
+
+    // ── Phase 2: search bar collapse ───────────────────────────────────────
+
+    test('initial searchBarCollapseProgress is 0.0', () {
+      final controller = GlassLargeTitleController();
+      expect(controller.searchBarCollapseProgress, 0.0);
+      controller.dispose();
+    });
+
+    test('custom searchBarHeight constructor param is accepted', () {
+      final controller = GlassLargeTitleController(searchBarHeight: 60.0);
+      // No scroll attached — progress stays 0.
+      expect(controller.searchBarCollapseProgress, 0.0);
+      controller.dispose();
+    });
+
+    test('reportSearchBarHeight updates threshold without error', () {
+      final controller = GlassLargeTitleController(searchBarHeight: 44.0);
+      expect(() => controller.reportSearchBarHeight(56.0), returnsNormally);
+      controller.dispose();
+    });
+
+    test('reportSearchBarHeight ignores zero height', () {
+      final controller = GlassLargeTitleController(searchBarHeight: 44.0);
+      var notifyCount = 0;
+      controller.addListener(() => notifyCount++);
+      controller.reportSearchBarHeight(0.0); // ignored
+      expect(notifyCount, 0);
+      controller.dispose();
+    });
+
+    test('reportSearchBarHeight ignores unchanged height', () {
+      final controller = GlassLargeTitleController(searchBarHeight: 44.0);
+      var notifyCount = 0;
+      controller.addListener(() => notifyCount++);
+      controller.reportSearchBarHeight(44.0); // same — ignored
+      expect(notifyCount, 0);
+      controller.dispose();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GlassLargeTitle widget
+  // ─────────────────────────────────────────────────────────────────────────
+
+  group('GlassLargeTitle widget', () {
+    late GlassLargeTitleController controller;
+
+    setUp(() {
+      controller = GlassLargeTitleController();
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    Widget buildTestApp({Widget? child}) {
+      return CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: child ?? const SizedBox(),
+        ),
+      );
+    }
+
+    testWidgets('renders without error', (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(text: 'Test', controller: controller),
+          ],
+        ),
+      ));
+      expect(find.text('Test'), findsOneWidget);
+    });
+
+    testWidgets('renders title text', (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(text: 'Chats', controller: controller),
+          ],
+        ),
+      ));
+      expect(find.text('Chats'), findsOneWidget);
+    });
+
+    testWidgets('is fully opaque at 0 scroll offset', (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(text: 'Messages', controller: controller),
+            // Enough content to scroll
+            SliverList.builder(
+              itemCount: 40,
+              itemBuilder: (_, i) =>
+                  SizedBox(height: 60, child: Text('Item $i')),
+            ),
+          ],
+        ),
+      ));
+      await tester.pump();
+
+      // collapseProgress should be 0 — opacity 1.0
+      expect(controller.collapseProgress, 0.0);
+
+      // Find the Text and verify it's within an Opacity of 1.0
+      final text = tester.widget<Text>(find.text('Messages'));
+      // Alpha on text colour should be 1.0 (fully visible)
+      expect(text.style?.color?.a, closeTo(1.0, 0.01));
+    });
+
+    testWidgets('accepts trailing widget', (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(
+              text: 'Library',
+              controller: controller,
+              trailing: const Text('trailing_widget'),
+            ),
+          ],
+        ),
+      ));
+      expect(find.text('trailing_widget'), findsOneWidget);
+    });
+
+    testWidgets('respects custom fontSize', (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(
+              text: 'Browse',
+              controller: controller,
+              fontSize: 28.0,
+            ),
+          ],
+        ),
+      ));
+      final text = tester.widget<Text>(find.text('Browse'));
+      expect(text.style?.fontSize, 28.0);
+    });
+
+    testWidgets('respects custom color', (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(
+              text: 'Inbox',
+              controller: controller,
+              color: const Color(0xFFFF0000),
+            ),
+          ],
+        ),
+      ));
+      final text = tester.widget<Text>(find.text('Inbox'));
+      // Red channel at full, fully opaque
+      expect(text.style?.color?.r, closeTo(1.0, 0.01));
+    });
+
+    testWidgets('swapping controller re-subscribes correctly', (tester) async {
+      final controller2 = GlassLargeTitleController();
+      var notifyCount = 0;
+
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(text: 'Title', controller: controller),
+          ],
+        ),
+      ));
+
+      // Swap to controller2
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller2.scrollController,
+          slivers: [
+            GlassLargeTitle(text: 'Title', controller: controller2),
+          ],
+        ),
+      ));
+
+      // No error — controller1 listener removed, controller2 subscribed
+      expect(notifyCount, 0);
+      controller2.dispose();
+    });
+
+    // ── Phase 2: searchBar widget ──────────────────────────────────────────
+
+    testWidgets('searchBar child is rendered when provided', (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(
+              text: 'Messages',
+              controller: controller,
+              searchBar: const Text('search_bar_widget'),
+            ),
+          ],
+        ),
+      ));
+      // Both title and search bar must be present.
+      expect(find.text('Messages'), findsOneWidget);
+      expect(find.text('search_bar_widget'), findsOneWidget);
+    });
+
+    testWidgets('no searchBar — renders without error and no ClipRect',
+        (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(text: 'Library', controller: controller),
+          ],
+        ),
+      ));
+      // Title present, no crash.
+      expect(find.text('Library'), findsOneWidget);
+      // No ClipRect added when searchBar is null.
+      expect(find.byType(ClipRect), findsNothing);
+    });
+
+    testWidgets('searchBar is wrapped in ClipRect for height collapse',
+        (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(
+              text: 'Inbox',
+              controller: controller,
+              searchBar: const SizedBox(key: Key('sb'), height: 44),
+            ),
+          ],
+        ),
+      ));
+      // ClipRect must wrap the search bar for height-collapse animation.
+      expect(find.byType(ClipRect), findsOneWidget);
+    });
+
+    testWidgets('searchBar is fully visible at zero scroll progress',
+        (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(
+              text: 'Search',
+              controller: controller,
+              searchBar: const Text('search_visible'),
+            ),
+            SliverList.builder(
+              itemCount: 40,
+              itemBuilder: (_, i) =>
+                  SizedBox(height: 60, child: Text('Item $i')),
+            ),
+          ],
+        ),
+      ));
+      await tester.pump();
+
+      // searchBarCollapseProgress == 0 → Opacity should be 1.0
+      expect(controller.searchBarCollapseProgress, 0.0);
+      // Search bar text is visible (not hidden by zero opacity).
+      expect(find.text('search_visible'), findsOneWidget);
+    });
+
+    testWidgets('custom searchBarPadding is accepted without error',
+        (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        child: CustomScrollView(
+          controller: controller.scrollController,
+          slivers: [
+            GlassLargeTitle(
+              text: 'Pad',
+              controller: controller,
+              searchBar: const Text('padded_search'),
+              searchBarPadding:
+                  const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+            ),
+          ],
+        ),
+      ));
+      expect(find.text('padded_search'), findsOneWidget);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GlassAppBar.largeTitleController
+  // ─────────────────────────────────────────────────────────────────────────
+
+  group('GlassAppBar with largeTitleController', () {
+    late GlassLargeTitleController controller;
+
+    setUp(() {
+      controller = GlassLargeTitleController();
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    Widget buildApp({GlassLargeTitleController? ctrl}) {
+      return MaterialApp(
+        home: Scaffold(
+          appBar: GlassAppBar(
+            title: const Text('bar_title'),
+            largeTitleController: ctrl,
+          ),
+          body: const SizedBox(),
+        ),
+      );
+    }
+
+    testWidgets('renders normally without controller — no regression',
+        (tester) async {
+      await tester.pumpWidget(buildApp());
+      expect(find.text('bar_title'), findsOneWidget);
+    });
+
+    testWidgets('with controller at progress 0, bar title opacity is 0',
+        (tester) async {
+      await tester.pumpWidget(buildApp(ctrl: controller));
+      await tester.pump();
+
+      // collapseProgress == 0 → barProgress = (0 - 0.5) / 0.5 = -1 → clamped to 0
+      // → Opacity wraps title at 0.0
+      final opacityFinder = find.ancestor(
+        of: find.text('bar_title'),
+        matching: find.byType(Opacity),
+      );
+      expect(opacityFinder, findsWidgets);
+      final opacity = tester.widgetList<Opacity>(opacityFinder).first;
+      expect(opacity.opacity, closeTo(0.0, 0.01));
+    });
+
+    testWidgets('bar title stays invisible below 50% collapse progress',
+        (tester) async {
+      // The delayed fade means bar title only starts appearing after progress >= 0.5.
+      await tester.pumpWidget(buildApp(ctrl: controller));
+      await tester.pump();
+
+      final opacityFinder = find.ancestor(
+        of: find.text('bar_title'),
+        matching: find.byType(Opacity),
+      );
+      final opacity = tester.widgetList<Opacity>(opacityFinder).first;
+      // progress=0.0 → barProgress=(0-0.5)/0.5=-1→0.0 → easeOut(0.0)=0.0
+      expect(opacity.opacity, closeTo(0.0, 0.01));
+    });
+
+    testWidgets('without controller, no Opacity wrapper around title',
+        (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pump();
+
+      // With no controller, title should NOT be wrapped in a zero-opacity Opacity.
+      final zeroOpacities = tester
+          .widgetList<Opacity>(find.ancestor(
+            of: find.text('bar_title'),
+            matching: find.byType(Opacity),
+          ))
+          .where((o) => o.opacity < 1.0)
+          .toList();
+      expect(zeroOpacities, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First-class iOS 26 large-title + search-bar collapse. Replaces manual `ScrollController` + `setState` boilerplate with a single controller and two widgets.

## Two-phase collapse

- **Phase 1** — large title fades out with `Curves.easeIn` + rubber-band overscroll stretch (~52pt window, self-measuring for Dynamic Type).
- **Phase 2** — optional inline search bar collapses under the nav bar immediately after Phase 1 completes (`ClipRect` + `Align(heightFactor)` + `Opacity`).

## New API

- `GlassLargeTitle` — sliver widget. First sliver in any `CustomScrollView`.
  - `searchBar: Widget?` — Phase 2 collapse (accepts any widget, e.g. `GlassSearchBar`).
  - `trailing`, `fontSize`, `fontWeight`, `letterSpacing`, `padding`, `searchBarPadding`, `color`.
- `GlassLargeTitleController` — owns `ScrollController`, exposes `collapseProgress` + `searchBarCollapseProgress`. Self-calibrates via `reportMeasuredHeight` / `reportSearchBarHeight`.
- `GlassAppBar.largeTitleController` — new optional param. Bar title cross-fades in as large title collapses. **Non-breaking.**

```dart
final _ctrl = GlassLargeTitleController(); // dispose in State.dispose()

// Phase 1 only
GlassLargeTitle(text: 'Chats', controller: _ctrl)

// Phase 1 + 2
GlassLargeTitle(
  text: 'Messages',
  controller: _ctrl,
  searchBar: GlassSearchBar(placeholder: 'Search', onChanged: (_) {}),
)
```

## Demo changes

- **Pattern 2** — updated to new API.
- **Pattern 7 (new)** — "Large Title + Search Bar" (Messages/Mail two-phase collapse).
- **Apple Messages demo** — migrated from manual `AnimatedOpacity` boolean-threshold to `GlassLargeTitle` + `GlassAppBar.largeTitleController`. Animation now matches iOS 26 fidelity.

## ROADMAP

Phase 3 (compact search icon in `GlassAppBar` at full collapse) documented in `docs/ROADMAP.md`. Blocked by `ObstructingPreferredSizeWidget` fixed-height contract — deferred to a future breaking release.

## Tests

+10 new tests covering Phase 2 API. **2,291 total, all passing.** `dart format` clean.

## Checklist

- [x] `dart format .` — clean
- [x] `flutter analyze` — no errors
- [x] `flutter test` — 2,291/2,291 passing
- [x] CHANGELOG.md updated (0.19.6)
- [x] docs/ROADMAP.md updated (Phase 3 documented)
- [x] Non-breaking — `GlassLargeTitle` and `largeTitleController` are purely additive