### PR TITLE
fix(overlays): correct GlassPopover positioning in nested overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+# 0.21.8
+
+## 🐛 Bug Fixes
+
+- **`GlassPopover` drifted off its trigger inside a nested overlay** — the
+  morphing overlay is positioned with absolute, root-relative coordinates (the
+  trigger's `localToGlobal(Offset.zero)`), but its `OverlayPortal` attached to
+  the *nearest* overlay. When that nearest overlay is itself offset from the
+  screen origin — e.g. a `ShellRoute` / nested-`Navigator` content area sitting
+  beside a side rail — its origin is counted twice and the popover appears
+  shifted away from the button that opened it. The portal now targets
+  `OverlayChildLocation.rootOverlay`, which always shares the global coordinate
+  space, so the popover lands on its trigger in every embedding. Top-level usage
+  (no nested overlay) is unaffected.
+
+- **Intrinsic-height `GlassPopover` overflowed when its content grew while open**
+  — with no `popoverHeight`, the popover measured its content once at open time
+  and froze that height. Content that grew afterwards (a row expanding after a
+  toggle, an async list filling in) overflowed the frozen box. The popover now
+  wraps its content in a `SizeChangedLayoutNotifier` and re-measures on the next
+  frame, so it follows the live content height (bounded by the screen) instead of
+  clamping to the open-time measurement. Fixed-`popoverHeight` popovers are
+  unchanged (the caller owns scrolling there).
+
+---
+
 # 0.21.6
 
 ## 🐛 Bug Fixes

--- a/lib/widgets/overlays/shared/glass_popover_internal.dart
+++ b/lib/widgets/overlays/shared/glass_popover_internal.dart
@@ -33,6 +33,32 @@ class _GlassPopoverState extends State<GlassPopover>
   /// Key used to measure the intrinsic height of the content subtree.
   final GlobalKey _contentKey = GlobalKey();
 
+  /// Guards against stacking multiple post-frame re-measure callbacks when the
+  /// live content reports several size changes within one frame.
+  bool _remeasureScheduled = false;
+
+  /// Re-measures the live content after it changed size while the popover is
+  /// open (e.g. a row growing taller after a state toggle) and grows/shrinks
+  /// the popover to match, instead of overflowing the frozen initial height.
+  void _scheduleRemeasure() {
+    if (_remeasureScheduled || !_contentMeasured) return;
+    _remeasureScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _remeasureScheduled = false;
+      if (!mounted || !_contentMeasured) return;
+      final renderBox =
+          _contentKey.currentContext?.findRenderObject() as RenderBox?;
+      if (renderBox == null || !renderBox.hasSize) return;
+      final newHeight = renderBox.size.height;
+      if (_measuredContentHeight != newHeight) {
+        setState(() {
+          _measuredContentHeight = newHeight;
+          _updatePositionAndClamping();
+        });
+      }
+    });
+  }
+
   // ---------------------------------------------------------------------------
   // Alignment helper
   // ---------------------------------------------------------------------------
@@ -220,8 +246,19 @@ class _GlassPopoverState extends State<GlassPopover>
             // ── Overlay portal ─────────────────────────────────────────────
             // OverlayPortal renders in the overlay layer, not in-tree, so it
             // is zero-sized here and does not affect the Stack's dimensions.
+            //
+            // Target the ROOT overlay, not the nearest one. The morph is placed
+            // with absolute, root-relative coordinates (the trigger's
+            // `localToGlobal(Offset.zero)`), so it must render in the overlay
+            // that shares that coordinate space. Rendering into a *nested*
+            // overlay (e.g. a ShellRoute / nested-Navigator content area offset
+            // by a side rail) shifts the popover by that overlay's origin — the
+            // trigger's global position gets double-counted. The root overlay
+            // always coincides with the global coordinate space, so the popover
+            // lands exactly on its trigger in every embedding.
             OverlayPortal(
               controller: _overlayController,
+              overlayLocation: OverlayChildLocation.rootOverlay,
               overlayChildBuilder: _buildMorphingOverlay,
             ),
           ],
@@ -698,9 +735,21 @@ class _GlassPopoverState extends State<GlassPopover>
 
     Widget measuredContent;
     if (widget.popoverHeight == null) {
-      measuredContent = SizedBox(
-        width: widget.popoverWidth,
-        child: content,
+      // Intrinsic-height mode: track live size changes (content growing or
+      // shrinking while open) and re-measure, so the popover follows instead
+      // of overflowing the height frozen at open time.
+      measuredContent = NotificationListener<SizeChangedLayoutNotification>(
+        onNotification: (_) {
+          _scheduleRemeasure();
+          return true;
+        },
+        child: SizeChangedLayoutNotifier(
+          child: SizedBox(
+            key: _contentKey,
+            width: widget.popoverWidth,
+            child: content,
+          ),
+        ),
       );
     } else {
       measuredContent = SizedBox(
@@ -719,8 +768,10 @@ class _GlassPopoverState extends State<GlassPopover>
       minWidth: widget.popoverWidth,
       maxWidth: widget.popoverWidth,
       minHeight: 0,
-      maxHeight:
-          widget.popoverHeight ?? _measuredContentHeight ?? double.infinity,
+      // Intrinsic mode is bounded by the screen (not the frozen measurement)
+      // so the content can re-layout to a new natural height and the
+      // SizeChangedLayoutNotifier above can report it for re-measurement.
+      maxHeight: widget.popoverHeight ?? _getMaxPopoverHeight(),
       child: Opacity(
         opacity: contentOpacity,
         child: Transform.scale(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: liquid_glass_widgets
 description: A Flutter UI kit implementing the iOS 26 Liquid Glass design language. Features shader-based glassmorphism, physics-driven jelly animations, and dynamic lighting.
-version: 0.21.6
+version: 0.21.8
 
 
 homepage: https://github.com/sdegenaar/liquid_glass_widgets

--- a/test/widgets/overlays/glass_popover_positioning_test.dart
+++ b/test/widgets/overlays/glass_popover_positioning_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+/// Regression tests for the two `GlassPopover` positioning fixes:
+///
+/// 1. **Nested-overlay offset** — the morphing overlay is placed with absolute,
+///    root-relative coordinates, so it must render into the *root* overlay.
+///    Rendering into a nearest/nested overlay (e.g. a `ShellRoute` content area
+///    offset by a side rail) double-counts that overlay's origin and the popover
+///    drifts off its trigger.
+/// 2. **Frozen intrinsic height** — in intrinsic-height mode the popover used to
+///    freeze the content height measured at open time; content that grew while
+///    open overflowed. It must now re-measure and follow the live size.
+void main() {
+  group('GlassPopover renders into the root overlay', () {
+    testWidgets('OverlayPortal targets OverlayChildLocation.rootOverlay',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: GlassPopover(
+                trigger:
+                    const SizedBox(width: 50, height: 50, child: Text('Open')),
+                contentBuilder: (context, close) => const Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Text('Body'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final portal = tester.widget<OverlayPortal>(
+        find.descendant(
+          of: find.byType(GlassPopover),
+          matching: find.byType(OverlayPortal),
+        ),
+      );
+
+      expect(
+        portal.overlayLocation,
+        OverlayChildLocation.rootOverlay,
+        reason: 'the absolutely-positioned morph must attach to the root '
+            'overlay so a nested overlay does not double-offset it',
+      );
+    });
+  });
+
+  group('GlassPopover live re-measure (intrinsic height)', () {
+    testWidgets('follows content that grows while open instead of overflowing',
+        (tester) async {
+      final height = ValueNotifier<double>(80);
+      addTearDown(height.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: GlassPopover(
+                // Intrinsic height (no popoverHeight) — the mode the fix targets.
+                popoverWidth: 220,
+                trigger:
+                    const SizedBox(width: 50, height: 50, child: Text('Open')),
+                contentBuilder: (context, close) =>
+                    ValueListenableBuilder<double>(
+                  valueListenable: height,
+                  builder: (context, h, _) => SizedBox(
+                    key: const Key('popover-body'),
+                    height: h,
+                    child: const Text('Body'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      final body = find.byKey(const Key('popover-body'));
+      expect(body, findsOneWidget);
+      expect(tester.getSize(body).height, 80);
+
+      // Grow the content while the popover is open.
+      height.value = 260;
+      await tester.pump(); // content rebuilds → SizeChangedLayoutNotifier fires
+      await tester.pumpAndSettle(); // flush the post-frame re-measure
+
+      // No overflow, and the popover followed the taller content.
+      expect(tester.takeException(), isNull);
+      expect(
+        tester.getSize(body).height,
+        260,
+        reason: 'the popover must re-measure and grow to the live content '
+            'height instead of clamping to the height frozen at open time',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Important | Merge order

Please merge in this order:
1. #161  -> bumps patch to: 0.21.7
2. (This PR) -> bumps patch to: 0.21.8
3. #162 -> bumps minor to: 0.22.0

> 0.21.7 -> 0.21.8 -> 0.28.0

## Summary / Fix

Two `GlassPopover` positioning bugs, both in how the morphing overlay is placed:

1. **The popover drifts off its trigger when there's a nested overlay** between
   it and the screen.
5. **An intrinsic-height popover overflows when its content grows while open.**

Both are backwards-compatible fixes — no API change. Regression tests included
for each.

## 1 · Nested-overlay offset → render into the **root** overlay

The morphing overlay is positioned with **absolute, root-relative coordinates**
— it reads the trigger's `localToGlobal(Offset.zero)` and places the morph at
that global point. But the `OverlayPortal` attached to the **nearest** overlay
(`OverlayChildLocation.nearestOverlay`, the default).

When the nearest overlay is itself offset from the screen origin — e.g. a
`ShellRoute` / nested-`Navigator` content area sitting beside a persistent side
rail — that overlay's origin gets counted **twice**: once by the global trigger
coordinate, once by the overlay's own offset. The popover lands shifted away
from the button that opened it (by the width of the rail, in the classic case).

**Fix:** target the root overlay, which always coincides with the global
coordinate space the morph is computed in:

```dart
OverlayPortal(
  controller: _overlayController,
  overlayLocation: OverlayChildLocation.rootOverlay, // was: nearest (default)
  overlayChildBuilder: _buildMorphingOverlay,
)
```

Top-level usage (no nested overlay) is unaffected — there the nearest overlay
*is* the root overlay.

## 2 · Intrinsic-height popover froze its content height

With no `popoverHeight`, the popover measures its content once at open time and
uses that as `maxHeight`. Content that grows **after** open — a row expanding
after a toggle, an async list filling in, a validation message appearing —
overflows the frozen box.

**Fix:** wrap the intrinsic-mode content in a `SizeChangedLayoutNotifier` and
re-measure on the next frame when it reports a size change, so the popover
follows the live content height (bounded by the screen) instead of clamping to
the open-time measurement:

```dart
NotificationListener<SizeChangedLayoutNotification>(
  onNotification: (_) { _scheduleRemeasure(); return true; },
  child: SizeChangedLayoutNotifier(child: SizedBox(key: _contentKey, ...)),
)
```

`_scheduleRemeasure()` coalesces to one post-frame callback, re-reads the
content `RenderBox`, and `setState`s the new height only when it actually
changed. The intrinsic `maxHeight` is now the screen-bounded
`_getMaxPopoverHeight()` (already in the file) rather than the frozen
measurement, so the content can re-layout to its new natural height for the
notifier to report.

Fixed-`popoverHeight` popovers are untouched — the caller owns scrolling there.

## Tests

`test/widgets/overlays/glass_popover_positioning_test.dart`:

- **root-overlay wiring** — asserts the popover's `OverlayPortal.overlayLocation`
  is `OverlayChildLocation.rootOverlay` (deterministic, no animation).
- **live re-measure** — opens an intrinsic-height popover whose content is 80 px,
  grows it to 260 px while open, and asserts no overflow and that the popover
  followed to 260 px (fails on the pre-fix frozen-height behaviour).

Both pass; the existing `glass_popover_test.dart` suite stays green.

## Versioning

Patch bump → **`0.21.8`**. Pure bug fixes, no API surface change.
