### PR TITLE
Don't hide the resting indicator pill when avoidsRefraction is set

### DIFF
--- a/lib/widgets/shared/animated_glass_indicator.dart
+++ b/lib/widgets/shared/animated_glass_indicator.dart
@@ -7,7 +7,6 @@ import '../../constants/glass_defaults.dart';
 import '../../types/glass_quality.dart';
 import '../../utils/draggable_indicator_physics.dart';
 import 'glass_effect.dart';
-import 'inherited_liquid_glass.dart';
 
 /// A shared component that renders the interactive "Jelly" indicator
 /// used in [GlassTabBar], [GlassSegmentedControl], and [GlassBottomBar].
@@ -280,29 +279,18 @@ class AnimatedGlassIndicator extends StatelessWidget {
     // 1. Background Indicator (Resting state)
     // Fade out as the drag spring thickness increases toward 0.15.
     final backgroundOpacity = (1.0 - (thickness / 0.15)).clamp(0.0, 1.0);
-    final backgroundIndicator = Builder(
-      builder: (context) {
-        // HIDE during capture so GlassEffect doesn't bake the pill into its snapshot
-        final avoidsRefraction = context
-                .dependOnInheritedWidgetOfExactType<InheritedLiquidGlass>()
-                ?.avoidsRefraction ??
-            false;
-        if (avoidsRefraction) return const SizedBox.expand();
-
-        return IgnorePointer(
-          child: Opacity(
-            opacity: backgroundOpacity,
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                color: indicatorColor,
-                borderRadius: BorderRadius.circular(borderRadius),
-                boxShadow: shadows,
-              ),
-              child: const SizedBox.expand(),
-            ),
+    final backgroundIndicator = IgnorePointer(
+      child: Opacity(
+        opacity: backgroundOpacity,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: indicatorColor,
+            borderRadius: BorderRadius.circular(borderRadius),
+            boxShadow: shadows,
           ),
-        );
-      },
+          child: const SizedBox.expand(),
+        ),
+      ),
     );
 
     // 2. Glass Indicator (Active/Dragging state)


### PR DESCRIPTION
## What
The resting (background) indicator pill returned `SizedBox.expand()` whenever an ancestor set `avoidsRefraction` (i.e. inside a `GlassContainer`). The inline comment framed this as hiding the pill "during capture," but `avoidsRefraction` is a steady-state layout flag, not a transient `GlassEffect` capture signal — and the pill sits outside `GlassEffect`'s `toImageSync` boundary regardless. So the guard permanently hid the resting selection in any `avoidsRefraction` context, which wasn't its intent.

This removes the guard, plus the now-unused `Builder` and `inherited_liquid_glass.dart` import. The resting pill renders correctly.

## Scope (deliberately narrow)
- No change outside a `GlassContainer` — `avoidsRefraction` is false there, so the guard never fired; bare `GlassTabBar` / `GlassSegmentedControl` are unaffected.
- Does **not** address the jelly-overshoot clipping when an indicator is nested in a `GlassContainer` (the `withOwnLayer` shape clip). That's the separate glass-in-glass concern from #136 and is out of scope here.

Refs #136.
