### PR TITLE
fix(surfaces): honour GlassTab.semanticLabel on .bottom / .inline / .searchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+# Unreleased
+
+## 🐛 Bug Fixes
+
+- **Icon-only tabs announce `'Tab'` on `GlassTabBar.bottom` / `.inline` /
+  `.searchable`** — `GlassTab.semanticLabel` never reached the bar. All three
+  constructors map `GlassTab` onto the internal `GlassBottomBarTab`, which had
+  no `semanticLabel` field, so the value was dropped before
+  `BottomBarTabItem` ran and its `label: tab.label ?? 'Tab'` fell through to
+  the untranslated `'Tab'` fallback. Because the icon subtree is wrapped in
+  `ExcludeSemantics`, a caller could not inject a name through the icon
+  either, which left icon-only tabs — a supported configuration — with no way
+  to be named at all. `GlassBottomBarTab` now carries `semanticLabel`, the
+  three constructors pass it through, and the announcement resolves
+  `semanticLabel ?? label ?? 'Tab'`. `GlassSegmentedControl` already behaved
+  this way; the bottom bars now match it.
+
+- **Tab labels were announced twice** — the label `Text` sat inside the tab's
+  own `Semantics`, so its text merged into the announcement on top of the
+  label already set there: a tab labelled `Home` announced as `Home\nHome`,
+  and `semanticLabel` acted as a prefix rather than the override its docs
+  promise. The label text is now wrapped in `ExcludeSemantics`, mirroring the
+  icon beside it.
+
+---
+
 # 0.22.0
 
 ## ✨ New Features
@@ -49,7 +75,6 @@
   popover now re-measures via `SizeChangedLayoutNotifier` when content grows
   while open, instead of clamping to the height frozen at open time.
   Fixed-`popoverHeight` popovers are unchanged. Thanks to @Ahmadre (#163).
-
 ---
 
 # 0.21.6

--- a/lib/widgets/surfaces/glass_bottom_bar.dart
+++ b/lib/widgets/surfaces/glass_bottom_bar.dart
@@ -707,12 +707,24 @@ class GlassBottomBarTab {
     this.label,
     required this.icon,
     this.activeIcon,
+    this.semanticLabel,
     this.glowColor,
     this.thickness,
   });
 
   /// Label text displayed below the icon.
   final String? label;
+
+  /// Overrides the accessibility announcement for this tab.
+  ///
+  /// Falls back to [label], then to `'Tab'`. Set this when the tab renders
+  /// without a [label] — an icon-only tab has nothing else to announce, so
+  /// without it screen readers read the untranslated `'Tab'` fallback.
+  ///
+  /// Also carries [GlassTab.semanticLabel] through [GlassTabBar.bottom],
+  /// [GlassTabBar.inline], and [GlassTabBar.searchable], which build on this
+  /// type internally.
+  final String? semanticLabel;
 
   /// Widget displayed when the tab is not selected.
   ///

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -832,6 +832,7 @@ class _GlassTabBarState extends State<GlassTabBar> {
               icon: t.icon ?? const SizedBox.shrink(),
               label: t.label,
               activeIcon: t.activeIcon,
+              semanticLabel: t.semanticLabel,
               glowColor: t.glowColor,
               thickness: t.thickness,
             ))
@@ -899,6 +900,7 @@ class _GlassTabBarState extends State<GlassTabBar> {
               icon: t.icon ?? const SizedBox.shrink(),
               label: t.label,
               activeIcon: t.activeIcon,
+              semanticLabel: t.semanticLabel,
               glowColor: t.glowColor,
               thickness: t.thickness,
             ))
@@ -962,6 +964,7 @@ class _GlassTabBarState extends State<GlassTabBar> {
               icon: t.icon ?? const SizedBox.shrink(),
               label: t.label,
               activeIcon: t.activeIcon,
+              semanticLabel: t.semanticLabel,
               glowColor: t.glowColor,
               thickness: t.thickness,
             ))

--- a/lib/widgets/surfaces/shared/tab_bar_bottom_internal.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_bottom_internal.dart
@@ -233,7 +233,10 @@ class BottomBarTabItem extends StatelessWidget {
       child: Semantics(
         button: true,
         selected: selected,
-        label: tab.label ?? 'Tab',
+        // An icon-only tab has no label to announce, so semanticLabel is the
+        // caller's only way to name it — the 'Tab' fallback is a last resort,
+        // not a name.
+        label: tab.semanticLabel ?? tab.label ?? 'Tab',
         child: SizedBox.expand(
           child: FittedBox(
             fit: BoxFit.scaleDown,
@@ -308,12 +311,18 @@ class BottomBarTabItem extends StatelessWidget {
                     ),
                   ),
                 if (tab.label != null)
-                  Text(
-                    tab.label!,
-                    maxLines: 1,
-                    textAlign: TextAlign.center,
-                    overflow: TextOverflow.ellipsis,
-                    style: resolvedLabelStyle,
+                  // The enclosing Semantics already announces the tab, so the
+                  // label text would otherwise be merged in a second time —
+                  // announcing 'Home' as 'Home\nHome', and demoting
+                  // semanticLabel from an override to a prefix.
+                  ExcludeSemantics(
+                    child: Text(
+                      tab.label!,
+                      maxLines: 1,
+                      textAlign: TextAlign.center,
+                      overflow: TextOverflow.ellipsis,
+                      style: resolvedLabelStyle,
+                    ),
                   ),
               ],
             ),

--- a/test/widgets/surfaces/tab_bar_semantic_label_test.dart
+++ b/test/widgets/surfaces/tab_bar_semantic_label_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+import '../../shared/test_helpers.dart';
+
+/// Accessibility naming for the bars that render tabs through
+/// `BottomBarTabItem` — [GlassTabBar.bottom], [GlassTabBar.inline],
+/// [GlassTabBar.searchable] and the deprecated [GlassBottomBar].
+///
+/// An icon-only tab has no label to announce, so [GlassTab.semanticLabel] is
+/// the caller's only way to name it.
+///
+/// These bars paint an unselected row plus a selected-styled row that the
+/// indicator clips, and the second row only covers the tabs the indicator
+/// currently touches. A tab therefore yields one or two semantics nodes
+/// depending on where the indicator sits, so these expectations assert which
+/// labels reach the tree rather than how many nodes carry them.
+void main() {
+  const iconOnlyTabs = [
+    GlassTab(icon: Icon(CupertinoIcons.home), semanticLabel: 'Home'),
+    GlassTab(icon: Icon(CupertinoIcons.search), semanticLabel: 'Search'),
+    GlassTab(icon: Icon(CupertinoIcons.person), semanticLabel: 'Profile'),
+  ];
+
+  group('GlassTabBar.bottom semantics', () {
+    testWidgets('icon-only tabs announce their semanticLabel', (tester) async {
+      final semantics = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassTabBar.bottom(
+            tabs: iconOnlyTabs,
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            maskingQuality: MaskingQuality.off,
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Home'), findsWidgets);
+      expect(find.bySemanticsLabel('Search'), findsWidgets);
+      expect(find.bySemanticsLabel('Profile'), findsWidgets);
+      expect(find.bySemanticsLabel('Tab'), findsNothing);
+
+      semantics.dispose();
+    });
+
+    testWidgets('semanticLabel replaces the label in the announcement', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassTabBar.bottom(
+            tabs: const [
+              GlassTab(
+                icon: Icon(CupertinoIcons.home),
+                label: 'Home',
+                semanticLabel: 'Home, first of two tabs',
+              ),
+              GlassTab(icon: Icon(CupertinoIcons.search), label: 'Search'),
+            ],
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            maskingQuality: MaskingQuality.off,
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Home, first of two tabs'), findsWidgets);
+      // Replaced, not prefixed: the label text is not announced as well.
+      expect(find.bySemanticsLabel('Home'), findsNothing);
+      // The visible label still renders; only the announcement changes.
+      expect(find.text('Home'), findsWidgets);
+
+      semantics.dispose();
+    });
+
+    testWidgets('a label-only tab announces its label exactly once', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassTabBar.bottom(
+            tabs: const [
+              GlassTab(icon: Icon(CupertinoIcons.home), label: 'Home'),
+              GlassTab(icon: Icon(CupertinoIcons.search), label: 'Search'),
+            ],
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            maskingQuality: MaskingQuality.off,
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Home'), findsWidgets);
+      expect(find.bySemanticsLabel('Search'), findsWidgets);
+
+      semantics.dispose();
+    });
+
+    testWidgets('a tab with neither keeps the Tab fallback', (tester) async {
+      final semantics = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassTabBar.bottom(
+            tabs: const [
+              GlassTab(icon: Icon(CupertinoIcons.home)),
+              GlassTab(icon: Icon(CupertinoIcons.search)),
+            ],
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            maskingQuality: MaskingQuality.off,
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Tab'), findsWidgets);
+
+      semantics.dispose();
+    });
+  });
+
+  group('GlassTabBar.inline semantics', () {
+    testWidgets('icon-only tabs announce their semanticLabel', (tester) async {
+      final semantics = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassTabBar.inline(
+            tabs: iconOnlyTabs,
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            maskingQuality: MaskingQuality.off,
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Home'), findsWidgets);
+      expect(find.bySemanticsLabel('Profile'), findsWidgets);
+      expect(find.bySemanticsLabel('Tab'), findsNothing);
+
+      semantics.dispose();
+    });
+  });
+
+  group('GlassTabBar.searchable semantics', () {
+    testWidgets('icon-only tabs announce their semanticLabel', (tester) async {
+      final semantics = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassTabBar.searchable(
+            tabs: iconOnlyTabs,
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            maskingQuality: MaskingQuality.off,
+            searchConfig: GlassSearchBarConfig(onSearchToggle: (_) {}),
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Home'), findsWidgets);
+      expect(find.bySemanticsLabel('Profile'), findsWidgets);
+      expect(find.bySemanticsLabel('Tab'), findsNothing);
+
+      semantics.dispose();
+    });
+  });
+
+  group('GlassBottomBar semantics', () {
+    testWidgets('icon-only tabs announce their semanticLabel', (tester) async {
+      final semantics = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassBottomBar(
+            tabs: const [
+              GlassBottomBarTab(
+                icon: Icon(CupertinoIcons.home),
+                semanticLabel: 'Home',
+              ),
+              GlassBottomBarTab(
+                icon: Icon(CupertinoIcons.search),
+                semanticLabel: 'Search',
+              ),
+            ],
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            maskingQuality: MaskingQuality.off,
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Home'), findsWidgets);
+      expect(find.bySemanticsLabel('Search'), findsWidgets);
+      expect(find.bySemanticsLabel('Tab'), findsNothing);
+
+      semantics.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## What

`GlassTab.semanticLabel` never reaches `GlassTabBar.bottom`, `.inline` or `.searchable`, so an icon-only tab announces the untranslated `'Tab'` fallback with no way for the caller to name it.

All three constructors map `GlassTab` onto the internal `GlassBottomBarTab` (`glass_tab_bar.dart:831 / 898 / 961). That type has no `semanticLabel` field, so the value is dropped before `BottomBarTabItem` runs and its `label: tab.label ?? 'Tab'` (`tab_bar_bottom_internal.dart:236`) falls through to `'Tab'`.

Icon-only tabs are a supported configuration — `BottomBarTabItem` only renders label text `if (tab.label != null)` — but they have no label to announce, and the icon subtree sits inside `ExcludeSemantics`, so a caller cannot inject a name through the icon either. The result is a tab bar whose buttons are all named `'Tab'`. `GlassSegmentedControl` already resolves `tab.semanticLabel ?? tab.label` (`scrollable_segment_content.dart:923`, `segmented_control_internal.dart:365`), so the two families disagree today.

The fix carries the field through:

- `GlassBottomBarTab` gains `semanticLabel`
- `.bottom` / `.inline` / `.searchable` pass it through the mapping
- `BottomBarTabItem` announces `semanticLabel ?? label ?? 'Tab'`

It also wraps the label `Text` in `ExcludeSemantics`. The text sat inside the tab's own `Semantics`, so it merged into the announcement on top of the label already set there — a tab labelled `Home` announced as `Home\nHome`, and `semanticLabel` would have prefixed the announcement rather than overridden it as its docs promise. The icon beside it is already excluded for exactly this reason.

## What doesn't change

- `'Tab'` is still the last-resort fallback when a tab sets neither field.
- A tab that sets only `label` still announces that label — once now, instead of twice.
- Visible layout is untouched: `ExcludeSemantics` hides the text from the semantics tree, not from the screen. `find.text` still finds it.
- `GlassSegmentedControl` is not touched; it already behaved this way.

## Implementation notes

`semanticLabel` is added to `GlassBottomBarTab` even though it is deprecated, because it is still the carrier type the internal bottom-bar engine is typed on. The structural alternative is to type `TabBarBottomLayout` / `BottomBarTabItem` on `GlassTab` directly, which would delete the three lossy mappings and retire the `SizedBox.shrink()` icon sentinel they force. That is a larger change in code you fixed recently in 0.21.3, so I have left it out — happy to open an issue for it if you want it.

Two things I noticed while testing here but did not touch, both pre-existing:

- Each tab yields two semantics nodes: the unselected row plus the selected-styled row the indicator clips. The second row reports `selected: true` for whichever tabs the indicator currently touches, so a screen reader sees duplicate buttons and `selected` does not track the real selection. Excluding the clipped row and moving the real `selected` onto the base row would fix it.
- `GlassTab.semanticLabel` documents no constructor restriction, unlike `glowColor` right below it which documents that it is `.bottom` / `.searchable` only. I read that as the field being intended to work everywhere; tell me if that reading is wrong.

## Testing

- `test/widgets/surfaces/tab_bar_semantic_label_test.dart` (new): covers `.bottom`, `.inline`, `.searchable` and `GlassBottomBar` — icon-only tabs announcing `semanticLabel`, `semanticLabel` replacing rather than prefixing a visible label, label-only tabs, and the `'Tab'` fallback when neither is set.
- Verified the tests fail against the unfixed engine: reverting only the `label:` line in `BottomBarTabItem` turns them red (`Found 0 widgets with a semantics label named "Home"`).
- Full suite green with the CI's exclusions (`golden/`, `renderer/`): 2131 passing. `flutter analyze --fatal-warnings` clean, `dart format` clean.