### PR TITLE
GlassTabBar.inline: expose springDescription like the other factories

### DIFF
--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -322,9 +322,14 @@ class GlassTabBar extends StatefulWidget {
     bool adaptiveBrightness = false,
     ValueChanged<Brightness>? onBrightnessChanged,
     ValueListenable<Brightness>? brightnessOverride,
+    // Indicator snap spring — null keeps the shared default. Exposed so
+    // inline hosts can match a reference feel (e.g. Apple Music's snappier
+    // settle) without forking the physics.
+    SpringDescription? springDescription,
   }) : this._(
           key: key,
           placement: _GlassTabBarPlacement.inline,
+          springDescription: springDescription,
           tabs: tabs,
           selectedIndex: selectedIndex,
           onTabSelected: onTabSelected,


### PR DESCRIPTION
`GlassTabBar`'s bottom-bar factories already accept `springDescription`, but the `.inline` factory doesn't forward it, so inline tab bars are locked to the shared `_kSpring` default (`stiffness: 350, damping: 30`).

That default appears tuned for the searchable bottom bar's collapse/expand geometry — for a short-travel inline segmented control it reads noticeably slower than the iOS 26 system feel (e.g. Apple Music's library toggle, which settles much faster with a slight overshoot).

This forwards the existing parameter through the `.inline` factory — no behavior change when null, same semantics as the sibling factories. We're using it in production with `SpringDescription(mass: 1, stiffness: 950, damping: 44)` to match Apple Music's segmented control.
