### PR TITLE
fix: support RTL in GlassTabBar.bottom indicator and hit-testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Unreleased
+
+- **`GlassTabBar.bottom` / `GlassBottomBar`** — fixes RTL support (#142, @naeemeltaief).
+  The indicator/gesture coordinate system operates in physical (left-anchored) alignment
+  space while the tab `Row`s honour the ambient `Directionality`, so under RTL the pill and
+  the tap/drag hit-testing landed on the mirror-image tab. The bottom layout now normalises
+  the tab order, selected index and tap callback for RTL and pins *only the tab rows* to LTR,
+  so the first tab sits on the trailing edge with the pill and hit-testing aligned to it.
+  `indicatorExpansion` / `tabPadding` continue to resolve against the ambient direction, so
+  `EdgeInsetsDirectional` values still work in RTL. Consumers no longer need to force
+  `Directionality.ltr` and reverse tabs by hand.
+
 # 0.19.5
 
 - **`LiquidGlassSettings`** — adds `platformViewFallbackColor` (#138, @jfhair). Splits

--- a/lib/widgets/surfaces/shared/tab_bar_bottom_layout.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_bottom_layout.dart
@@ -144,6 +144,19 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
   // Both bars reference kBottomBarGlassDefaults so their glass is guaranteed identical.
   static const _defaultGlassSettings = kBottomBarGlassDefaults;
 
+  /// Lays out the tab [Row] in physical (LTR) order regardless of the ambient
+  /// direction, so the first child is on the left — matching the indicator and
+  /// gesture coordinate space. RTL ordering is carried by the reversed tab data
+  /// in [_buildBar], not by the ambient direction of these Rows. Scoping the
+  /// pin to the Rows keeps `Directionality.of(context)` intact for the rest of
+  /// the subtree (notably [indicatorExpansion] / [tabPadding] resolution).
+  static Widget _ltrTabRow({required List<Widget> children}) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Row(children: children),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     if (!widget.adaptiveBrightness && widget.brightnessOverride == null) {
@@ -188,6 +201,37 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
 
     final effectiveSettings = widget.settings ?? _defaultGlassSettings;
 
+    // RTL support.
+    //
+    // The indicator/gesture coordinate system and the [AnimatedGlassIndicator]
+    // position both operate in physical, left-anchored alignment space (x == -1
+    // is always the left edge), and the gesture math is derived from the render
+    // box geometry — all direction-independent. The only direction-sensitive
+    // part is the two tab [Row]s, which honour the ambient [Directionality] and
+    // visually reverse under RTL. That reversal is what disagrees with the
+    // physical coordinate space, so the pill — and the tap/drag hit-testing —
+    // land on the mirror-image tab.
+    //
+    // Normalise by reversing the tab data and mirroring the selected index and
+    // the tap callback, then pin *only* the tab Rows to LTR (see [_ltrTabRow])
+    // so their physical order matches the coordinate space. Net effect under
+    // RTL: correct ordering (the first tab sits on the trailing/right edge)
+    // with the pill and hit-testing aligned to it. In LTR everything is a
+    // no-op.
+    //
+    // The pin is deliberately scoped to the Rows: [TabIndicator] resolves
+    // [indicatorExpansion] and [tabPadding] against `Directionality.of(context)`,
+    // so wrapping the whole subtree would force those to LTR and silently ignore
+    // any `EdgeInsetsDirectional` a consumer passes in an RTL app.
+    final isRtl = Directionality.of(context) == TextDirection.rtl;
+    final tabs = isRtl ? widget.tabs.reversed.toList() : widget.tabs;
+    final selectedIndex = isRtl
+        ? widget.tabs.length - 1 - widget.selectedIndex
+        : widget.selectedIndex;
+    final onTabSelected = isRtl
+        ? (int i) => widget.onTabSelected(widget.tabs.length - 1 - i)
+        : widget.onTabSelected;
+
     return AdaptiveLiquidGlassLayer(
       clipExpansion:
           const EdgeInsets.symmetric(horizontal: 20.0, vertical: 15.0),
@@ -208,7 +252,7 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
             final maxTabW = constraints.maxWidth - extraBtnW;
             final tabPillW = resolveTabPillWidth(
               tabWidth: widget.tabWidth,
-              tabCount: widget.tabs.length,
+              tabCount: tabs.length,
               maxAvailable: maxTabW,
             );
 
@@ -255,12 +299,12 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
                         child: TabIndicator(
                           quality: effectiveQuality,
                           visible: widget.showIndicator,
-                          tabIndex: widget.selectedIndex,
-                          tabCount: widget.tabs.length,
+                          tabIndex: selectedIndex,
+                          tabCount: tabs.length,
                           indicatorColor: widget.indicatorColor,
                           indicatorSettings: widget.indicatorSettings,
                           indicatorPinchStrength: widget.indicatorPinchStrength,
-                          onTabChanged: widget.onTabSelected,
+                          onTabChanged: onTabSelected,
                           barHeight: widget.barHeight,
                           barBorderRadius: widget.barBorderRadius,
                           indicatorBorderRadius: widget.indicatorBorderRadius,
@@ -281,12 +325,12 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
                           interactionScale: widget.interactionBehavior.hasScale
                               ? widget.pressScale
                               : 1.0,
-                          childUnselected: Row(
+                          childUnselected: _ltrTabRow(
                             children: [
-                              for (var i = 0; i < widget.tabs.length; i++)
+                              for (var i = 0; i < tabs.length; i++)
                                 Expanded(
                                   child: BottomBarTabItem(
-                                    tab: widget.tabs[i],
+                                    tab: tabs[i],
                                     selected: false,
                                     selectedIconColor:
                                         resolvedSelectedIconColor,
@@ -317,6 +361,7 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
                               _buildSelectedTabs(
                                   intensity,
                                   alignment,
+                                  tabs,
                                   resolvedSelectedIconColor,
                                   resolvedUnselectedIconColor),
                           magnification: widget.magnification,
@@ -334,25 +379,29 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
     );
   }
 
-  Widget _buildSelectedTabs(double intensity, Alignment alignment,
-      Color resolvedSelectedIconColor, Color resolvedUnselectedIconColor) {
+  Widget _buildSelectedTabs(
+      double intensity,
+      Alignment alignment,
+      List<GlassBottomBarTab> tabs,
+      Color resolvedSelectedIconColor,
+      Color resolvedUnselectedIconColor) {
     final scale = ui.lerpDouble(1.0, widget.magnification, intensity) ?? 1.0;
 
-    final currentTabFloat = ((alignment.x + 1) / 2) * widget.tabs.length;
+    final currentTabFloat = ((alignment.x + 1) / 2) * tabs.length;
     final affectedStart =
-        (currentTabFloat - 1).floor().clamp(0, widget.tabs.length - 1);
+        (currentTabFloat - 1).floor().clamp(0, tabs.length - 1);
     final affectedEnd =
-        (currentTabFloat + 1).ceil().clamp(0, widget.tabs.length - 1);
+        (currentTabFloat + 1).ceil().clamp(0, tabs.length - 1);
 
-    return Row(
+    return _ltrTabRow(
       children: [
-        for (var i = 0; i < widget.tabs.length; i++)
+        for (var i = 0; i < tabs.length; i++)
           Expanded(
             child: (i >= affectedStart && i <= affectedEnd)
                 ? Transform.scale(
                     scale: scale,
                     child: BottomBarTabItem(
-                      tab: widget.tabs[i],
+                      tab: tabs[i],
                       selected: true,
                       selectedIconColor: resolvedSelectedIconColor,
                       unselectedIconColor: resolvedUnselectedIconColor,

--- a/test/widgets/surfaces/tab_bar_bottom_layout_rtl_test.dart
+++ b/test/widgets/surfaces/tab_bar_bottom_layout_rtl_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+import '../../shared/test_helpers.dart';
+
+/// Regression tests for RTL handling in [GlassTabBar.bottom].
+///
+/// The indicator/gesture coordinate system operates in physical, left-anchored
+/// alignment space, while the tab [Row]s honour the ambient [Directionality]
+/// and visually reverse under RTL. Before the fix those two disagreed, so under
+/// RTL the pill and the tap hit-testing landed on the mirror-image tab — e.g.
+/// tapping the first tab (rendered on the trailing/right edge) reported the
+/// last index instead of the first.
+///
+/// Finder note: with [MaskingQuality.off] every label is drawn twice — once in
+/// the base (unselected) row and once in the vibrant selected-overlay row — so
+/// each label matches two hit-testable widgets. `.hitTestable().first` keeps the
+/// occlusion-safe filtering while deterministically resolving to the base row,
+/// whose text sits at the tab's real on-screen position.
+void main() {
+  const tabs = [
+    GlassTab(label: 'Home', icon: Icon(CupertinoIcons.home)),
+    GlassTab(label: 'Search', icon: Icon(CupertinoIcons.search)),
+    GlassTab(label: 'Profile', icon: Icon(CupertinoIcons.person)),
+  ];
+
+  Widget rtlBar({required ValueChanged<int> onTabSelected}) {
+    return createTestApp(
+      child: Directionality(
+        textDirection: TextDirection.rtl,
+        child: GlassTabBar.bottom(
+          tabs: tabs,
+          selectedIndex: 1,
+          onTabSelected: onTabSelected,
+          // Avoid the dual-layer jelly clipping path in tests.
+          maskingQuality: MaskingQuality.off,
+        ),
+      ),
+    );
+  }
+
+  group('GlassTabBar.bottom RTL', () {
+    testWidgets('tapping a tab reports its logical index', (tester) async {
+      var selected = -1;
+      await tester.pumpWidget(rtlBar(onTabSelected: (i) => selected = i));
+
+      // 'Home' is logical index 0; under RTL it renders on the trailing (right)
+      // edge. Tapping it must still report index 0 — before the fix the
+      // LTR-only hit-testing mirrored this to the last index.
+      await tester.tap(find.text('Home').hitTestable().first);
+      await tester.pumpAndSettle();
+      expect(selected, 0);
+
+      // 'Profile' is logical index 2; under RTL it renders on the leading
+      // (left) edge. It must still report index 2.
+      await tester.tap(find.text('Profile').hitTestable().first);
+      await tester.pumpAndSettle();
+      expect(selected, 2);
+    });
+
+    testWidgets('first tab renders on the trailing (right) edge', (
+      tester,
+    ) async {
+      await tester.pumpWidget(rtlBar(onTabSelected: (_) {}));
+
+      final screenWidth = tester.getSize(find.byType(GlassTabBar)).width;
+      final homeCenter = tester.getCenter(find.text('Home').hitTestable().first);
+      final profileCenter =
+          tester.getCenter(find.text('Profile').hitTestable().first);
+
+      // RTL ordering: the first tab sits to the right of the last tab.
+      expect(homeCenter.dx, greaterThan(profileCenter.dx));
+      expect(homeCenter.dx, greaterThan(screenWidth / 2));
+    });
+  });
+}


### PR DESCRIPTION
## What

Fixes RTL support for `GlassTabBar.bottom` (and the deprecated `GlassBottomBar` shim).

Closes #142.

## Problem

The indicator/gesture coordinate system and `AnimatedGlassIndicator` operate in **physical, left-anchored** alignment space (`x == -1` is always the left edge):

- `computeTabAlignment(index)` → `DraggableIndicatorPhysics.computeAlignment(index, count)` maps index `0` to the physical left.
- `onBarTapDown` / `onBarDragEnd` map a physical pointer position back to an index in the same space.

But the tab `Row`s in `tab_bar_bottom_layout.dart` use a plain `Row`, which honours the ambient `Directionality` and visually **reverses** under RTL. The two disagree, so under RTL the selected pill and the tap/drag hit-testing land on the **mirror-image** tab — tapping the first (right-edge) tab selects the last index.

This forced consumers to wrap the bar in `Directionality.ltr` and reverse the tab list, selected index and callback by hand.

## Fix

Contained to `tab_bar_bottom_layout.dart`. In `_buildBar`, when the ambient direction is RTL:

- reverse the tab data,
- mirror the selected index (`count - 1 - selectedIndex`),
- mirror the tap callback (`onTabSelected(count - 1 - i)`),
- pin the bar's internals to `Directionality.ltr` so the physical coordinate space stays consistent with the (now-normalised) tab order.

Net effect under RTL: correct ordering — the first tab sits on the trailing (right) edge — with the pill and hit-testing aligned to it. LTR is an exact no-op (same widget tree as before). All physics (jelly drag, spring, sway) keep running in their original LTR space, so behaviour is unchanged there.

## Tests

Adds `test/widgets/surfaces/tab_bar_bottom_layout_rtl_test.dart`:

- **tap → logical index** under RTL: tapping `Home` (rendered on the right) reports index `0`; tapping `Profile` (left) reports `2`. This test **fails on `main`** (reports the mirrored index) and passes with the fix.
- **ordering**: the first tab renders to the right of the last tab and past the horizontal centre.

Existing bottom-bar suites (`glass_bottom_bar_test.dart`, `glass_bottom_bar_drag_test.dart`, `glass_bottom_bar_coverage_test.dart`, `glass_tab_bar_constructors_test.dart`) all still pass. `flutter analyze` is clean.

## Notes

- Scoped to the bottom placement (the reported case). The searchable layout likely needs the same treatment; happy to follow up in a separate PR if you'd like.
