### PR TITLE
LiquidGlassSettings.ambientRim: tunable full-perimeter rim on the moving indicator

### DIFF
--- a/lib/src/renderer/liquid_glass_settings.dart
+++ b/lib/src/renderer/liquid_glass_settings.dart
@@ -26,6 +26,7 @@ class LiquidGlassSettings with EquatableMixin {
     this.lightAngle = GlassDefaults.lightAngle,
     this.lightIntensity = .5,
     this.ambientStrength = 0,
+    this.ambientRim = 0,
     this.refractiveIndex = 1.2,
     this.saturation = 1.5,
     this.glowIntensity = 0.75,
@@ -53,6 +54,7 @@ class LiquidGlassSettings with EquatableMixin {
     required this.lightAngle,
     required this.lightIntensity,
     required this.ambientStrength,
+    this.ambientRim = 0,
     required this.refractiveIndex,
     required this.saturation,
     required this.glowIntensity,
@@ -175,6 +177,15 @@ class LiquidGlassSettings with EquatableMixin {
   ///
   /// Higher values create more pronounced ambient light.
   final double ambientStrength;
+
+  /// Full-perimeter rim ("ring") boost, 0 to ~1.
+  ///
+  /// Premium: added to the Fresnel edge-luminosity strength (base 0.12), so
+  /// the glass edge reads as a bright ring regardless of light direction —
+  /// the iOS 26 in-motion pill look. Standard interactive glass: overrides
+  /// the hardcoded ambientRim floor in [AnimatedGlassIndicator]. Default 0 =
+  /// existing rendering everywhere.
+  final double ambientRim;
 
   /// The effective ambient strength taking visibility into account.
   double get effectiveAmbientStrength => ambientStrength * visibility;
@@ -312,6 +323,7 @@ class LiquidGlassSettings with EquatableMixin {
         lightAngle: lightAngle,
         lightIntensity: lightIntensity,
         ambientStrength: ambientStrength,
+        ambientRim: ambientRim,
         refractiveIndex: refractiveIndex,
         saturation: saturation,
         glowIntensity: glowIntensity,
@@ -393,6 +405,7 @@ class LiquidGlassSettings with EquatableMixin {
         lightAngle: lerpDouble(a.lightAngle, b.lightAngle, t)!,
         lightIntensity: lerpDouble(a.lightIntensity, b.lightIntensity, t)!,
         ambientStrength: lerpDouble(a.ambientStrength, b.ambientStrength, t)!,
+        ambientRim: lerpDouble(a.ambientRim, b.ambientRim, t)!,
         refractiveIndex: lerpDouble(a.refractiveIndex, b.refractiveIndex, t)!,
         saturation: lerpDouble(a.saturation, b.saturation, t)!,
         glowIntensity: lerpDouble(a.glowIntensity, b.glowIntensity, t)!,
@@ -432,6 +445,7 @@ class LiquidGlassSettings with EquatableMixin {
     double? lightAngle,
     double? lightIntensity,
     double? ambientStrength,
+    double? ambientRim,
     double? refractiveIndex,
     double? saturation,
     double? glowIntensity,
@@ -453,6 +467,7 @@ class LiquidGlassSettings with EquatableMixin {
         lightAngle: lightAngle ?? this.lightAngle,
         lightIntensity: lightIntensity ?? this.lightIntensity,
         ambientStrength: ambientStrength ?? this.ambientStrength,
+        ambientRim: ambientRim ?? this.ambientRim,
         refractiveIndex: refractiveIndex ?? this.refractiveIndex,
         saturation: saturation ?? this.saturation,
         glowIntensity: glowIntensity ?? this.glowIntensity,
@@ -482,6 +497,7 @@ class LiquidGlassSettings with EquatableMixin {
         lightAngle,
         lightIntensity,
         ambientStrength,
+        ambientRim,
         refractiveIndex,
         saturation,
         glowIntensity,

--- a/lib/src/renderer/rendering/liquid_glass_render_object.dart
+++ b/lib/src/renderer/rendering/liquid_glass_render_object.dart
@@ -334,6 +334,10 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
           ..setFloatUniforms(initialIndex: 25, (value) {
             value.setOffset(Offset.zero);
           })
+          // Slot 27: uAmbientRim — full-perimeter Fresnel rim boost.
+          ..setFloatUniforms(initialIndex: 27, (value) {
+            value.setFloat(settings.ambientRim);
+          })
           ..setImageSampler(
             1,
             geometryImage,
@@ -461,6 +465,10 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
       // Slot 25-26: uCaptureOffset — shift fragCoord into capture-image space.
       ..setFloatUniforms(initialIndex: 25, (value) {
         value.setOffset(captureOffset);
+      })
+      // Slot 27: uAmbientRim — full-perimeter Fresnel rim boost.
+      ..setFloatUniforms(initialIndex: 27, (value) {
+        value.setFloat(settings.ambientRim);
       })
       // Slot 0: captured background image (replaces the BackdropFilter read).
       ..setImageSampler(0, capture)

--- a/lib/widgets/shared/animated_glass_indicator.dart
+++ b/lib/widgets/shared/animated_glass_indicator.dart
@@ -205,6 +205,9 @@ class AnimatedGlassIndicator extends StatelessWidget {
           override.ambientStrength != _settingsDefaults.ambientStrength
               ? override.ambientStrength
               : null,
+      ambientRim: override.ambientRim != _settingsDefaults.ambientRim
+          ? override.ambientRim
+          : null,
       refractiveIndex:
           override.refractiveIndex != _settingsDefaults.refractiveIndex
               ? override.refractiveIndex
@@ -332,8 +335,14 @@ class AnimatedGlassIndicator extends StatelessWidget {
       backgroundKey: backgroundKey,
       clipExpansion: _jellyClipExpansion,
       rimThickness: (settings?.effectiveThickness ?? 0.8).clamp(0.8, 8.0),
-      // iOS 26 Standard glass matching GlassSwitch/Slider pattern
-      ambientRim: isStdPath ? 0.08 : 0.1,
+      // iOS 26 Standard glass matching GlassSwitch/Slider pattern.
+      // settings.ambientRim (default 0) overrides the hardcoded floor — the
+      // omnidirectional ring that the directional key/kick highlights can't
+      // provide. Same field boosts the premium Fresnel rim, so one knob
+      // brightens the ring on either quality path.
+      ambientRim: (effectiveSettings.ambientRim > 0)
+          ? effectiveSettings.ambientRim
+          : (isStdPath ? 0.08 : 0.1),
       baseAlphaMultiplier:
           isStdPath ? 0.08 : 0.2, // Match GlassSlider (near clear center)
       edgeAlphaMultiplier:

--- a/shaders/liquid_glass_final_render.frag
+++ b/shaders/liquid_glass_final_render.frag
@@ -81,6 +81,10 @@ uniform vec4 uBackgroundFallback;
 //   to the correct texel in the pre-captured bar texture.
 uniform vec2 uCaptureOffset;
 
+// Slot 27: uAmbientRim — full-perimeter Fresnel rim boost. Added to the base
+// 0.12 edge-luminosity strength; 0 = unchanged default rendering.
+uniform float uAmbientRim;
+
 uniform sampler2D uBackgroundTexture;
 uniform sampler2D uGeometryTexture;
 
@@ -470,7 +474,21 @@ void main() {
     // The extra 0.02 restores the subtle rim luminosity that the geometry AA band
     // experiment temporarily reduced — keeping the glass edge visually present
     // against dark bar backgrounds without making it glowing or harsh.
-    float fresnel = (1.0 - normalZ) * edgeFactor * 0.12;
+    float rimBase = (1.0 - normalZ) * edgeFactor;
+    // uAmbientRim > 0 draws an ADDITIONAL rim band of that width (in the
+    // SDF's pixel units). The stock Fresnel profile cannot be widened by
+    // intensity scaling: within the circular bevel normalizedHeight == normalZ
+    // == sqrt(1-((T-d)/T)^2), which rises so steeply that the edgeFactor gate
+    // confines (1-normalZ)*edgeFactor to the outer ~10% of the bevel — a
+    // hairline. Inverting that profile recovers the true distance from the
+    // shape edge, d = T*(1-sqrt(1-h^2)), so the band below has an exact,
+    // thickness-independent geometric width with a ±0.75px AA edge.
+    // At uAmbientRim = 0 rendering is exactly stock.
+    float cosTerm = sqrt(max(0.0, 1.0 - normalizedHeight * normalizedHeight));
+    float rimDist = uThickness * (1.0 - cosTerm);
+    float ring    = (1.0 - smoothstep(uAmbientRim - 0.75, uAmbientRim + 0.75, rimDist))
+                  * step(0.001, uAmbientRim);
+    float fresnel = rimBase * 0.12 + ring * 0.45;
     finalColor.rgb = clamp(finalColor.rgb + vec3(fresnel), 0.0, 1.0);
 
     float alpha  = geometryData.a;

--- a/test/renderer/liquid_glass_settings_ambient_rim_test.dart
+++ b/test/renderer/liquid_glass_settings_ambient_rim_test.dart
@@ -1,0 +1,73 @@
+// Tests for LiquidGlassSettings.ambientRim (full-perimeter rim on the
+// moving indicator): constructor default, copyWith, lerp, equality, and
+// preservation through copyWithPinch.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/src/renderer/liquid_glass_settings.dart';
+
+void main() {
+  group('LiquidGlassSettings.ambientRim', () {
+    test('defaults to 0 (exact stock rendering)', () {
+      expect(const LiquidGlassSettings().ambientRim, 0);
+    });
+
+    test('constructor sets the value', () {
+      expect(const LiquidGlassSettings(ambientRim: 4.0).ambientRim, 4.0);
+    });
+
+    group('copyWith', () {
+      const base = LiquidGlassSettings(ambientRim: 2.0);
+
+      test('no-arg copyWith preserves ambientRim', () {
+        expect(base.copyWith().ambientRim, 2.0);
+      });
+
+      test('copyWith replaces ambientRim', () {
+        expect(base.copyWith(ambientRim: 6.0).ambientRim, 6.0);
+      });
+
+      test('copyWith of another field preserves ambientRim', () {
+        expect(base.copyWith(blur: 9).ambientRim, 2.0);
+      });
+    });
+
+    group('lerp', () {
+      const a = LiquidGlassSettings(ambientRim: 0.0);
+      const b = LiquidGlassSettings(ambientRim: 4.0);
+
+      test('t=0 → a', () {
+        expect(LiquidGlassSettings.lerp(a, b, 0.0).ambientRim, 0.0);
+      });
+
+      test('t=1 → b', () {
+        expect(LiquidGlassSettings.lerp(a, b, 1.0).ambientRim, 4.0);
+      });
+
+      test('t=0.5 interpolates', () {
+        expect(LiquidGlassSettings.lerp(a, b, 0.5).ambientRim,
+            closeTo(2.0, 1e-10));
+      });
+    });
+
+    group('equality', () {
+      test('settings differing only in ambientRim are unequal', () {
+        expect(
+          const LiquidGlassSettings(ambientRim: 1.0),
+          isNot(equals(const LiquidGlassSettings(ambientRim: 2.0))),
+        );
+      });
+
+      test('same ambientRim compares equal', () {
+        expect(
+          const LiquidGlassSettings(ambientRim: 3.0),
+          equals(const LiquidGlassSettings(ambientRim: 3.0)),
+        );
+      });
+    });
+
+    test('copyWithPinch preserves ambientRim', () {
+      const s = LiquidGlassSettings(ambientRim: 5.0);
+      expect(s.copyWithPinch(0.6).ambientRim, 5.0);
+    });
+  });
+}

--- a/test/widgets/shared/animated_glass_indicator_ambient_rim_test.dart
+++ b/test/widgets/shared/animated_glass_indicator_ambient_rim_test.dart
@@ -1,0 +1,94 @@
+// AnimatedGlassIndicator: LiquidGlassSettings.ambientRim forwarding.
+//
+// A caller-provided ambientRim (> 0) must reach the GlassEffect; when unset
+// (0), the indicator falls back to its per-path floors (standard/minimal
+// 0.08, premium 0.1).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/widgets/shared/glass_effect.dart';
+
+import '../../shared/test_helpers.dart';
+
+Widget _wrap(Widget indicator) => createTestApp(
+      child: SizedBox(
+        width: 400,
+        height: 80,
+        child: Stack(children: [indicator]),
+      ),
+    );
+
+AnimatedGlassIndicator _make({
+  LiquidGlassSettings? settings,
+  GlassQuality quality = GlassQuality.standard,
+}) =>
+    AnimatedGlassIndicator(
+      velocity: 0.0,
+      itemCount: 3,
+      alignment: Alignment.center,
+      thickness: 0.5, // > 0.01 → glass pass mounts
+      quality: quality,
+      indicatorColor: Colors.blue,
+      isBackgroundIndicator: false,
+      borderRadius: 20.0,
+      settings: settings,
+      pinchStrength: 0.4,
+      expansion: const EdgeInsets.all(8.0),
+      paintBackground: true,
+      paintGlass: true,
+      innerBlur: 0.0,
+    );
+
+double _effectAmbientRim(WidgetTester tester) =>
+    tester.widget<GlassEffect>(find.byType(GlassEffect)).ambientRim;
+
+void main() {
+  group('AnimatedGlassIndicator — ambientRim forwarding', () {
+    testWidgets('explicit ambientRim reaches GlassEffect (standard)',
+        (tester) async {
+      await tester.pumpWidget(_wrap(_make(
+        settings: const LiquidGlassSettings(ambientRim: 0.3),
+      )));
+      await tester.pump();
+      expect(_effectAmbientRim(tester), 0.3);
+    });
+
+    testWidgets('explicit ambientRim reaches GlassEffect (premium)',
+        (tester) async {
+      await tester.pumpWidget(_wrap(_make(
+        settings: const LiquidGlassSettings(ambientRim: 4.0),
+        quality: GlassQuality.premium,
+      )));
+      await tester.pump();
+      expect(_effectAmbientRim(tester), 4.0);
+    });
+
+    testWidgets('unset ambientRim falls back to the standard-path floor 0.08',
+        (tester) async {
+      await tester.pumpWidget(_wrap(_make(
+        settings: const LiquidGlassSettings(blur: 2), // ambientRim stays 0
+      )));
+      await tester.pump();
+      expect(_effectAmbientRim(tester), 0.08);
+    });
+
+    testWidgets('unset ambientRim falls back to the premium floor 0.1',
+        (tester) async {
+      await tester.pumpWidget(_wrap(_make(
+        quality: GlassQuality.premium,
+      )));
+      await tester.pump();
+      expect(_effectAmbientRim(tester), 0.1);
+    });
+
+    testWidgets('minimal quality uses the standard-path floor 0.08',
+        (tester) async {
+      await tester.pumpWidget(_wrap(_make(
+        quality: GlassQuality.minimal,
+      )));
+      await tester.pump();
+      expect(_effectAmbientRim(tester), 0.08);
+    });
+  });
+}


### PR DESCRIPTION
iOS 26's moving pill shows a clearly visible bright ring while in motion (Apple Music's segmented control is a good reference). At premium quality there was previously no knob for it: the Fresnel edge luminosity is a hairline by construction — inside the circular bevel `normalizedHeight == normalZ`, and the `edgeFactor` gate confines `(1-normalZ)*edgeFactor` to roughly the outer 10% of the bevel, so no intensity scaling can widen it.

This adds `LiquidGlassSettings.ambientRim` (default 0 = pixel-exact stock rendering):

- **Premium:** a new uniform (slot 27) draws an additional rim band whose geometric width in pixels equals the value. The bevel height profile is inverted to true distance from the shape edge (`d = T·(1−√(1−h²))`), so the band has an exact, thickness-independent width with a ±0.75px AA edge.
- **Standard/minimal:** the value overrides the indicator's hardcoded `ambientRim` floor, so one field drives the ring on both quality paths (strength semantics there, matching the existing shader knob).

Forwarded through `copyWith`/`lerp`/`props` and the indicator's settings merge.

Worth noting this is really a **light-mode** need: over a dark panel the stock hairline rim reads fine (we leave `ambientRim` at 0 there), but over a near-white track the contrast is so low that a 1px rim disappears entirely once the pill is moving — the ring has to be physically wider to register. That matches iOS 26 itself: compared side-by-side with Apple Music's segmented control, the light-mode pill carries a clearly wider bright ring in motion, while the dark-mode pill's rim is narrower and subtler. We match both precisely with this knob at `4.0` (≈1.3pt at 3×) in light and `0` in dark (dark needs only a slimmer bevel via the existing `thickness` setting — the stock rim mechanism is sufficient there).

One honest caveat: the field's unit differs per path — px width on premium, strength on standard. Happy to rename/split if you'd prefer symmetric semantics.
