### PR TITLE
GlassModalSheet: expose live drag progress on the controller

### DIFF
--- a/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
@@ -274,6 +274,14 @@ class GlassModalSheetController {
   set value(double newValue) {
     _state?._jumpTo(newValue);
   }
+
+  /// Live progress between the half and full snaps: 0.0 at (or below) the half
+  /// snap, 1.0 at full. Use with [progressListenable] to react during a drag.
+  double get progress => _state?._expandProgress ?? 0.0;
+
+  /// Notifies on every sheet position change — drag and snap animation alike.
+  /// Null until the sheet is mounted; read [progress] from inside the listener.
+  Listenable? get progressListenable => _state?._animationController;
 }
 
 // ===========================================================================

--- a/test/widgets/overlays/glass_modal_sheet_progress_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_progress_test.dart
@@ -1,0 +1,95 @@
+// GlassModalSheetController.progress / progressListenable: live half↔full
+// position reporting.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+import '../../shared/test_helpers.dart';
+
+Widget _sheetApp(GlassModalSheetController controller) => createTestApp(
+      child: Stack(
+        children: [
+          GlassModalSheet(
+            controller: controller,
+            initialState: GlassSheetState.half,
+            child: const Text('Sheet Content'),
+          ),
+        ],
+      ),
+    );
+
+void main() {
+  group('GlassModalSheetController — progress', () {
+    test('unmounted controller reports progress 0.0', () {
+      expect(GlassModalSheetController().progress, 0.0);
+    });
+
+    test('unmounted controller has a null progressListenable', () {
+      expect(GlassModalSheetController().progressListenable, isNull);
+    });
+
+    testWidgets('mounted at half → progress 0.0, listenable non-null',
+        (tester) async {
+      final controller = GlassModalSheetController();
+      await tester.pumpWidget(_sheetApp(controller));
+      await tester.pumpAndSettle();
+
+      expect(controller.currentState, GlassSheetState.half);
+      expect(controller.progress, 0.0);
+      expect(controller.progressListenable, isNotNull);
+    });
+
+    testWidgets('snap to full → progress 1.0', (tester) async {
+      final controller = GlassModalSheetController();
+      await tester.pumpWidget(_sheetApp(controller));
+      await tester.pumpAndSettle();
+
+      controller.snapToState(GlassSheetState.full, animate: false);
+      await tester.pumpAndSettle();
+
+      expect(controller.progress, 1.0);
+    });
+
+    testWidgets('snap back to half → progress returns to 0.0',
+        (tester) async {
+      final controller = GlassModalSheetController();
+      await tester.pumpWidget(_sheetApp(controller));
+      await tester.pumpAndSettle();
+
+      controller.snapToState(GlassSheetState.full, animate: false);
+      await tester.pumpAndSettle();
+      controller.snapToState(GlassSheetState.half, animate: false);
+      await tester.pumpAndSettle();
+
+      expect(controller.progress, 0.0);
+    });
+
+    testWidgets(
+        'progressListenable notifies during an animated snap and progress '
+        'passes through intermediate values', (tester) async {
+      final controller = GlassModalSheetController();
+      await tester.pumpWidget(_sheetApp(controller));
+      await tester.pumpAndSettle();
+
+      var notifications = 0;
+      var sawIntermediate = false;
+      void listener() {
+        notifications++;
+        final p = controller.progress;
+        if (p > 0.05 && p < 0.95) sawIntermediate = true;
+      }
+
+      controller.progressListenable!.addListener(listener);
+      controller.snapToState(GlassSheetState.full, animate: true);
+      await tester.pumpAndSettle();
+      controller.progressListenable!.removeListener(listener);
+
+      expect(notifications, greaterThan(0));
+      expect(sawIntermediate, isTrue,
+          reason: 'progress should report positions between the snaps '
+              'while the sheet animates');
+      expect(controller.progress, 1.0);
+    });
+  });
+}


### PR DESCRIPTION
Adds a read-only `progress` getter and a `progressListenable` to the modal sheet controller, reporting the live half↔full drag position (0–1) while the user drags.

Hosts can drive coordinated UI from the sheet's real position — e.g. cross-fading or translating content behind the sheet in lockstep with the drag — instead of only reacting after a snap settles. Purely additive; no behavior change for existing users.
