### PR TITLE
Fix discrete GlassSlider snapping with non-zero minimum

### DIFF
--- a/lib/widgets/interactive/glass_slider.dart
+++ b/lib/widgets/interactive/glass_slider.dart
@@ -366,7 +366,8 @@ class _GlassSliderState extends State<GlassSlider>
     // Snap to divisions if provided
     if (widget.divisions != null) {
       final stepSize = (widget.max - widget.min) / widget.divisions!;
-      newValue = (newValue / stepSize).round() * stepSize + widget.min;
+      newValue =
+          ((newValue - widget.min) / stepSize).round() * stepSize + widget.min;
       newValue = newValue.clamp(widget.min, widget.max);
 
       // Haptic feedback on division change

--- a/test/widgets/interactive/glass_slider_test.dart
+++ b/test/widgets/interactive/glass_slider_test.dart
@@ -116,6 +116,48 @@ void main() {
       expect(find.byType(GlassSlider), findsOneWidget);
     });
 
+    testWidgets(
+      'discrete slider respects a non-zero minimum while dragging',
+      (tester) async {
+        double? changedValue;
+
+        await tester.pumpWidget(
+          createTestApp(
+            child: AdaptiveLiquidGlassLayer(
+              settings: defaultTestGlassSettings,
+              child: SizedBox(
+                width: 300,
+                child: GlassSlider(
+                  value: 22,
+                  min: 12,
+                  max: 32,
+                  divisions: 20,
+                  onChanged: (value) => changedValue = value,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final finder = find.byType(GlassSlider);
+        final slider = tester.widget<GlassSlider>(finder);
+        final rect = tester.getRect(finder);
+        final usableTrackWidth = rect.width - slider.thumbRadius * 2;
+        final target = Offset(
+          rect.left + slider.thumbRadius + usableTrackWidth * 0.1,
+          rect.center.dy,
+        );
+
+        final gesture = await tester.startGesture(rect.center);
+        await gesture.moveTo(target);
+        await tester.pump();
+
+        expect(changedValue, 14);
+
+        await gesture.up();
+      },
+    );
+
     testWidgets('works in standalone mode', (tester) async {
       await tester.pumpWidget(
         createTestApp(


### PR DESCRIPTION
## Problem

Discrete slider snapping rounds the absolute value and then adds `min` again. With a non-zero minimum, this shifts the snapped range: for example, a 12–32 slider reports 24 at the minimum and reaches 32 too early.

## Fix

Snap the value relative to `min`, then translate the snapped offset back into the slider range.

## Validation

- Added a widget regression test that reproduces 26 instead of 14 before the fix.
- All 13 `GlassSlider` tests pass after the fix.
- Targeted `flutter analyze --fatal-warnings` reports no issues.
