### PR TITLE
feat(effects): add ProgressiveBlur — graduated backdrop-blur primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,56 @@
+# 0.22.0
+
+## ✨ New feature — `ProgressiveBlur`
+
+- **`ProgressiveBlur`** + **`ProgressiveBlurDirection`** — a *graduated*
+  (progressive) backdrop blur: a clean gaussian frost that is strongest at one
+  edge and eases to perfectly sharp at the opposite edge — the Signal / iOS-26
+  header dissolve. Stack it behind a translucent app bar or bottom bar so
+  scrolling content dissolves beneath the bar instead of ending on a hard
+  cut-off.
+
+  The library's glass surfaces apply a **uniform** blur; this is the missing
+  *progressive* primitive, and it is self-contained — it needs no
+  `LiquidGlassLayer` or glass ancestor, so it can back any bar.
+
+  **How it works.** The naive "blur then fade with a `ShaderMask`" recipe does
+  not work: a `BackdropFilter`'s captured backdrop is not part of an ancestor
+  `ShaderMask`'s layer on Impeller, so the mask reveals nothing. Instead this
+  binds a fragment shader as the `ImageFilter` of a `BackdropFilter` (via
+  `ui.ImageFilter.shader`), so the engine hands the captured backdrop to the
+  shader's sampler and it reads reliably on every backend.
+  `shaders/progressive_blur.frag` is a **separable** gaussian run twice
+  (horizontal then vertical via `ImageFilter.compose`) whose sigma follows the
+  gradient — one backdrop capture + one draw, band-free. Where shader-based
+  `ImageFilter`s are unavailable (Skia / web), it degrades to a uniform
+  `BackdropFilter` so nothing breaks.
+
+  ```dart
+  Stack(
+    children: [
+      const Positioned(
+        top: 0, left: 0, right: 0, height: 96,
+        child: ProgressiveBlur(maxSigma: 20),
+      ),
+      // ... translucent app bar on top ...
+    ],
+  )
+  ```
+
+  - **`maxSigma`** — blur sigma at the strong edge (`0` ⇒ passthrough). Drive it
+    from a scroll offset to fade the blur in/out.
+  - **`direction`** — which edge the blur is strongest at
+    (`topToBottom` / `bottomToTop` / `leftToRight` / `rightToLeft`).
+  - **`falloff`** — gradient gamma.
+
+  The shader is pre-warmed by `LiquidGlassWidgets.initialize()` alongside the
+  other library shaders, so apps get the compiled program for free;
+  `ProgressiveBlur.preload()` remains available (and idempotent) for standalone
+  use without `initialize()`. See
+  [`docs/PROGRESSIVE_BLUR.md`](docs/PROGRESSIVE_BLUR.md).
+
+---
+
 # 0.21.6
 
 ## 🐛 Bug Fixes

--- a/docs/PROGRESSIVE_BLUR.md
+++ b/docs/PROGRESSIVE_BLUR.md
@@ -1,0 +1,128 @@
+# ProgressiveBlur
+
+`ProgressiveBlur` is a **graduated** backdrop blur: a clean gaussian frost that
+is strongest at one edge and eases to perfectly sharp at the opposite edge — the
+Signal / iOS-26 header dissolve. Stack it behind a translucent app bar or bottom
+bar so scrolling content dissolves beneath the bar instead of ending on a hard
+cut-off.
+
+- **Added in:** `0.22.0`
+- **Self-contained:** needs no `LiquidGlassLayer` or glass ancestor.
+
+## Why the library needs it
+
+Every glass surface in this library applies a **uniform** blur — the same sigma
+across the whole surface. That is correct for a glass *panel*, but a bar that
+floats over scrolling content wants the blur to **fade out** away from the bar
+edge, so content doesn't terminate on a visible hard line. That graduated blur
+is the one primitive the library did not provide; `ProgressiveBlur` fills the
+gap.
+
+## The hard part — why the obvious recipe fails
+
+The intuitive approach is "blur the backdrop, then fade the blurred layer with a
+`ShaderMask` (or a gradient-masked `Opacity`)". This does **not** work: a
+`BackdropFilter`'s captured backdrop is not included in an ancestor
+`ShaderMask`'s layer on Impeller, so the mask has nothing to reveal and the bar
+shows no blur at all.
+
+The working approach binds a fragment shader **as the `ImageFilter` of the
+`BackdropFilter` itself**:
+
+```dart
+BackdropFilter(
+  filter: ui.ImageFilter.shader(myFragmentShader), // backdrop is bound to the sampler
+  child: const SizedBox.expand(),
+)
+```
+
+Because the shader *is* the backdrop filter, the engine binds the captured
+backdrop to the shader's `sampler2D`, and it reads reliably on every backend.
+`shaders/progressive_blur.frag` then samples that backdrop with a gaussian whose
+sigma follows the gradient.
+
+### Separable, two-pass gaussian
+
+A single-pass disk blur is `O(σ²)` work per fragment and either streaks (too few
+taps) or turns to noise (importance sampling). Instead the shader is **one axis**
+of a separable gaussian, run twice — horizontal then vertical — via
+`ui.ImageFilter.compose`:
+
+```
+inner = ImageFilter.shader(horizontalPass)
+outer = ImageFilter.shader(verticalPass)
+filter = ImageFilter.compose(outer: outer, inner: inner)
+```
+
+That is `O(σ)` per pass and produces a clean 2-D gaussian in one backdrop
+capture + one draw, so the dissolve is band-free.
+
+### Gradient normalisation
+
+The bound texture is the **whole backdrop** (the screen), not the bar's own
+rectangle, so `uSize` is the screen size. To make the gradient run across the
+*bar* rather than the whole screen, the widget passes its own device-pixel
+rectangle (`uRegionOriginPx` / `uRegionSizePx`) into the shader and normalises
+the gradient over that. The GLES backend captures the backdrop y-flipped, which
+the shader corrects under `IMPELLER_TARGET_OPENGLES`.
+
+## Usage
+
+```dart
+Stack(
+  children: [
+    // Graduated blur behind the bar — strong at the top, sharp toward the body.
+    const Positioned(
+      top: 0, left: 0, right: 0, height: 96,
+      child: ProgressiveBlur(maxSigma: 20),
+    ),
+    // ... your translucent app bar on top ...
+  ],
+)
+```
+
+### Fade the blur with scroll
+
+`maxSigma` is just a number — drive it from a scroll offset so the frost only
+appears once content slides under the bar:
+
+```dart
+ProgressiveBlur(
+  maxSigma: (scrollOffset / 40).clamp(0, 1) * 20, // 0 → sharp until you scroll
+)
+```
+
+### Parameters
+
+| Parameter | Default | Meaning |
+| --- | --- | --- |
+| `maxSigma` | `18` | Blur sigma (logical px) at the strong edge. `0` ⇒ no blur (passthrough). |
+| `direction` | `topToBottom` | Which edge the blur is strongest at; it eases to sharp at the opposite edge. `topToBottom` / `bottomToTop` / `leftToRight` / `rightToLeft`. |
+| `falloff` | `1.2` | Gradient gamma. `>1` keeps the blur strong across the strong edge, then eases to sharp near the opposite edge. |
+
+## Shader pre-warming
+
+`progressive_blur.frag` is pre-warmed by `LiquidGlassWidgets.initialize()`
+alongside the other library shaders, so apps that already call `initialize()`
+get the compiled program for free and the first bar paint isn't janky.
+
+If you use `ProgressiveBlur` **without** `initialize()`, call
+`ProgressiveBlur.preload()` once from `main()` after the binding is initialised.
+It is idempotent (compiles once, process-wide) and never throws — on failure the
+widget falls back to a uniform blur.
+
+```dart
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await ProgressiveBlur.preload(); // only needed if you don't call initialize()
+  runApp(const MyApp());
+}
+```
+
+## Graceful degradation
+
+Where shader-based `ImageFilter`s are unavailable — Skia, or the web canvas
+backend (`ui.ImageFilter.isShaderFilterSupported == false`) — or before the
+shader has finished compiling, `ProgressiveBlur` renders a single **uniform**
+`BackdropFilter` at a reduced sigma instead. The graduated look is lost but the
+bar still frosts its backdrop and nothing crashes.

--- a/lib/liquid_glass_setup.dart
+++ b/lib/liquid_glass_setup.dart
@@ -14,6 +14,7 @@ import 'widgets/shared/glass_adaptive_scope.dart';
 import 'widgets/shared/glass_effect.dart';
 import 'widgets/shared/glass_accessibility_scope.dart';
 import 'widgets/shared/lightweight_liquid_glass.dart';
+import 'widgets/effects/progressive_blur.dart';
 
 /// Entry point and configuration for the Liquid Glass Widgets library.
 ///
@@ -109,6 +110,7 @@ class LiquidGlassWidgets {
   /// | `interactive_indicator.frag` | Custom refraction effect |
   /// | `liquid_glass_geometry_blended.frag` | Geometry / SDF pass |
   /// | `liquid_glass_final_render.frag` | Final composite pass |
+  /// | `progressive_blur.frag` | Graduated backdrop blur ([ProgressiveBlur]) |
   static Future<void> initialize({
     bool enablePerformanceMonitor = true,
   }) async {
@@ -130,6 +132,10 @@ class LiquidGlassWidgets {
         ShaderKeys.blendedGeometry,
         ShaderKeys.liquidGlassRender,
       ]),
+      // ProgressiveBlur's graduated-blur shader — warmed here too so consumers
+      // never need a separate preload call (it degrades to a uniform blur if the
+      // shader can't load, so this never throws).
+      ProgressiveBlur.preload(),
     ]);
 
     // 2. Schedule Impeller pipeline warm-up after the first frame — zero

--- a/lib/liquid_glass_widgets.dart
+++ b/lib/liquid_glass_widgets.dart
@@ -111,6 +111,8 @@ export 'widgets/overlays/glass_modal_sheet.dart'
         ScrollControllerProvider; // access scroll controller from sheet content
 export 'widgets/overlays/glass_toast.dart';
 export 'widgets/overlays/glass_popover.dart';
+// Widgets - Effects
+export 'widgets/effects/progressive_blur.dart';
 // Widgets - Surfaces
 export 'widgets/surfaces/glass_app_bar.dart';
 export 'widgets/surfaces/glass_large_title.dart';

--- a/lib/widgets/effects/progressive_blur.dart
+++ b/lib/widgets/effects/progressive_blur.dart
@@ -1,0 +1,222 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+/// The edge a [ProgressiveBlur] is *strongest* at; it eases to perfectly sharp
+/// at the opposite edge. Named after the direction the blur travels — e.g.
+/// [topToBottom] is heavy at the top and dissolves downward (the classic
+/// app-bar / status-bar look), [bottomToTop] is heavy at the bottom (e.g. a
+/// bottom bar or a fade above a docked toolbar).
+enum ProgressiveBlurDirection {
+  /// Strong at the top edge, sharp at the bottom.
+  topToBottom,
+
+  /// Strong at the bottom edge, sharp at the top.
+  bottomToTop,
+
+  /// Strong at the left edge, sharp at the right.
+  leftToRight,
+
+  /// Strong at the right edge, sharp at the left.
+  rightToLeft;
+
+  /// The `uDirection` uniform value the shader expects (0 top, 1 bottom, 2 left,
+  /// 3 right = where the blur is strongest).
+  double get _uniform => index.toDouble();
+}
+
+/// A *progressive* (graduated) backdrop blur — the Signal / iOS-26 header look:
+/// a clean gaussian frost that is strongest at one edge and eases to perfectly
+/// sharp at the opposite edge. Stack it behind a translucent app bar so content
+/// dissolves beneath it instead of ending on a hard cut-off.
+///
+/// This is the graduated-blur primitive the rest of the library does not
+/// provide (glass surfaces apply a *uniform* blur). It is self-contained — it
+/// needs no [LiquidGlassLayer] or glass ancestor — so it can back any bar.
+///
+/// ## How it works — a single GPU pass that samples the backdrop
+///
+/// The naive "blur then fade with a ShaderMask" recipe does NOT work: a
+/// [BackdropFilter]'s captured backdrop is not included in an ancestor
+/// [ShaderMask]'s layer on Impeller, so the mask reveals nothing and iOS shows
+/// no blur at all. Instead this uses [ui.ImageFilter.shader]: a fragment shader
+/// runs as the [ui.ImageFilter] of a [BackdropFilter], so the engine binds the
+/// captured backdrop to the shader's sampler — sampling it reliably on every
+/// backend. `shaders/progressive_blur.frag` reads that backdrop with an
+/// importance-sampled gaussian whose sigma follows the gradient (normalised over
+/// the widget's own device-pixel rectangle, since the bound texture is the whole
+/// screen), giving a smooth, band-free dissolve in one backdrop capture + one
+/// draw.
+///
+/// Drive [maxSigma] from a scroll offset to fade the blur in/out (0 → sharp).
+///
+/// ```dart
+/// Stack(
+///   children: [
+///     const Positioned(top: 0, left: 0, right: 0, height: 96,
+///       child: ProgressiveBlur(maxSigma: 20)),
+///     // ... your translucent app bar on top ...
+///   ],
+/// )
+/// ```
+///
+/// Call [preload] once from `main()` (after the binding is initialised) to
+/// pre-compile the shader so the first bar paint already has it.
+class ProgressiveBlur extends StatefulWidget {
+  const ProgressiveBlur({
+    super.key,
+    this.maxSigma = 18,
+    this.direction = ProgressiveBlurDirection.topToBottom,
+    this.falloff = 1.2,
+  });
+
+  /// Blur sigma (logical px) at the strong edge. 0 ⇒ no blur (passthrough).
+  /// Optional — defaults to a moderate 18.
+  final double maxSigma;
+
+  /// Which edge the blur is strongest at (it eases to sharp at the opposite
+  /// edge). Defaults to [ProgressiveBlurDirection.topToBottom].
+  final ProgressiveBlurDirection direction;
+
+  /// Gradient gamma. >1 keeps the blur strong across the strong edge then eases
+  /// to sharp near the opposite edge.
+  final double falloff;
+
+  // ── Shader program: compiled once, process-wide ───────────────────────────
+  static ui.FragmentProgram? _program;
+  static Future<ui.FragmentProgram>? _loading;
+
+  /// Pre-compiles the blur shader so the first bar paint already has it. Safe to
+  /// call repeatedly (compiled once). Call from `main()` after the binding is
+  /// initialized. Never throws — on failure the widget falls back to a uniform
+  /// blur.
+  static Future<void> preload() async {
+    if (_program != null) return;
+    // Package-qualified asset path (this shader ships with the package); the
+    // bare path is the fallback for unit tests where the package prefix may not
+    // resolve.
+    const path = 'packages/liquid_glass_widgets/shaders/progressive_blur.frag';
+    const testPath = 'shaders/progressive_blur.frag';
+    try {
+      _program = await (_loading ??= _loadProgram(path, testPath));
+    } catch (e) {
+      // Graceful degradation: the widget falls back to a uniform blur. (Also the
+      // path taken in unit tests, where compiled shaders aren't bundled.)
+      _loading = null;
+      debugPrint(
+        'progressive_blur.frag load failed, using uniform-blur fallback: $e',
+      );
+    }
+  }
+
+  static Future<ui.FragmentProgram> _loadProgram(
+    String path,
+    String testPath,
+  ) async {
+    try {
+      return await ui.FragmentProgram.fromAsset(path);
+    } catch (_) {
+      return ui.FragmentProgram.fromAsset(testPath);
+    }
+  }
+
+  @override
+  State<ProgressiveBlur> createState() => _ProgressiveBlurState();
+}
+
+class _ProgressiveBlurState extends State<ProgressiveBlur> {
+  // Two instances of the same program: one blurs along X, the other along Y.
+  ui.FragmentShader? _hShader;
+  ui.FragmentShader? _vShader;
+
+  @override
+  void initState() {
+    super.initState();
+    _makeShaders();
+    if (_hShader == null) {
+      // Not pre-compiled yet — load, then rebuild with the shaders.
+      ProgressiveBlur.preload().then((_) {
+        if (mounted) setState(_makeShaders);
+      });
+    }
+  }
+
+  void _makeShaders() {
+    final p = ProgressiveBlur._program;
+    if (p != null && _hShader == null) {
+      _hShader = p.fragmentShader();
+      _vShader = p.fragmentShader();
+    }
+  }
+
+  @override
+  void dispose() {
+    _hShader?.dispose();
+    _vShader?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.maxSigma <= 0) return const SizedBox.expand();
+
+    final h = _hShader;
+    final v = _vShader;
+    // Fallback — the shaders aren't ready yet, or the backend can't run shader
+    // filters (Skia / web: isShaderFilterSupported == false). A single uniform
+    // backdrop blur is a cheap stand-in; the translucent scrim above the bar
+    // hides the harder bottom edge. Web/desktop have the headroom for it.
+    if (h == null || v == null || !ui.ImageFilter.isShaderFilterSupported) {
+      return ClipRect(
+        child: BackdropFilter(
+          filter: ui.ImageFilter.blur(
+            sigmaX: widget.maxSigma * 0.6,
+            sigmaY: widget.maxSigma * 0.6,
+          ),
+          child: const SizedBox.expand(),
+        ),
+      );
+    }
+
+    // The bound texture (and thus uSize, float indices 0,1) is the WHOLE
+    // backdrop, not this widget — so we pass the widget's own device-pixel
+    // rectangle to normalise the gradient over the bar (see the .frag header).
+    // The bar is anchored at the top-left of the backdrop layer (true for top
+    // app bars), so its origin is (0,0); LayoutBuilder gives its size.
+    final dpr = MediaQuery.devicePixelRatioOf(context);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final wPx = constraints.maxWidth * dpr;
+        final hPx = constraints.maxHeight * dpr;
+        void configure(ui.FragmentShader s, double axis) {
+          s
+            ..setFloat(2, widget.maxSigma * dpr)
+            ..setFloat(3, widget.falloff)
+            ..setFloat(4, widget.direction._uniform)
+            ..setFloat(5, axis) // 0 = horizontal, 1 = vertical
+            ..setFloat(6, 0) // region origin x (device px)
+            ..setFloat(7, 0) // region origin y (device px)
+            ..setFloat(8, wPx) // region width (device px)
+            ..setFloat(9, hPx); // region height (device px)
+        }
+
+        configure(h, 0);
+        configure(v, 1);
+
+        // Separable 2-pass: horizontal (inner) then vertical (outer) = a clean
+        // 2-D gaussian.
+        final filter = ui.ImageFilter.compose(
+          outer: ui.ImageFilter.shader(v),
+          inner: ui.ImageFilter.shader(h),
+        );
+
+        return ClipRect(
+          child: BackdropFilter(
+            filter: filter,
+            child: const SizedBox.expand(),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: liquid_glass_widgets
 description: A Flutter UI kit implementing the iOS 26 Liquid Glass design language. Features shader-based glassmorphism, physics-driven jelly animations, and dynamic lighting.
-version: 0.21.6
+version: 0.22.0
 
 
 homepage: https://github.com/sdegenaar/liquid_glass_widgets
@@ -47,3 +47,4 @@ flutter:
     - shaders/interactive_indicator.frag
     - shaders/liquid_glass_geometry_blended.frag
     - shaders/liquid_glass_final_render.frag
+    - shaders/progressive_blur.frag

--- a/shaders/progressive_blur.frag
+++ b/shaders/progressive_blur.frag
@@ -1,0 +1,74 @@
+#version 460 core
+#include <flutter/runtime_effect.glsl>
+// Copyright 2026, Rebar Ahmad. Licensed under the package's MIT License.
+//
+// One axis of a SEPARABLE gaussian, used twice (horizontal then vertical) via
+// ImageFilter.compose to build a full, clean 2-D gaussian in O(σ) work per pass
+// instead of the O(σ²) a single-pass disk needs (a disk either streaks with too
+// few taps or turns to noise with importance sampling — this avoids both).
+//
+// The blur radius follows a gradient (strong at one edge, easing to sharp at the
+// other). The bound texture is the whole backdrop (screen), so the gradient is
+// normalised over the widget's own device-pixel rectangle passed from Dart.
+
+uniform vec2 uSize;          // 0,1  bound-texture size, device px (engine)
+uniform float uMaxSigma;     // 2    sigma at the strong edge, device px
+uniform float uFalloff;      // 3    gradient gamma
+uniform float uDirection;    // 4    strong edge: 0 top,1 bottom,2 left,3 right
+uniform float uAxis;         // 5    blur axis: 0 = X (horizontal), 1 = Y (vertical)
+uniform vec2 uRegionOriginPx;// 6,7  region top-left, device px
+uniform vec2 uRegionSizePx;  // 8,9  region size, device px
+uniform sampler2D uTexture;  //      input (backdrop for pass 1, pass-1 out for pass 2)
+
+out vec4 fragColor;
+
+// Half-kernel taps per side. Taps are placed with a stride that covers ±3σ, and
+// the sampler's bilinear filtering smooths between them — enough for a clean
+// gaussian at the gentle sigmas we use.
+const int kHalf = 48;
+
+void main() {
+  // Gradient sigma from the fragment's position within the region.
+  vec2 rn = clamp(
+      (FlutterFragCoord().xy - uRegionOriginPx) / uRegionSizePx, 0.0, 1.0);
+  float g;
+  if (uDirection < 0.5)      g = rn.y;        // strong TOP
+  else if (uDirection < 1.5) g = 1.0 - rn.y;  // strong BOTTOM
+  else if (uDirection < 2.5) g = rn.x;        // strong LEFT
+  else                       g = 1.0 - rn.x;  // strong RIGHT
+  float sigma = uMaxSigma * pow(1.0 - g, uFalloff);
+
+  // Screen-normalised sampling UV (GLES captures the backdrop y-flipped).
+  vec2 uv = FlutterFragCoord().xy / uSize;
+#ifdef IMPELLER_TARGET_OPENGLES
+  uv.y = 1.0 - uv.y;
+#endif
+
+  if (sigma < 0.5) {
+    fragColor = texture(uTexture, uv);
+    return;
+  }
+
+  // 1px step in uv along the blur axis.
+  vec2 axis = (uAxis < 0.5) ? vec2(1.0 / uSize.x, 0.0) : vec2(0.0, 1.0 / uSize.y);
+  float stride = max(1.0, 3.0 * sigma / float(kHalf)); // device px between taps
+  float inv2s2 = 1.0 / (2.0 * sigma * sigma);
+
+  vec4 acc = texture(uTexture, uv); // centre tap, weight 1
+  float wsum = 1.0;
+  for (int i = 1; i <= kHalf; i++) {
+    float d = float(i) * stride;      // device px offset
+    float w = exp(-d * d * inv2s2);
+    vec2 off = axis * d;              // uv offset
+    vec2 sp = uv + off;
+    vec2 sm = uv - off;
+    // Discard out-of-bounds taps (clamping would smear the edge pixel).
+    float ip = step(0.0, sp.x) * step(sp.x, 1.0) * step(0.0, sp.y) * step(sp.y, 1.0);
+    float im = step(0.0, sm.x) * step(sm.x, 1.0) * step(0.0, sm.y) * step(sm.y, 1.0);
+    acc += texture(uTexture, clamp(sp, 0.0, 1.0)) * (w * ip);
+    acc += texture(uTexture, clamp(sm, 0.0, 1.0)) * (w * im);
+    wsum += w * ip + w * im;
+  }
+
+  fragColor = acc / wsum;
+}

--- a/test/widgets/effects/progressive_blur_test.dart
+++ b/test/widgets/effects/progressive_blur_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+/// Tests for [ProgressiveBlur].
+///
+/// The real graduated blur is a GPU fragment shader, which the headless test
+/// backend does not compile — so `isShaderFilterSupported` is false here and the
+/// widget takes its documented **uniform-blur fallback** (`ClipRect` >
+/// `BackdropFilter`). These tests therefore assert the backend-independent
+/// contract: passthrough at `maxSigma <= 0`, a backdrop filter when blurring,
+/// no glass ancestor required, and an idempotent, non-throwing [preload].
+void main() {
+  Widget host(Widget child) => MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              const Positioned.fill(child: ColoredBox(color: Colors.blue)),
+              Positioned(top: 0, left: 0, right: 0, height: 96, child: child),
+            ],
+          ),
+        ),
+      );
+
+  testWidgets('renders a backdrop filter when blurring', (tester) async {
+    await tester.pumpWidget(host(const ProgressiveBlur(maxSigma: 20)));
+    await tester.pump();
+
+    expect(find.byType(ProgressiveBlur), findsOneWidget);
+    // Either the shader filter or the uniform fallback — both draw through a
+    // single BackdropFilter inside a ClipRect.
+    expect(find.byType(BackdropFilter), findsOneWidget);
+    expect(find.byType(ClipRect), findsWidgets);
+  });
+
+  testWidgets('maxSigma <= 0 is a passthrough (no backdrop filter)',
+      (tester) async {
+    await tester.pumpWidget(host(const ProgressiveBlur(maxSigma: 0)));
+    await tester.pump();
+
+    expect(find.byType(ProgressiveBlur), findsOneWidget);
+    expect(find.byType(BackdropFilter), findsNothing);
+  });
+
+  testWidgets('dropping maxSigma to 0 removes the backdrop filter',
+      (tester) async {
+    await tester.pumpWidget(host(const ProgressiveBlur(maxSigma: 20)));
+    await tester.pump();
+    expect(find.byType(BackdropFilter), findsOneWidget);
+
+    await tester.pumpWidget(host(const ProgressiveBlur(maxSigma: 0)));
+    await tester.pump();
+    expect(find.byType(BackdropFilter), findsNothing);
+  });
+
+  testWidgets('needs no LiquidGlassLayer / glass ancestor', (tester) async {
+    // Deliberately mounted bare — no wrap(), no LiquidGlassLayer.
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 300,
+          height: 96,
+          child: ProgressiveBlur(maxSigma: 16),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(ProgressiveBlur), findsOneWidget);
+  });
+
+  testWidgets('honours the direction without throwing', (tester) async {
+    for (final dir in ProgressiveBlurDirection.values) {
+      await tester.pumpWidget(host(ProgressiveBlur(maxSigma: 18, direction: dir)));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+    }
+    // All four edges are exposed.
+    expect(ProgressiveBlurDirection.values, hasLength(4));
+  });
+
+  test('preload is idempotent and never throws', () async {
+    // Safe to await repeatedly; in tests the shader isn't bundled, so this
+    // exercises the graceful-degradation branch and must still complete.
+    await ProgressiveBlur.preload();
+    await ProgressiveBlur.preload();
+  });
+}


### PR DESCRIPTION
## Important | Merge order

Please merge in this order:
1. #161  -> bumps patch to: 0.21.7
2. #163  -> bumps patch to: 0.21.8
3. (this PR) -> bumps minor to: 0.22.0

> 0.21.7 -> 0.21.8 -> 0.28.0

## Summary / New Component

<img width="1179" height="985" alt="IMG_4075" src="https://github.com/user-attachments/assets/11c335ac-c486-42ae-b76f-a37056bf4826" />

Adds **`ProgressiveBlur`** — a *graduated* (progressive) backdrop blur: a clean
gaussian frost that is strongest at one edge and eases to perfectly sharp at the
opposite edge. It's the Signal / iOS-26 header dissolve — stack it behind a
translucent app bar or bottom bar so scrolling content dissolves beneath the bar
instead of ending on a hard cut-off.

Today the library's glass surfaces apply a **uniform** blur. This is the one
progressive primitive it's missing. `ProgressiveBlur` is self-contained — it
needs no `LiquidGlassLayer` or glass ancestor — so it can back any bar.

```dart
Stack(
  children: [
    const Positioned(
      top: 0, left: 0, right: 0, height: 96,
      child: ProgressiveBlur(maxSigma: 20),
    ),
    // ... your translucent app bar on top ...
  ],
)
```

## Related Issue:

- #160 

## Public API

| Symbol | Notes |
| --- | --- |
| `ProgressiveBlur` | `StatefulWidget`; `maxSigma` (default `18`), `direction` (default `topToBottom`), `falloff` (default `1.2`). |
| `ProgressiveBlurDirection` | `topToBottom` / `bottomToTop` / `leftToRight` / `rightToLeft` — the edge the blur is strongest at. |
| `ProgressiveBlur.preload()` | Static; pre-compiles the shader. Idempotent, never throws. Optional — `initialize()` already warms it. |

`maxSigma: 0` is a passthrough (no blur), so you can drive it straight off a
scroll offset to fade the frost in and out.

## Why the obvious recipe doesn't work (and what this does instead)

The intuitive approach — "blur the backdrop, then fade it out with a
`ShaderMask` / gradient mask" — **fails on Impeller**: a `BackdropFilter`'s
captured backdrop is not part of an ancestor `ShaderMask`'s layer, so the mask
has nothing to reveal and the bar shows no blur at all.

Instead this binds a fragment shader **as the `ImageFilter` of the
`BackdropFilter` itself** (`ui.ImageFilter.shader`), so the engine hands the
captured backdrop to the shader's `sampler2D` and it reads reliably on every
backend. `shaders/progressive_blur.frag` is **one axis of a separable gaussian**,
run twice (horizontal then vertical) via `ui.ImageFilter.compose` — `O(σ)` per
pass, one backdrop capture + one draw, so the dissolve is band-free. The gradient
is normalised over the widget's own device-pixel rectangle (passed as uniforms),
because the bound texture is the whole screen, and the GLES y-flip is corrected
under `IMPELLER_TARGET_OPENGLES`.

Where shader-based `ImageFilter`s are unavailable (Skia / web canvas, or before
the shader finishes compiling), it degrades to a single uniform `BackdropFilter`
so nothing breaks.

## Shader pre-warming

`progressive_blur.frag` is added to `LiquidGlassWidgets.initialize()`'s parallel
shader warm-up, so apps that already call `initialize()` get the compiled program
for free and the first bar paint isn't janky. `ProgressiveBlur.preload()` remains
public and idempotent for apps that use the widget without `initialize()`.

## Tests & docs

- `test/widgets/effects/progressive_blur_test.dart` — backend-independent
  contract: renders a `BackdropFilter` when blurring, passthrough at
  `maxSigma <= 0`, no glass ancestor required, all four directions, and
  `preload()` idempotent + non-throwing. (The headless test backend has no
  compiled shader, so these exercise the uniform-blur fallback path — the same
  path real Skia/web builds take.)
- `docs/PROGRESSIVE_BLUR.md` — rationale, the `ImageFilter.shader` technique, the
  separable two-pass gaussian, usage, scroll-driven fade, and degradation.

## Licensing

The new shader (`shaders/progressive_blur.frag`) is authored by me and
contributed here **under this package's MIT License**, consistent with the rest
of the repo. Its header carries only a copyright/attribution line.

## Versioning

New public widget → **minor** bump to **`0.22.0`**. Fully backwards-compatible;
no existing API changes. `progressive_blur.frag` is registered as a shader asset
in `pubspec.yaml`.

## Notes for review

- Impeller (iOS / Android / macOS) gets the true graduated shader blur; Skia and
  the web canvas backend get the uniform-blur fallback by design.
- Happy to split the `initialize()` pre-warm into a follow-up if you'd rather
  land the widget alone first.
