### PR TITLE
Fix GlassSegmentedControl track glass regression

### DIFF
--- a/lib/widgets/interactive/glass_segmented_control.dart
+++ b/lib/widgets/interactive/glass_segmented_control.dart
@@ -417,7 +417,8 @@ class GlassSegmentedControl extends StatefulWidget {
 
   /// Glass effect settings for the segmented-control track.
   ///
-  /// If null, uses optimized defaults:
+  /// If null, resolves from inherited/global/theme settings before falling
+  /// back to optimized defaults:
   /// - thickness: 30
   /// - blur: 3
   /// - chromaticAberration: 0.5

--- a/lib/widgets/interactive/glass_segmented_control.dart
+++ b/lib/widgets/interactive/glass_segmented_control.dart
@@ -587,13 +587,9 @@ class _GlassSegmentedControlState extends State<GlassSegmentedControl> {
     }
 
     // ── Fixed mode: equal-width SegmentedControlContent ───────────────────────
-    final defaultBackerColor =
-        GlassTheme.brightnessOf(context) == Brightness.light
-            ? CupertinoColors.black.withValues(alpha: 0.08)
-            : CupertinoColors.white.withValues(alpha: 0.12);
-    final trackSettings = effectiveSettings.copyWith(
-      backerColor: widget.backgroundColor ?? defaultBackerColor,
-    );
+    final trackSettings = widget.backgroundColor == null
+        ? effectiveSettings
+        : effectiveSettings.copyWith(backerColor: widget.backgroundColor);
 
     // SizedBox sets the fixed control bounds. The glass track and indicator
     // are sibling layers so the track can clip itself without clipping the

--- a/lib/widgets/interactive/glass_segmented_control.dart
+++ b/lib/widgets/interactive/glass_segmented_control.dart
@@ -6,6 +6,7 @@ import '../../src/types/glass_interaction_behavior.dart';
 import '../../theme/glass_theme.dart';
 import '../../theme/glass_theme_helpers.dart';
 import '../../types/glass_quality.dart';
+import '../shared/adaptive_glass.dart';
 import '../shared/adaptive_liquid_glass_layer.dart';
 import '../surfaces/glass_bottom_bar.dart' show MaskingQuality;
 import '../surfaces/glass_tab_bar.dart' show DividerSettings, GlassSegment;
@@ -39,9 +40,10 @@ import 'shared/segmented_control_internal.dart';
 ///    the container's own-layer clip cuts the indicator's jelly overshoot
 ///    during drag animations.
 ///
-/// The track background is already handled by [backgroundColor] — no outer
-/// container is needed. For a standalone glass layer, use [useOwnLayer] on
-/// this widget directly.
+/// The track background is rendered as glass by this widget — no outer
+/// [GlassContainer] or [GlassCard] is needed. [backgroundColor] customizes the
+/// track's dimming backer; the glass material itself resolves from the inherited
+/// theme unless [settings] or [quality] is passed explicitly.
 ///
 
 /// ## Usage
@@ -413,9 +415,9 @@ class GlassSegmentedControl extends StatefulWidget {
   // Glass Effect Properties
   // ===========================================================================
 
-  /// Glass effect settings (only used when [useOwnLayer] is true).
+  /// Glass effect settings for the segmented-control track.
   ///
-  /// If null when [useOwnLayer] is true, uses optimized defaults:
+  /// If null, uses optimized defaults:
   /// - thickness: 30
   /// - blur: 3
   /// - chromaticAberration: 0.5
@@ -423,10 +425,10 @@ class GlassSegmentedControl extends StatefulWidget {
   /// - refractiveIndex: 1.15
   final LiquidGlassSettings? settings;
 
-  /// Whether to create its own layer or use grouped glass.
+  /// Whether the track glass creates its own layer or renders as grouped glass.
   ///
-  /// - `false` (default): Uses grouped glass, must be inside [LiquidGlassLayer]
-  /// - `true`: Creates own layer with [LiquidGlass.withOwnLayer]
+  /// The moving indicator is always rendered as a sibling above the track so
+  /// its jelly expansion is not clipped by the track shape.
   ///
   /// Defaults to false.
   final bool useOwnLayer;
@@ -522,15 +524,18 @@ class _GlassSegmentedControlState extends State<GlassSegmentedControl> {
       widgetQuality: widget.quality,
     );
 
-    final effectiveSettings = widget.settings ??
-        const LiquidGlassSettings(
-          thickness: GlassDefaults.thickness,
-          blur: GlassDefaults.blur,
-          chromaticAberration: GlassDefaults.chromaticAberration,
-          lightIntensity: GlassDefaults.lightIntensity,
-          refractiveIndex: GlassDefaults.refractiveIndex,
-          lightAngle: GlassDefaults.lightAngle,
-        );
+    final effectiveSettings = GlassThemeHelpers.resolveSettings(
+      context,
+      explicit: widget.settings,
+      fallback: const LiquidGlassSettings(
+        thickness: GlassDefaults.thickness,
+        blur: GlassDefaults.blur,
+        chromaticAberration: GlassDefaults.chromaticAberration,
+        lightIntensity: GlassDefaults.lightIntensity,
+        refractiveIndex: GlassDefaults.refractiveIndex,
+        lightAngle: GlassDefaults.lightAngle,
+      ),
+    );
 
     // ── Scrollable mode: 100% mirrors GlassTabBar(isScrollable: true) ────────
     if (widget.isScrollable) {
@@ -582,55 +587,66 @@ class _GlassSegmentedControlState extends State<GlassSegmentedControl> {
     }
 
     // ── Fixed mode: equal-width SegmentedControlContent ───────────────────────
-    final backgroundColor = widget.backgroundColor ??
-        (GlassTheme.brightnessOf(context) == Brightness.light
+    final defaultBackerColor =
+        GlassTheme.brightnessOf(context) == Brightness.light
             ? CupertinoColors.black.withValues(alpha: 0.08)
-            : CupertinoColors.white.withValues(alpha: 0.12));
+            : CupertinoColors.white.withValues(alpha: 0.12);
+    final trackSettings = effectiveSettings.copyWith(
+      backerColor: widget.backgroundColor ?? defaultBackerColor,
+    );
 
-    // SizedBox sets the height without clipping. DecoratedBox paints the
-    // background without enforcing a clip — jelly expansion can overflow freely.
+    // SizedBox sets the fixed control bounds. The glass track and indicator
+    // are sibling layers so the track can clip itself without clipping the
+    // moving indicator's jelly expansion.
     final isVertical = widget.direction == Axis.vertical;
+    final trackShape = LiquidRoundedSuperellipse(
+      borderRadius: widget.borderRadius,
+    );
     final control = SizedBox(
       width: isVertical ? widget.height : null,
       height: isVertical
           ? (widget.segmentExtent ?? widget.height) * widget.segments.length
           : widget.height,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: backgroundColor,
-          borderRadius: BorderRadius.circular(widget.borderRadius),
-        ),
-        child: Padding(
-          padding: widget.padding,
-          child: SegmentedControlContent(
-            segments: widget.segments,
-            direction: widget.direction,
-            selectedIndex: widget.selectedIndex,
-            onSegmentSelected: widget.onSegmentSelected,
-            selectedTextStyle: widget.selectedTextStyle,
-            unselectedTextStyle: widget.unselectedTextStyle,
-            indicatorColor: widget.indicatorColor,
-            indicatorSettings: widget.indicatorSettings,
-            indicatorPinchStrength: widget.indicatorPinchStrength,
-            indicatorExpansion: widget.indicatorExpansion,
-            borderRadius: widget.borderRadius,
-            quality: effectiveQuality,
-            backgroundKey: widget.backgroundKey,
-            interactionBehavior: widget.interactionBehavior,
-            glowColor: widget.glowColor,
-            glowRadius: widget.glowRadius,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned.fill(
+            child: RepaintBoundary(
+              child: AdaptiveGlass(
+                shape: trackShape,
+                settings: trackSettings,
+                quality: effectiveQuality,
+                useOwnLayer: widget.useOwnLayer,
+                clipBehavior: Clip.antiAlias,
+                child: const SizedBox.expand(),
+              ),
+            ),
           ),
-        ),
+          Padding(
+            padding: widget.padding,
+            child: SegmentedControlContent(
+              segments: widget.segments,
+              direction: widget.direction,
+              selectedIndex: widget.selectedIndex,
+              onSegmentSelected: widget.onSegmentSelected,
+              selectedTextStyle: widget.selectedTextStyle,
+              unselectedTextStyle: widget.unselectedTextStyle,
+              indicatorColor: widget.indicatorColor,
+              indicatorSettings: widget.indicatorSettings,
+              indicatorPinchStrength: widget.indicatorPinchStrength,
+              indicatorExpansion: widget.indicatorExpansion,
+              borderRadius: widget.borderRadius,
+              quality: effectiveQuality,
+              backgroundKey: widget.backgroundKey,
+              interactionBehavior: widget.interactionBehavior,
+              glowColor: widget.glowColor,
+              glowRadius: widget.glowRadius,
+            ),
+          ),
+        ],
       ),
     );
 
-    if (widget.useOwnLayer) {
-      return AdaptiveLiquidGlassLayer(
-        settings: effectiveSettings,
-        quality: effectiveQuality,
-        child: control,
-      );
-    }
     return control;
   }
 }

--- a/test/widgets/interactive/glass_segmented_control_test.dart
+++ b/test/widgets/interactive/glass_segmented_control_test.dart
@@ -4,6 +4,18 @@ import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
 
 import '../../shared/test_helpers.dart';
 
+bool _hasAncestor(Element element, Element ancestor) {
+  var found = false;
+  element.visitAncestorElements((candidate) {
+    if (candidate == ancestor) {
+      found = true;
+      return false;
+    }
+    return true;
+  });
+  return found;
+}
+
 void main() {
   group('GlassSegmentedControl', () {
     testWidgets('can be instantiated with required parameters', (tester) async {
@@ -400,6 +412,123 @@ void main() {
         ),
       );
       expect(find.byType(GlassSegmentedControl), findsOneWidget);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Fixed-mode glass track regression
+  // --------------------------------------------------------------------------
+
+  group('GlassSegmentedControl fixed-mode glass track', () {
+    testWidgets('renders a glass track by default', (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassSegmentedControl(
+            segments: const [
+              GlassSegment(label: 'A'),
+              GlassSegment(label: 'B'),
+              GlassSegment(label: 'C'),
+            ],
+            selectedIndex: 0,
+            onSegmentSelected: (_) {},
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final trackFinder = find.descendant(
+        of: find.byType(GlassSegmentedControl),
+        matching: find.byType(AdaptiveGlass),
+      );
+
+      expect(trackFinder, findsOneWidget);
+
+      final track = tester.widget<AdaptiveGlass>(trackFinder);
+      expect(track.useOwnLayer, isFalse);
+      expect(track.quality, GlassQuality.standard);
+      expect(
+        track.shape,
+        const LiquidRoundedSuperellipse(borderRadius: 16),
+      );
+    });
+
+    testWidgets('fixed track resolves theme quality and settings',
+        (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          child: LiquidGlassWidgets.wrap(
+            theme: GlassThemeData.simple(
+              quality: GlassQuality.minimal,
+              blur: 7,
+              thickness: 41,
+              saturation: 1.2,
+            ),
+            child: GlassSegmentedControl(
+              segments: const [
+                GlassSegment(label: 'A'),
+                GlassSegment(label: 'B'),
+              ],
+              selectedIndex: 0,
+              onSegmentSelected: (_) {},
+              backgroundColor: const Color(0x33010203),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final track = tester.widget<AdaptiveGlass>(
+        find.descendant(
+          of: find.byType(GlassSegmentedControl),
+          matching: find.byType(AdaptiveGlass),
+        ),
+      );
+
+      expect(track.quality, GlassQuality.minimal);
+      expect(track.settings.blur, 7);
+      expect(track.settings.thickness, 41);
+      expect(track.settings.saturation, 1.2);
+      expect(track.settings.backerColor, const Color(0x33010203));
+    });
+
+    testWidgets('moving indicator is not a child of the glass track',
+        (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassSegmentedControl(
+            direction: Axis.vertical,
+            height: 44,
+            segmentExtent: 52,
+            segments: const [
+              GlassSegment(label: 'Top'),
+              GlassSegment(label: 'Middle'),
+              GlassSegment(label: 'Bottom'),
+            ],
+            selectedIndex: 1,
+            onSegmentSelected: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final trackElement = tester.element(
+        find.descendant(
+          of: find.byType(GlassSegmentedControl),
+          matching: find.byType(AdaptiveGlass),
+        ),
+      );
+      final indicatorElements = find
+          .descendant(
+            of: find.byType(GlassSegmentedControl),
+            matching: find.byType(AnimatedGlassIndicator),
+          )
+          .evaluate()
+          .toList();
+
+      expect(indicatorElements, isNotEmpty);
+      for (final indicatorElement in indicatorElements) {
+        expect(_hasAncestor(indicatorElement, trackElement), isFalse);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

This fixes the fixed-size `GlassSegmentedControl` track so it renders as actual glass instead of a plain decorated box.

Changes:

- render the segmented-control track through package-owned `AdaptiveGlass`
- resolve track `settings` and `quality` through `GlassThemeHelpers`, so inherited/global/theme settings apply unless explicitly overridden
- preserve `backgroundColor` precedence by mapping it to the track backer color
- keep the animated/moving indicator as a sibling above the track so its jelly expansion is not clipped by the track shape
- add regression tests for the default glass track, inherited minimal/theme settings, and indicator layering

## Root cause

`GlassSegmentedControl` had glass configuration parameters, but the fixed-size track path only used a `DecoratedBox`/color backer for the outer track. As a result, app-level glass settings such as blur/quality could affect the indicator while the track background itself stayed non-glass.

## Validation

- `flutter test test/widgets/interactive/glass_segmented_control_test.dart test/widgets/interactive/glass_segmented_control_vertical_test.dart`
- `flutter analyze`

