### PR TITLE
AnimatedGlassIndicator: paint explicit shadowElevation/shadow on the glass jelly

### DIFF
--- a/lib/widgets/shared/animated_glass_indicator.dart
+++ b/lib/widgets/shared/animated_glass_indicator.dart
@@ -1,9 +1,13 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart' show listEquals;
 import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
 import '../../src/renderer/liquid_glass_renderer.dart';
 
 import '../../constants/glass_defaults.dart';
+import '../../theme/glass_theme.dart';
 import '../../types/glass_quality.dart';
 import '../../utils/draggable_indicator_physics.dart';
 import 'glass_effect.dart';
@@ -344,13 +348,42 @@ class AnimatedGlassIndicator extends StatelessWidget {
       ),
     );
 
+    // Drop shadow for the moving glass jelly. GlassEffect itself never paints
+    // LiquidGlassSettings.effectiveShadow (only container widgets like
+    // AdaptiveGlass do), so without this the jelly renders shadowless no
+    // matter what the caller sets. Gated on an EXPLICIT shadow/shadowElevation
+    // in the caller's indicator settings — the constructor default (1.0) must
+    // not grow a shadow under every existing indicator. Alpha tracks [fade] so
+    // the shadow materialises with the glass and vanishes at rest.
+    // Shadows only apply in light mode — same rule as every other
+    // effectiveShadow consumer (AdaptiveGlass, AdaptiveLiquidGlassLayer,
+    // the tab-bar shadow overlay).
+    final jellyShadowIsDark =
+        GlassTheme.brightnessOf(context) == Brightness.dark;
+    final explicitJellyShadows = (!jellyShadowIsDark &&
+            settings != null &&
+            (settings!.shadow != null ||
+                settings!.shadowElevation != _settingsDefaults.shadowElevation))
+        ? effectiveSettings.effectiveShadow
+        : const <BoxShadow>[];
+    final shadowedGlass = explicitJellyShadows.isEmpty
+        ? glassWidget
+        : CustomPaint(
+            painter: _OuterShadowPainter(
+              borderRadius: borderRadius,
+              shadows: explicitJellyShadows,
+              opacity: fade,
+            ),
+            child: glassWidget,
+          );
+
     // Mount early (0.01) so geometry is built before the indicator is visible.
     // We MUST NOT wrap this in a RepaintBoundary because the jelly Transform
     // below will apply a sub-pixel shift/scale. If we pre-rasterise the glass
     // with a RepaintBoundary, the pre-computed AA will misalign with the pixel
     // grid during the transform, causing stair-stepping on the edges.
     final interactiveIndicator =
-        thickness > 0.01 ? glassWidget : const SizedBox.expand();
+        thickness > 0.01 ? shadowedGlass : const SizedBox.expand();
 
     // Standard: background inside Transform to get jelly physics
     final glassChild = Stack(
@@ -448,4 +481,58 @@ class AnimatedGlassIndicator extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Paints [shadows] around a rounded-rect silhouette with the shape's own
+/// interior clipped out (even-odd), so a TRANSLUCENT child shows no shadow
+/// body through itself — outer halo only. A plain BoxShadow behind clear
+/// glass reads as an inner shadow because its filled blurred body is visible
+/// through the glass.
+class _OuterShadowPainter extends CustomPainter {
+  const _OuterShadowPainter({
+    required this.borderRadius,
+    required this.shadows,
+    required this.opacity,
+  });
+
+  final double borderRadius;
+  final List<BoxShadow> shadows;
+  final double opacity;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rrect = RRect.fromRectAndRadius(
+      Offset.zero & size,
+      Radius.circular(borderRadius),
+    );
+    var slack = 0.0;
+    for (final s in shadows) {
+      slack = math.max(
+        slack,
+        s.blurRadius + s.spreadRadius + s.offset.distance,
+      );
+    }
+    final clip = Path()
+      ..fillType = PathFillType.evenOdd
+      ..addRect((Offset.zero & size).inflate(slack + 16))
+      ..addRRect(rrect);
+    canvas.save();
+    canvas.clipPath(clip);
+    for (final s in shadows) {
+      final paint = Paint()
+        ..color = s.color.withValues(alpha: s.color.a * opacity)
+        ..maskFilter = MaskFilter.blur(BlurStyle.normal, s.blurSigma);
+      canvas.drawRRect(
+        rrect.shift(s.offset).inflate(s.spreadRadius),
+        paint,
+      );
+    }
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(_OuterShadowPainter oldDelegate) =>
+      oldDelegate.borderRadius != borderRadius ||
+      oldDelegate.opacity != opacity ||
+      !listEquals(oldDelegate.shadows, shadows);
 }

--- a/test/widgets/shared/animated_glass_indicator_jelly_shadow_test.dart
+++ b/test/widgets/shared/animated_glass_indicator_jelly_shadow_test.dart
@@ -1,0 +1,122 @@
+// AnimatedGlassIndicator: outer drop shadow on the moving glass jelly.
+//
+// The shadow paints only when the caller EXPLICITLY sets a non-default
+// shadowElevation (or a shadow list) in the indicator settings, only in
+// light mode (package-wide shadow convention), and only while the glass
+// pass is mounted. Existing indicators must render without it.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+import '../../shared/test_helpers.dart';
+
+/// The outer-shadow layer is a CustomPaint with the (private)
+/// _OuterShadowPainter — identified by runtime type name.
+Finder _outerShadowPaint() => find.byWidgetPredicate((w) =>
+    w is CustomPaint &&
+    w.painter.runtimeType.toString() == '_OuterShadowPainter');
+
+Widget _wrap(Widget indicator, {required Brightness brightness}) =>
+    createTestApp(
+      theme: ThemeData(brightness: brightness),
+      child: SizedBox(
+        width: 400,
+        height: 80,
+        child: Stack(children: [indicator]),
+      ),
+    );
+
+AnimatedGlassIndicator _make({
+  LiquidGlassSettings? settings,
+  double thickness = 0.5, // > 0.01 → glass pass mounts (mid-morph)
+}) =>
+    AnimatedGlassIndicator(
+      velocity: 0.0,
+      itemCount: 3,
+      alignment: Alignment.center,
+      thickness: thickness,
+      quality: GlassQuality.standard,
+      indicatorColor: Colors.blue,
+      isBackgroundIndicator: false,
+      borderRadius: 20.0,
+      settings: settings,
+      pinchStrength: 0.4,
+      expansion: const EdgeInsets.all(8.0),
+      paintBackground: true,
+      paintGlass: true,
+      innerBlur: 0.0,
+    );
+
+void main() {
+  group('AnimatedGlassIndicator — jelly outer shadow', () {
+    testWidgets('explicit shadowElevation paints the shadow in light mode',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        _make(settings: const LiquidGlassSettings(shadowElevation: 3.0)),
+        brightness: Brightness.light,
+      ));
+      await tester.pump();
+      expect(_outerShadowPaint(), findsOneWidget);
+    });
+
+    testWidgets('explicit shadow list paints the shadow in light mode',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        _make(
+          settings: const LiquidGlassSettings(shadow: [
+            BoxShadow(
+                color: Colors.black26,
+                blurRadius: 6,
+                offset: Offset(0, 2)),
+          ]),
+        ),
+        brightness: Brightness.light,
+      ));
+      await tester.pump();
+      expect(_outerShadowPaint(), findsOneWidget);
+    });
+
+    testWidgets('default settings paint NO shadow (back-compat)',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        _make(settings: const LiquidGlassSettings()),
+        brightness: Brightness.light,
+      ));
+      await tester.pump();
+      expect(_outerShadowPaint(), findsNothing);
+    });
+
+    testWidgets('null settings paint NO shadow (back-compat)',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        _make(),
+        brightness: Brightness.light,
+      ));
+      await tester.pump();
+      expect(_outerShadowPaint(), findsNothing);
+    });
+
+    testWidgets('dark mode paints NO shadow even with explicit elevation',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        _make(settings: const LiquidGlassSettings(shadowElevation: 3.0)),
+        brightness: Brightness.dark,
+      ));
+      await tester.pump();
+      expect(_outerShadowPaint(), findsNothing);
+    });
+
+    testWidgets('no shadow at rest (glass pass unmounted)', (tester) async {
+      await tester.pumpWidget(_wrap(
+        _make(
+          settings: const LiquidGlassSettings(shadowElevation: 3.0),
+          thickness: 0.0, // resting — interactive indicator not built
+        ),
+        brightness: Brightness.light,
+      ));
+      await tester.pump();
+      expect(_outerShadowPaint(), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
`GlassEffect` never consumes `LiquidGlassSettings.effectiveShadow` — only the container widgets do — so a `shadowElevation` passed via `indicatorSettings` was silently ignored on the moving indicator, and the jelly always rendered shadowless (iOS 26's moving pill carries a soft drop shadow distinct from the track's).

This paints the shadow behind the glass jelly with the pill's own silhouette clipped out (even-odd path), because a plain `BoxShadow` behind translucent glass shows its filled blurred body *through* the glass and reads as an inner shadow. Alpha tracks the morph fade, so the shadow materialises with the glass and vanishes at rest.

Like the `ambientRim` PR, this came out of light-mode contrast tuning: over a near-white track, a clear glass jelly in motion has almost nothing separating it from the surface it slides across. Watching Apple Music's segmented control animate, the moving pill visibly *floats* — it carries its own soft drop shadow above the track's, and that depth cue does a lot of the work of keeping the pill legible mid-morph. With the shadow silently dropped, no amount of rim/specular tuning reproduced that read.

Guard rails:
- Only an **explicitly non-default** `shadowElevation`/`shadow` in the caller's indicator settings triggers it — existing indicators render byte-identically.
- Follows the package convention that shadows only apply in light mode (same `GlassTheme.brightnessOf` gate as AdaptiveGlass and the tab-bar shadow overlay) — which fits the motivation: it's a light-mode contrast cue to begin with.

Note: this and the `ambientRim` PR touch neighbouring code in `animated_glass_indicator.dart` — whichever merges second may need a trivial rebase.
