### PR TITLE
GlassSegmentedControl: vertical axis support (direction + segmentExtent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# Unreleased
+
+## ✨ New Features
+
+- **Vertical `GlassSegmentedControl`** — fixed controls now accept
+  `direction: Axis.vertical` and an optional `segmentExtent`. Layout,
+  fractional indicator positioning, jelly expansion, drag velocity, snapping,
+  and gesture recognition all follow the vertical axis. The horizontal default
+  and scrollable constructor remain unchanged.
+
+## 🧪 Example
+
+- Added an icon-only vertical segmented control to the Interactive page for
+  tap, drag, indicator, and accessibility testing on a physical device.
+
+---
+
 # 0.21.3
 
 ## 🐛 Bug Fixes

--- a/example/lib/pages/interactive_page.dart
+++ b/example/lib/pages/interactive_page.dart
@@ -19,6 +19,7 @@ class _InteractivePageState extends State<InteractivePage> {
   // Segmented control state
   int _segment1 = 0;
   int _segment2 = 1;
+  int _verticalSegment = 0;
 
   // Slider state
   double _slider1 = 0.5;
@@ -333,6 +334,68 @@ class _InteractivePageState extends State<InteractivePage> {
                         onSegmentSelected: (i) => setState(() => _segment2 = i),
                         height: 28,
                         borderRadius: 14,
+                      ),
+                      SizedBox(height: 24),
+                      _QualityLabel(label: 'Vertical — tap or drag'),
+                      SizedBox(height: 16),
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          GlassSegmentedControl(
+                            direction: Axis.vertical,
+                            height: 52,
+                            segmentExtent: 56,
+                            segments: const [
+                              GlassSegment(
+                                icon: Icon(CupertinoIcons.square_grid_2x2),
+                                semanticLabel: 'Canvas',
+                              ),
+                              GlassSegment(
+                                icon: Icon(CupertinoIcons.circle_grid_hex),
+                                semanticLabel: 'Flow',
+                              ),
+                              GlassSegment(
+                                icon: Icon(CupertinoIcons.layers_alt),
+                                semanticLabel: 'Deep Dive',
+                              ),
+                            ],
+                            selectedIndex: _verticalSegment,
+                            onSegmentSelected: (i) =>
+                                setState(() => _verticalSegment = i),
+                          ),
+                          SizedBox(width: 20),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  const [
+                                    'Canvas',
+                                    'Flow',
+                                    'Deep Dive'
+                                  ][_verticalSegment],
+                                  style: TextStyle(
+                                    fontSize: 17,
+                                    fontWeight: FontWeight.w600,
+                                    color: CupertinoColors.label
+                                        .resolveFrom(context),
+                                  ),
+                                ),
+                                SizedBox(height: 6),
+                                Text(
+                                  'The indicator, jelly motion, drag physics, '
+                                  'and icon state all follow the vertical axis.',
+                                  style: TextStyle(
+                                    fontSize: 13,
+                                    height: 1.35,
+                                    color: CupertinoColors.secondaryLabel
+                                        .resolveFrom(context),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
                       ),
 
                       SizedBox(height: 40),

--- a/lib/utils/draggable_indicator_physics.dart
+++ b/lib/utils/draggable_indicator_physics.dart
@@ -164,7 +164,7 @@ class DraggableIndicatorPhysics {
     return (relativeIndex * 2) - 1;
   }
 
-  /// Converts a global drag position to horizontal alignment (-1 to 1).
+  /// Converts a global drag position to alignment (-1 to 1) along [direction].
   ///
   /// Applies rubber band resistance when dragging beyond edges.
   ///
@@ -172,13 +172,15 @@ class DraggableIndicatorPhysics {
   /// - [globalPosition]: The global position from drag details
   /// - [context]: Build context to find the render box
   /// - [itemCount]: Total number of items
+  /// - [direction]: Axis whose coordinate and extent drive the mapping
   ///
   /// Returns: Alignment value with rubber band resistance applied.
   static double getAlignmentFromGlobalPosition(
     Offset globalPosition,
     BuildContext context,
-    int itemCount,
-  ) {
+    int itemCount, {
+    Axis direction = Axis.horizontal,
+  }) {
     final box = context.findRenderObject()! as RenderBox;
     final localPosition = box.globalToLocal(globalPosition);
 
@@ -188,7 +190,11 @@ class DraggableIndicatorPhysics {
     final padding = indicatorWidth / 2;
 
     // Map drag position to 0-1 range
-    final rawRelativeX = (localPosition.dx / box.size.width).clamp(0.0, 1.0);
+    final mainPosition =
+        direction == Axis.horizontal ? localPosition.dx : localPosition.dy;
+    final mainExtent =
+        direction == Axis.horizontal ? box.size.width : box.size.height;
+    final rawRelativeX = (mainPosition / mainExtent).clamp(0.0, 1.0);
     final normalizedX = (rawRelativeX - padding) / draggableRange;
 
     // Apply rubber band resistance for overdrag

--- a/lib/widgets/interactive/glass_segmented_control.dart
+++ b/lib/widgets/interactive/glass_segmented_control.dart
@@ -148,8 +148,29 @@ import 'shared/segmented_control_internal.dart';
 ///   ),
 /// )
 /// ```
+///
+/// ### Vertical icon control
+/// ```dart
+/// GlassSegmentedControl(
+///   direction: Axis.vertical,
+///   height: 44, // cross-axis width in vertical mode
+///   segmentExtent: 52,
+///   segments: const [
+///     GlassSegment(
+///       icon: Icon(CupertinoIcons.square_grid_2x2),
+///       semanticLabel: 'Canvas',
+///     ),
+///     GlassSegment(
+///       icon: Icon(CupertinoIcons.circle_grid_hex),
+///       semanticLabel: 'Flow',
+///     ),
+///   ],
+///   selectedIndex: selectedIndex,
+///   onSegmentSelected: onSelected,
+/// )
+/// ```
 class GlassSegmentedControl extends StatefulWidget {
-  /// Creates a fixed-width glass segmented control (iOS UISegmentedControl).
+  /// Creates a fixed-extent glass segmented control (iOS UISegmentedControl).
   ///
   /// All segments are equal-width. For a scrollable variant that mimics
   /// [GlassTabBar]`(isScrollable: true)`, use [GlassSegmentedControl.scrollable].
@@ -173,6 +194,8 @@ class GlassSegmentedControl extends StatefulWidget {
     this.useOwnLayer = false,
     this.quality,
     this.backgroundKey,
+    this.direction = Axis.horizontal,
+    this.segmentExtent,
     // ── iOS 26 interaction ──────────────────────────────────────────────────
     this.interactionBehavior = GlassInteractionBehavior.full,
     this.glowColor,
@@ -248,6 +271,8 @@ class GlassSegmentedControl extends StatefulWidget {
     this.dividerSettings,
     this.indicatorShadow,
   })  : isScrollable = true,
+        direction = Axis.horizontal,
+        segmentExtent = null,
         interactionBehavior = GlassInteractionBehavior.full,
         glowColor = null,
         glowRadius = 1.5,
@@ -294,11 +319,24 @@ class GlassSegmentedControl extends StatefulWidget {
   /// > compare the received index against `selectedIndex` before acting.
   final ValueChanged<int> onSegmentSelected;
 
+  /// The axis along which fixed-mode segments are laid out.
+  ///
+  /// Scrollable controls remain horizontal.
+  final Axis direction;
+
+  /// Main-axis size of each segment in vertical mode.
+  ///
+  /// Defaults to [height], producing square segments.
+  final double? segmentExtent;
+
   // ===========================================================================
   // Layout Properties
   // ===========================================================================
 
   /// Height of the segmented control.
+  ///
+  /// In vertical mode this is the control's cross-axis width. The total height
+  /// is ([segmentExtent] ?? [height]) × the number of segments.
   ///
   /// Defaults to 32 (matching iOS UISegmentedControl).
   final double height;
@@ -551,8 +589,12 @@ class _GlassSegmentedControlState extends State<GlassSegmentedControl> {
 
     // SizedBox sets the height without clipping. DecoratedBox paints the
     // background without enforcing a clip — jelly expansion can overflow freely.
+    final isVertical = widget.direction == Axis.vertical;
     final control = SizedBox(
-      height: widget.height,
+      width: isVertical ? widget.height : null,
+      height: isVertical
+          ? (widget.segmentExtent ?? widget.height) * widget.segments.length
+          : widget.height,
       child: DecoratedBox(
         decoration: BoxDecoration(
           color: backgroundColor,
@@ -562,6 +604,7 @@ class _GlassSegmentedControlState extends State<GlassSegmentedControl> {
           padding: widget.padding,
           child: SegmentedControlContent(
             segments: widget.segments,
+            direction: widget.direction,
             selectedIndex: widget.selectedIndex,
             onSegmentSelected: widget.onSegmentSelected,
             selectedTextStyle: widget.selectedTextStyle,

--- a/lib/widgets/interactive/shared/segmented_control_internal.dart
+++ b/lib/widgets/interactive/shared/segmented_control_internal.dart
@@ -45,6 +45,7 @@ class SegmentedControlContent extends StatefulWidget {
     required this.indicatorColor,
     required this.borderRadius,
     required this.quality,
+    this.direction = Axis.horizontal,
     this.indicatorSettings,
     this.indicatorPinchStrength = 0.4,
     this.indicatorExpansion =
@@ -73,6 +74,7 @@ class SegmentedControlContent extends StatefulWidget {
   final EdgeInsetsGeometry indicatorExpansion;
   final double borderRadius;
   final GlassQuality quality;
+  final Axis direction;
   final GlobalKey? backgroundKey;
   final GlassInteractionBehavior interactionBehavior;
   final Color? glowColor;
@@ -94,8 +96,8 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
   bool _isDown = false;
   bool _isDragging = false;
 
-  /// Current horizontal alignment of the indicator in the range [-1, 1].
-  late double _xAlign = _computeXAlignmentForSegment(widget.selectedIndex);
+  /// Current main-axis alignment of the indicator in the range [-1, 1].
+  late double _mainAlign = _computeAlignmentForSegment(widget.selectedIndex);
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -105,15 +107,15 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
     if (oldWidget.selectedIndex != widget.selectedIndex ||
         oldWidget.segments.length != widget.segments.length) {
       setState(() {
-        _xAlign = _computeXAlignmentForSegment(widget.selectedIndex);
+        _mainAlign = _computeAlignmentForSegment(widget.selectedIndex);
       });
     }
   }
 
   // ── Coordinate helpers ────────────────────────────────────────────────────
 
-  /// Converts a segment index to horizontal alignment (-1 to 1).
-  double _computeXAlignmentForSegment(int segmentIndex) {
+  /// Converts a segment index to main-axis alignment (-1 to 1).
+  double _computeAlignmentForSegment(int segmentIndex) {
     return DraggableIndicatorPhysics.computeAlignment(
       segmentIndex,
       widget.segments.length,
@@ -126,6 +128,7 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
       globalPosition,
       context,
       widget.segments.length,
+      direction: widget.direction,
     );
   }
 
@@ -136,9 +139,11 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
   }
 
   void _onDragUpdate(DragUpdateDetails details) {
+    final nextAlignment =
+        _getAlignmentFromGlobalPosition(details.globalPosition);
     setState(() {
       _isDragging = true;
-      _xAlign = _getAlignmentFromGlobalPosition(details.globalPosition);
+      _mainAlign = nextAlignment;
     });
   }
 
@@ -149,21 +154,25 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
     });
 
     final box = context.findRenderObject()! as RenderBox;
-    final currentRelativeX = (_xAlign + 1) / 2;
+    final currentRelative = (_mainAlign + 1) / 2;
     final segmentWidth = 1.0 / widget.segments.length;
     final indicatorWidth = 1.0 / widget.segments.length;
     final draggableRange = 1.0 - indicatorWidth;
-    final velocityX =
-        (details.velocity.pixelsPerSecond.dx / box.size.width) / draggableRange;
+    final mainVelocity = widget.direction == Axis.horizontal
+        ? details.velocity.pixelsPerSecond.dx
+        : details.velocity.pixelsPerSecond.dy;
+    final mainExtent =
+        widget.direction == Axis.horizontal ? box.size.width : box.size.height;
+    final velocityX = (mainVelocity / mainExtent) / draggableRange;
 
     final targetSegmentIndex = DraggableIndicatorPhysics.computeTargetIndex(
-      currentRelativeX: currentRelativeX,
+      currentRelativeX: currentRelative,
       velocityX: velocityX,
       itemWidth: segmentWidth,
       itemCount: widget.segments.length,
     );
 
-    _xAlign = _computeXAlignmentForSegment(targetSegmentIndex);
+    _mainAlign = _computeAlignmentForSegment(targetSegmentIndex);
 
     if (targetSegmentIndex != widget.selectedIndex) {
       widget.onSegmentSelected(targetSegmentIndex);
@@ -172,9 +181,9 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
 
   void _onDragCancel() {
     if (_isDragging) {
-      final currentRelativeX = (_xAlign + 1) / 2;
+      final currentRelative = (_mainAlign + 1) / 2;
       final targetSegmentIndex = DraggableIndicatorPhysics.computeTargetIndex(
-        currentRelativeX: currentRelativeX,
+        currentRelativeX: currentRelative,
         velocityX: 0,
         itemWidth: 1.0 / widget.segments.length,
         itemCount: widget.segments.length,
@@ -182,14 +191,14 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
       setState(() {
         _isDragging = false;
         _isDown = false;
-        _xAlign = _computeXAlignmentForSegment(targetSegmentIndex);
+        _mainAlign = _computeAlignmentForSegment(targetSegmentIndex);
       });
       if (targetSegmentIndex != widget.selectedIndex) {
         widget.onSegmentSelected(targetSegmentIndex);
       }
     } else {
       setState(
-        () => _xAlign = _computeXAlignmentForSegment(widget.selectedIndex),
+        () => _mainAlign = _computeAlignmentForSegment(widget.selectedIndex),
       );
     }
   }
@@ -209,7 +218,7 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
         (GlassTheme.brightnessOf(context) == Brightness.light
             ? CupertinoColors.black.withValues(alpha: 0.08)
             : CupertinoColors.white.withValues(alpha: 0.2));
-    final targetAlignment = _computeXAlignmentForSegment(widget.selectedIndex);
+    final targetAlignment = _computeAlignmentForSegment(widget.selectedIndex);
 
     // Indicator is slightly less rounded than the container to account for
     // the inset padding.
@@ -243,19 +252,36 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
         if (!_isDragging) setState(() => _isDown = false);
       },
       child: GestureDetector(
-        onHorizontalDragDown: _onDragDown,
-        onHorizontalDragUpdate: _onDragUpdate,
-        onHorizontalDragEnd: _onDragEnd,
-        onHorizontalDragCancel: _onDragCancel,
+        onHorizontalDragDown:
+            widget.direction == Axis.horizontal ? _onDragDown : null,
+        onHorizontalDragUpdate:
+            widget.direction == Axis.horizontal ? _onDragUpdate : null,
+        onHorizontalDragEnd:
+            widget.direction == Axis.horizontal ? _onDragEnd : null,
+        onHorizontalDragCancel:
+            widget.direction == Axis.horizontal ? _onDragCancel : null,
+        onVerticalDragDown:
+            widget.direction == Axis.vertical ? _onDragDown : null,
+        onVerticalDragUpdate:
+            widget.direction == Axis.vertical ? _onDragUpdate : null,
+        onVerticalDragEnd:
+            widget.direction == Axis.vertical ? _onDragEnd : null,
+        onVerticalDragCancel:
+            widget.direction == Axis.vertical ? _onDragCancel : null,
         child: VelocitySpringBuilder(
-          value: _xAlign,
+          value: _mainAlign,
           springWhenActive: GlassSpring.interactive(),
           springWhenReleased: GlassSpring.snappy(
             duration: const Duration(milliseconds: 350),
           ),
           active: _isDragging,
           builder: (context, value, velocity, child) {
-            final alignment = Alignment(value, 0);
+            final alignment = widget.direction == Axis.horizontal
+                ? Alignment(value, 0)
+                : Alignment(0, value);
+            final alignmentDelta = widget.direction == Axis.horizontal
+                ? alignment.x - targetAlignment
+                : alignment.y - targetAlignment;
 
             return SpringBuilder(
               spring: GlassSpring.snappy(
@@ -264,9 +290,7 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
               // Show glass bloom when: pressed, dragging, OR indicator is still
               // settling toward its target. Threshold 0.05 matches
               // tab_bar_internal.dart for consistent cross-component behaviour.
-              value: _isDown || (alignment.x - targetAlignment).abs() > 0.05
-                  ? 1.0
-                  : 0.0,
+              value: _isDown || alignmentDelta.abs() > 0.05 ? 1.0 : 0.0,
               builder: (context, thickness, child) {
                 final isPremiumQuality = widget.quality == GlassQuality.premium;
                 return Stack(
@@ -279,6 +303,7 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
                       velocity: velocity,
                       itemCount: widget.segments.length,
                       alignment: alignment,
+                      direction: widget.direction,
                       thickness: thickness,
                       quality: widget.quality,
                       indicatorColor: indicatorColor,
@@ -303,6 +328,7 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
                         velocity: velocity,
                         itemCount: widget.segments.length,
                         alignment: alignment,
+                        direction: widget.direction,
                         thickness: thickness,
                         quality: widget.quality,
                         indicatorColor: indicatorColor,
@@ -318,7 +344,8 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
                   ],
                 );
               },
-              child: Row(
+              child: Flex(
+                direction: widget.direction,
                 children: [
                   for (var i = 0; i < widget.segments.length; i++)
                     Expanded(
@@ -361,7 +388,8 @@ class SegmentedControlContentState extends State<SegmentedControlContent> {
               ),
             );
           },
-          child: Row(
+          child: Flex(
+            direction: widget.direction,
             children: [
               for (var i = 0; i < widget.segments.length; i++)
                 Expanded(

--- a/lib/widgets/shared/animated_glass_indicator.dart
+++ b/lib/widgets/shared/animated_glass_indicator.dart
@@ -32,6 +32,11 @@ class AnimatedGlassIndicator extends StatelessWidget {
   /// Current alignment of the indicator.
   final Alignment alignment;
 
+  /// Axis along which fixed-size indicators travel.
+  ///
+  /// Defaults to horizontal so existing tab bars and bottom bars are unchanged.
+  final Axis direction;
+
   /// Animation value (0.0 to 1.0) indicating drag state.
   /// 0 = resting, >0 = dragging/animating.
   final double thickness;
@@ -142,6 +147,7 @@ class AnimatedGlassIndicator extends StatelessWidget {
     this.shadows,
     this.pinchStrength = 1.0,
     this.innerBlur = 0.0,
+    this.direction = Axis.horizontal,
   });
 
   /// The iOS 26-calibrated default glass settings for all indicator pills.
@@ -268,10 +274,26 @@ class AnimatedGlassIndicator extends StatelessWidget {
     vertical: 15.0,
   );
 
+  /// Rotated clip budget for indicators whose travel axis is vertical.
+  static const _jellyClipExpansionVertical = EdgeInsets.symmetric(
+    horizontal: 15.0,
+    vertical: 20.0,
+  );
+
   @override
   Widget build(BuildContext context) {
+    final isVertical = direction == Axis.vertical;
+
     // Calculate expansion rectangle based on thickness
-    final resolvedExpansion = expansion.resolve(Directionality.of(context));
+    final resolved = expansion.resolve(Directionality.of(context));
+    final resolvedExpansion = isVertical
+        ? EdgeInsets.fromLTRB(
+            resolved.top,
+            resolved.left,
+            resolved.bottom,
+            resolved.right,
+          )
+        : resolved;
     final rect = RelativeRect.lerp(
       RelativeRect.fill,
       RelativeRect.fromLTRB(
@@ -341,7 +363,8 @@ class AnimatedGlassIndicator extends StatelessWidget {
       quality: quality,
       interactionIntensity: thickness,
       backgroundKey: backgroundKey,
-      clipExpansion: _jellyClipExpansion,
+      clipExpansion:
+          isVertical ? _jellyClipExpansionVertical : _jellyClipExpansion,
       // rimThickness translation: Premium uses thickness as 3D glass depth
       // (Impeller SDF — no visible border drawn). Standard uses rimThickness
       // as a literal pixel-width border in the GLSL shader, so the same raw
@@ -480,7 +503,9 @@ class AnimatedGlassIndicator extends StatelessWidget {
           child: Transform(
             alignment: Alignment.center,
             transform: DraggableIndicatorPhysics.buildJellyTransform(
-              velocity: Offset(velocity, 0),
+              velocity: direction == Axis.horizontal
+                  ? Offset(velocity, 0)
+                  : Offset(0, velocity),
               maxDistortion: isStdPath ? 0.35 : 0.8,
               velocityScale: 10,
             ),
@@ -493,6 +518,10 @@ class AnimatedGlassIndicator extends StatelessWidget {
     Widget positioning;
     if (exactWidth != null && exactOffset != null) {
       // Exact pixel positioning for scrollable mode with variable-width tabs
+      assert(
+        !isVertical,
+        'exactWidth/exactOffset positioning is horizontal-only',
+      );
       positioning = Positioned(
         left: exactOffset,
         top: 0,
@@ -504,7 +533,8 @@ class AnimatedGlassIndicator extends StatelessWidget {
       // Fractional positioning for fixed-width tabs
       positioning = Positioned.fill(
         child: FractionallySizedBox(
-          widthFactor: 1 / itemCount,
+          widthFactor: direction == Axis.horizontal ? 1 / itemCount : null,
+          heightFactor: direction == Axis.vertical ? 1 / itemCount : null,
           alignment: alignment,
           child: indicatorBody,
         ),

--- a/test/widgets/interactive/glass_segmented_control_vertical_test.dart
+++ b/test/widgets/interactive/glass_segmented_control_vertical_test.dart
@@ -1,0 +1,279 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/widgets/shared/glass_effect.dart';
+
+import '../../shared/test_helpers.dart';
+
+void main() {
+  test('horizontal remains the default axis', () {
+    final control = GlassSegmentedControl(
+      segments: const [
+        GlassSegment(label: 'A'),
+        GlassSegment(label: 'B'),
+      ],
+      selectedIndex: 0,
+      onSegmentSelected: (_) {},
+    );
+
+    expect(control.direction, Axis.horizontal);
+    expect(control.segmentExtent, isNull);
+  });
+
+  testWidgets('vertical control sizes and stacks segments on its main axis',
+      (tester) async {
+    await tester.pumpWidget(
+      createTestApp(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: GlassSegmentedControl(
+            segments: const [
+              GlassSegment(label: 'Top'),
+              GlassSegment(label: 'Middle'),
+              GlassSegment(label: 'Bottom'),
+            ],
+            selectedIndex: 0,
+            onSegmentSelected: (_) {},
+            direction: Axis.vertical,
+            height: 44,
+            segmentExtent: 52,
+            useOwnLayer: true,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+
+    final size = tester.getSize(find.byType(GlassSegmentedControl));
+    expect(size.width, 44);
+    expect(size.height, 52 * 3);
+
+    final top = tester.getCenter(find.text('Top'));
+    final middle = tester.getCenter(find.text('Middle'));
+    final bottom = tester.getCenter(find.text('Bottom'));
+    expect(middle.dy, greaterThan(top.dy));
+    expect(bottom.dy, greaterThan(middle.dy));
+    expect(middle.dx, closeTo(top.dx, 0.5));
+  });
+
+  testWidgets('vertical indicator occupies and follows the vertical axis',
+      (tester) async {
+    await tester.pumpWidget(
+      createTestApp(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: GlassSegmentedControl(
+            segments: const [
+              GlassSegment(label: 'Top'),
+              GlassSegment(label: 'Middle'),
+              GlassSegment(label: 'Bottom'),
+            ],
+            selectedIndex: 1,
+            onSegmentSelected: (_) {},
+            direction: Axis.vertical,
+            useOwnLayer: true,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final indicatorBox = tester.widget<FractionallySizedBox>(
+      find
+          .descendant(
+            of: find.byType(GlassSegmentedControl),
+            matching: find.byType(FractionallySizedBox),
+          )
+          .first,
+    );
+    final alignment = indicatorBox.alignment.resolve(TextDirection.ltr);
+
+    expect(indicatorBox.widthFactor, isNull);
+    expect(indicatorBox.heightFactor, closeTo(1 / 3, 1e-9));
+    expect(alignment.x, 0);
+    expect(alignment.y, 0);
+  });
+
+  testWidgets('off-center vertical selection settles at rest', (tester) async {
+    await tester.pumpWidget(
+      createTestApp(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: GlassSegmentedControl(
+            segments: const [
+              GlassSegment(label: 'Top'),
+              GlassSegment(label: 'Middle'),
+              GlassSegment(label: 'Bottom'),
+            ],
+            selectedIndex: 2,
+            onSegmentSelected: (_) {},
+            direction: Axis.vertical,
+            useOwnLayer: true,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final opacity = tester.widget<Opacity>(find.byType(Opacity).first);
+    expect(opacity.opacity, 1);
+  });
+
+  testWidgets('vertical mode wires only the vertical drag recognizer',
+      (tester) async {
+    await tester.pumpWidget(
+      createTestApp(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: GlassSegmentedControl(
+            segments: const [
+              GlassSegment(label: 'A'),
+              GlassSegment(label: 'B'),
+            ],
+            selectedIndex: 0,
+            onSegmentSelected: (_) {},
+            direction: Axis.vertical,
+          ),
+        ),
+      ),
+    );
+
+    final drag = tester
+        .widgetList<GestureDetector>(find.byType(GestureDetector))
+        .firstWhere(
+          (gesture) =>
+              gesture.onVerticalDragUpdate != null ||
+              gesture.onHorizontalDragUpdate != null,
+        );
+    expect(drag.onVerticalDragUpdate, isNotNull);
+    expect(drag.onHorizontalDragUpdate, isNull);
+  });
+
+  testWidgets('vertical icon segments preserve accessibility labels',
+      (tester) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      createTestApp(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: GlassSegmentedControl(
+            segments: const [
+              GlassSegment(
+                icon: Icon(CupertinoIcons.square_grid_2x2),
+                semanticLabel: 'Canvas',
+              ),
+              GlassSegment(
+                icon: Icon(CupertinoIcons.circle_grid_hex),
+                semanticLabel: 'Flow',
+              ),
+              GlassSegment(
+                icon: Icon(CupertinoIcons.layers_alt),
+                semanticLabel: 'Deep Dive',
+              ),
+            ],
+            selectedIndex: 0,
+            onSegmentSelected: (_) {},
+            direction: Axis.vertical,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.bySemanticsLabel('Canvas'), findsOneWidget);
+    expect(find.bySemanticsLabel('Flow'), findsOneWidget);
+    expect(find.bySemanticsLabel('Deep Dive'), findsOneWidget);
+    semantics.dispose();
+  });
+
+  testWidgets('vertical drag selects along the y axis', (tester) async {
+    int? selected;
+    await tester.pumpWidget(
+      createTestApp(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: GlassSegmentedControl(
+            segments: const [
+              GlassSegment(label: 'Top'),
+              GlassSegment(label: 'Middle'),
+              GlassSegment(label: 'Bottom'),
+            ],
+            selectedIndex: 0,
+            onSegmentSelected: (index) => selected = index,
+            direction: Axis.vertical,
+            height: 44,
+            segmentExtent: 52,
+            useOwnLayer: true,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final gesture =
+        await tester.startGesture(tester.getCenter(find.text('Top')));
+    await tester.pump();
+    await gesture.moveBy(const Offset(0, 104));
+    // The first large move resolves the tap-vs-drag arena. A subsequent event
+    // is what the winning drag recognizer reports as an update.
+    await gesture.moveBy(const Offset(0, 1));
+    // Let the active velocity spring visibly follow the held drag. One frame is
+    // intentionally insufficient because the first frame rebuilds and starts
+    // the spring; the second advances it.
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    final draggedIndicator = tester.widget<FractionallySizedBox>(
+      find
+          .descendant(
+            of: find.byType(GlassSegmentedControl),
+            matching: find.byType(FractionallySizedBox),
+          )
+          .first,
+    );
+    expect(
+      draggedIndicator.alignment.resolve(TextDirection.ltr).y,
+      greaterThan(0.8),
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(selected, 2);
+  });
+
+  testWidgets('vertical indicator rotates the jelly clip budget',
+      (tester) async {
+    await tester.pumpWidget(
+      createTestApp(
+        child: Center(
+          child: SizedBox(
+            width: 44,
+            height: 132,
+            child: Stack(
+              children: const [
+                AnimatedGlassIndicator(
+                  velocity: 1,
+                  itemCount: 3,
+                  alignment: Alignment.topCenter,
+                  thickness: 1,
+                  quality: GlassQuality.minimal,
+                  indicatorColor: CupertinoColors.white,
+                  isBackgroundIndicator: false,
+                  borderRadius: 18,
+                  direction: Axis.vertical,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final effect = tester.widget<GlassEffect>(find.byType(GlassEffect));
+    expect(
+      effect.clipExpansion,
+      const EdgeInsets.symmetric(horizontal: 15, vertical: 20),
+    );
+  });
+}


### PR DESCRIPTION
## What

Adds vertical layout support to the fixed-mode `GlassSegmentedControl` via two new optional parameters:

- `direction: Axis.vertical` — lays segments out top-to-bottom. Fractional indicator positioning, jelly expansion, drag velocity/snapping, and gesture recognition all follow the vertical axis.
- `segmentExtent` — main-axis size of each segment in vertical mode (defaults to `height`, producing square segments).

In vertical mode `height` becomes the control's cross-axis width; total height is `(segmentExtent ?? height) × segments.length`.

## What doesn't change

- The horizontal default is untouched — both new parameters are optional and the existing API behaves exactly as before.
- `GlassSegmentedControl.scrollable` stays horizontal-only (pinned in its initializer list), so the new axis can't be half-supported there.

## Implementation notes

- `DraggableIndicatorPhysics.getAlignmentFromGlobalPosition` gains an optional `direction` parameter and maps the drag coordinate/extent along that axis (rubber-band overdrag behaves identically on both axes).
- `SegmentedControlContent` / `AnimatedGlassIndicator` become axis-aware: alignment, indicator sizing, and jelly expansion swap main/cross axes based on `direction`.

## Testing

- `test/widgets/interactive/glass_segmented_control_vertical_test.dart` (new, 279 lines): vertical layout geometry, tap selection, drag selection + snapping, indicator travel, semantics, and horizontal-regression guards. Full suite: 2348 passing, `flutter analyze` clean, `dart format` clean.
- Example: the Interactive page gains an icon-only vertical control for on-device tap/drag/a11y testing.