### PR TITLE
Add left placement option for bottom bar extraButton

### DIFF
--- a/lib/widgets/surfaces/glass_bottom_bar.dart
+++ b/lib/widgets/surfaces/glass_bottom_bar.dart
@@ -190,6 +190,7 @@ class GlassBottomBar extends StatelessWidget {
     required this.onTabSelected,
     super.key,
     this.extraButton,
+    this.collapseConfig,
     this.spacing = 8,
     this.horizontalPadding = 20,
     this.verticalPadding = 20,
@@ -234,10 +235,15 @@ class GlassBottomBar extends StatelessWidget {
     this.adaptiveBrightness = false,
     this.onBrightnessChanged,
     this.brightnessOverride,
+    this.scrollController,
   })  : assert(tabs.length > 0, 'GlassBottomBar requires at least one tab'),
         assert(
           selectedIndex >= 0 && selectedIndex < tabs.length,
           'selectedIndex must be between 0 and tabs.length - 1',
+        ),
+        assert(
+          collapseConfig == null || extraButton != null,
+          'GlassBottomBar.collapseConfig requires extraButton.',
         ),
         assert(
           tabWidth == null || tabWidth > 0,
@@ -417,6 +423,17 @@ class GlassBottomBar extends StatelessWidget {
   /// [GlassExtraButtonPlacement.left] to place it before the tab pill.
   /// The button is rendered as a [GlassButton] and inherits the glass settings.
   final GlassTabBarExtraButton? extraButton;
+
+  /// Optional vertical-swipe collapse behavior for the tab pill.
+  ///
+  /// Requires [extraButton]. When null, the bar remains fully expanded.
+  final GlassBottomBarCollapseConfig? collapseConfig;
+
+  /// Optional scroll controller that drives automatic collapse/expand.
+  ///
+  /// When both [collapseConfig] and [extraButton] are provided, upward content
+  /// scrolling collapses the tab pill and downward scrolling expands it.
+  final ScrollController? scrollController;
 
   // ===========================================================================
   // Layout Properties
@@ -633,6 +650,7 @@ class GlassBottomBar extends StatelessWidget {
         selectedIndex: selectedIndex,
         onTabSelected: onTabSelected,
         extraButton: extraButton,
+        collapseConfig: collapseConfig,
         spacing: spacing,
         horizontalPadding: horizontalPadding,
         verticalPadding: verticalPadding,
@@ -676,6 +694,7 @@ class GlassBottomBar extends StatelessWidget {
         adaptiveBrightness: adaptiveBrightness,
         onBrightnessChanged: onBrightnessChanged,
         brightnessOverride: brightnessOverride,
+        scrollController: scrollController,
       );
 }
 
@@ -799,6 +818,52 @@ enum GlassExtraButtonPlacement {
 
   /// Place the button on the physical right side of the bar, after the tabs.
   right,
+}
+
+/// Which way the tab pill retracts when the bottom bar collapses.
+enum GlassBottomBarCollapseDirection {
+  /// Retract toward the configured [GlassTabBarExtraButton].
+  towardsExtraButton,
+
+  /// Retract away from the configured [GlassTabBarExtraButton].
+  awayFromExtraButton,
+}
+
+/// Enables the bottom bar's collapse-to-extra-button interaction.
+///
+/// When provided to [GlassBottomBar] or [GlassTabBar.bottom], an upward swipe
+/// collapses the tab pill toward a single point while keeping the extra button
+/// visible. A downward swipe expands it again, and tapping the collapsed bar
+/// can optionally expand it before the extra action fires.
+class GlassBottomBarCollapseConfig {
+  /// Creates a collapse behavior configuration.
+  const GlassBottomBarCollapseConfig({
+    this.direction = GlassBottomBarCollapseDirection.towardsExtraButton,
+    this.expandOnTap = true,
+    this.animationDuration = const Duration(milliseconds: 220),
+    this.collapsedExtraButtonScale = 0.9,
+  }) : assert(
+          collapsedExtraButtonScale > 0,
+          'collapsedExtraButtonScale must be greater than 0.',
+        );
+
+  /// Which physical edge the tab pill collapses toward.
+  final GlassBottomBarCollapseDirection direction;
+
+  /// Whether tapping the collapsed bar expands it.
+  ///
+  /// Defaults to `true`.
+  final bool expandOnTap;
+
+  /// Duration of the collapse/expand animation.
+  ///
+  /// Defaults to 220 milliseconds.
+  final Duration animationDuration;
+
+  /// Scale applied to the extra button while collapsed.
+  ///
+  /// Defaults to `0.9`.
+  final double collapsedExtraButtonScale;
 }
 
 /// Controls how the tab pill is anchored **horizontally** during the morph

--- a/lib/widgets/surfaces/glass_bottom_bar.dart
+++ b/lib/widgets/surfaces/glass_bottom_bar.dart
@@ -410,9 +410,11 @@ class GlassBottomBar extends StatelessWidget {
   /// your state and switch between pages.
   final ValueChanged<int> onTabSelected;
 
-  /// Optional extra button displayed to the right of the tab bar.
+  /// Optional extra button displayed beside the tab bar.
   ///
   /// Typically used for a primary action like "Create", "Add", or "Compose".
+  /// Defaults to the right side; set [GlassTabBarExtraButton.placement] to
+  /// [GlassExtraButtonPlacement.left] to place it before the tab pill.
   /// The button is rendered as a [GlassButton] and inherits the glass settings.
   final GlassTabBarExtraButton? extraButton;
 
@@ -770,8 +772,8 @@ class GlassBottomBarTab {
 /// Where a [GlassTabBarExtraButton] appears relative to the search pill
 /// in a [GlassSearchableBottomBar].
 ///
-/// Has no effect in [GlassBottomBar], where the extra button always sits
-/// between the tab content and the right edge.
+/// Has no effect in [GlassBottomBar] or [GlassTabBar.bottom], where
+/// [GlassExtraButtonPlacement] controls left/right placement instead.
 enum GlassExtraButtonPosition {
   /// Place the button **before** the search pill — between the tab pill and
   /// the search pill. This is the default and matches the classic iOS
@@ -784,6 +786,19 @@ enum GlassExtraButtonPosition {
   /// The search pill's spring calculations automatically reserve the required
   /// space so no RenderFlex overflow occurs during transitions.
   afterSearch,
+}
+
+/// Where a [GlassTabBarExtraButton] appears in a non-searchable
+/// [GlassBottomBar] or [GlassTabBar.bottom].
+///
+/// Defaults to [GlassExtraButtonPlacement.right], matching the original
+/// bottom-bar layout.
+enum GlassExtraButtonPlacement {
+  /// Place the button on the physical left side of the bar, before the tabs.
+  left,
+
+  /// Place the button on the physical right side of the bar, after the tabs.
+  right,
 }
 
 /// Controls how the tab pill is anchored **horizontally** during the morph
@@ -820,6 +835,7 @@ class GlassTabBarExtraButton {
     required this.label,
     this.iconColor,
     this.size = 64,
+    this.placement = GlassExtraButtonPlacement.right,
     this.position = GlassExtraButtonPosition.beforeSearch,
     this.collapseOnSearchFocus = true,
   });
@@ -842,6 +858,16 @@ class GlassTabBarExtraButton {
   ///
   /// Defaults to 64 to match the default bar height.
   final double size;
+
+  /// Where this button is placed in [GlassBottomBar] and [GlassTabBar.bottom].
+  ///
+  /// Defaults to [GlassExtraButtonPlacement.right], which preserves the
+  /// original bottom-bar behavior. Set to [GlassExtraButtonPlacement.left] to
+  /// place the action before the tab pill.
+  ///
+  /// Has no effect in [GlassSearchableBottomBar], where [position] controls
+  /// placement relative to the search pill.
+  final GlassExtraButtonPlacement placement;
 
   /// Where this button is placed relative to the search pill in a
   /// [GlassSearchableBottomBar].

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -10,6 +10,7 @@ import '../shared/inherited_liquid_glass.dart';
 import 'glass_bottom_bar.dart'
     show
         GlassBottomBar,
+        GlassBottomBarCollapseConfig,
         GlassTabBarExtraButton,
         GlassBottomBarTab,
         GlassTabPillAnchor,
@@ -145,6 +146,8 @@ class GlassTabBar extends StatefulWidget {
     required ValueChanged<int> onTabSelected,
     Key? key,
     GlassTabBarExtraButton? extraButton,
+    GlassBottomBarCollapseConfig? collapseConfig,
+    ScrollController? scrollController,
     double spacing = 8,
     double horizontalPadding = 20,
     double verticalPadding = 20,
@@ -197,6 +200,8 @@ class GlassTabBar extends StatefulWidget {
           selectedIndex: selectedIndex,
           onTabSelected: onTabSelected,
           extraButton: extraButton,
+          collapseConfig: collapseConfig,
+          scrollController: scrollController,
           spacing: spacing,
           horizontalPadding: horizontalPadding,
           verticalPadding: verticalPadding,
@@ -557,6 +562,7 @@ class GlassTabBar extends StatefulWidget {
       this.tabWidth,
       this.indicatorBorderRadius,
       this.extraButton,
+      this.collapseConfig,
       this.interactionBehavior = GlassInteractionBehavior.full,
       this.pressScale = 1.04,
       this.interactionGlowColor,
@@ -582,6 +588,12 @@ class GlassTabBar extends StatefulWidget {
         assert(
           selectedIndex >= 0 && selectedIndex < tabs.length,
           'selectedIndex must be within bounds of tabs list',
+        ),
+        assert(
+          placement != _GlassTabBarPlacement.bottom ||
+              collapseConfig == null ||
+              extraButton != null,
+          'GlassTabBar.bottom collapseConfig requires extraButton.',
         );
 
   /// List of tabs to display.
@@ -741,6 +753,9 @@ class GlassTabBar extends StatefulWidget {
   /// Optional extra action button (bottom/searchable only).
   final GlassTabBarExtraButton? extraButton;
 
+  /// Optional vertical-swipe collapse behavior for [GlassTabBar.bottom].
+  final GlassBottomBarCollapseConfig? collapseConfig;
+
   /// Which physical interaction effects are active. Defaults to [GlassInteractionBehavior.full].
   final GlassInteractionBehavior interactionBehavior;
 
@@ -799,7 +814,7 @@ class GlassTabBar extends StatefulWidget {
   /// Maximum whitening amount. Defaults to 1.0.
   final double whitenAtBottomTarget;
 
-  /// Scroll controller wired for whitening + minimize behaviour.
+  /// Scroll controller wired for searchable whitening and bottom-bar collapse.
   final ScrollController? scrollController;
 
   @override
@@ -832,6 +847,7 @@ class _GlassTabBarState extends State<GlassTabBar> {
       selectedIndex: widget.selectedIndex,
       onTabSelected: widget.onTabSelected,
       extraButton: widget.extraButton,
+      collapseConfig: widget.collapseConfig,
       spacing: widget.spacing,
       horizontalPadding: widget.horizontalPadding,
       verticalPadding: widget.verticalPadding,
@@ -875,6 +891,7 @@ class _GlassTabBarState extends State<GlassTabBar> {
       adaptiveBrightness: widget.adaptiveBrightness,
       onBrightnessChanged: widget.onBrightnessChanged,
       brightnessOverride: widget.brightnessOverride,
+      scrollController: widget.scrollController,
       springDescription: widget.springDescription,
     );
   }

--- a/lib/widgets/surfaces/shared/tab_bar_bottom_layout.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_bottom_layout.dart
@@ -17,7 +17,8 @@ import '../../shared/adaptive_liquid_glass_layer.dart';
 import '../../shared/glass_content_aware_scope.dart';
 import '../../../theme/glass_theme_data.dart';
 import '../../../theme/glass_theme_helpers.dart';
-import '../glass_bottom_bar.dart' show GlassTabBarExtraButton, MaskingQuality;
+import '../glass_bottom_bar.dart'
+    show GlassExtraButtonPlacement, GlassTabBarExtraButton, MaskingQuality;
 import '../glass_tab_bar.dart' show GlassTab;
 import 'tab_bar_bottom_internal.dart'
     show
@@ -248,6 +249,10 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
         ),
         child: LayoutBuilder(
           builder: (context, constraints) {
+            final extraPlacement = widget.extraButton?.placement ??
+                GlassExtraButtonPlacement.right;
+            final extraOnLeft =
+                extraPlacement == GlassExtraButtonPlacement.left;
             final extraBtnW = widget.extraButton != null
                 ? widget.extraButton!.size + widget.spacing
                 : 0.0;
@@ -266,12 +271,13 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
                     clipBehavior: Clip.none,
                     children: [
                       // 1. Optional extra button — painted first (bottom of z-order).
-                      // Pinned to the trailing edge. Painted before the tab pill
-                      // so the jelly indicator's glass effect correctly overlaps and
-                      // refracts the extra button during horizontal stretch physics.
+                      // Painted before the tab pill so the jelly indicator's
+                      // glass effect correctly overlaps and refracts the extra
+                      // button during horizontal stretch physics.
                       if (widget.extraButton != null)
                         Positioned(
-                          right: 0,
+                          left: extraOnLeft ? 0 : null,
+                          right: extraOnLeft ? null : 0,
                           top: 0,
                           bottom: 0,
                           child: SizedBox(
@@ -294,7 +300,7 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
 
                       // 2. Tab pill — painted last (top of z-order).
                       Positioned(
-                        left: 0,
+                        left: extraOnLeft ? extraBtnW : 0,
                         top: 0,
                         width: tabPillW,
                         height: widget.barHeight,

--- a/lib/widgets/surfaces/shared/tab_bar_bottom_layout.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_bottom_layout.dart
@@ -297,8 +297,17 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout>
   }) {
     final collapseTowardsRightEdge =
         _collapseTowardsRightEdge(extraOnLeft: extraOnLeft);
-    if (!collapseTowardsRightEdge) return expandedLeft;
-    return expandedLeft + math.max(0.0, expandedWidth - _kCollapsedTabSize);
+    if (!collapseTowardsRightEdge) {
+      final leftGapToRemove = extraOnLeft ? widget.spacing : 0.0;
+      return math.max(0.0, expandedLeft - leftGapToRemove);
+    }
+
+    final rightGapToRemove = extraOnLeft ? 0.0 : widget.spacing;
+    return expandedLeft +
+        math.max(
+          0.0,
+          expandedWidth + rightGapToRemove - _kCollapsedTabSize,
+        );
   }
 
   bool _collapseTowardsRightEdge({required bool extraOnLeft}) {
@@ -538,100 +547,99 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout>
                           key: _kTabPillKey,
                           child: IgnorePointer(
                             ignoring: _isCollapsed,
-                            child: ClipRect(
-                              child: FittedBox(
-                                fit: BoxFit.fill,
-                                alignment: collapsedContentAlignment,
-                                child: SizedBox(
-                                  width: tabPillW,
-                                  height: widget.barHeight,
-                                  child: TabIndicator(
-                                    quality: effectiveQuality,
-                                    springDescription: widget.springDescription,
-                                    visible: widget.showIndicator,
-                                    tabIndex: selectedIndex,
-                                    tabCount: tabs.length,
-                                    indicatorColor: widget.indicatorColor,
-                                    indicatorSettings: widget.indicatorSettings,
-                                    indicatorPinchStrength:
-                                        widget.indicatorPinchStrength,
-                                    onTabChanged: onTabSelected,
-                                    barHeight: widget.barHeight,
-                                    barBorderRadius: widget.barBorderRadius,
-                                    indicatorBorderRadius:
-                                        widget.indicatorBorderRadius,
-                                    tabPadding: widget.tabPadding,
-                                    backgroundKey: widget.backgroundKey,
-                                    maskingQuality: widget.maskingQuality,
-                                    indicatorExpansion:
-                                        widget.indicatorExpansion,
-                                    platformViewBackdrop:
-                                        widget.platformViewBackdrop,
-                                    interactionGlowColor:
-                                        widget.interactionBehavior.hasGlow
-                                            ? effectiveInteractionGlowColor
-                                            : const Color(0x00000000),
-                                    interactionGlowRadius:
-                                        widget.interactionGlowRadius,
-                                    interactionGlowBlurRadius:
-                                        effectiveGlowBlurRadius,
-                                    interactionGlowSpreadRadius:
-                                        effectiveGlowSpreadRadius,
-                                    interactionGlowOpacity:
-                                        effectiveGlowOpacity,
-                                    interactionScale:
-                                        widget.interactionBehavior.hasScale
-                                            ? widget.pressScale
-                                            : 1.0,
-                                    childUnselected: _ltrTabRow(
-                                      children: [
-                                        for (var i = 0; i < tabs.length; i++)
-                                          Expanded(
-                                            child: BottomBarTabItem(
-                                              tab: tabs[i],
-                                              selected: false,
-                                              selectedIconColor:
-                                                  resolvedSelectedIconColor,
-                                              unselectedIconColor:
-                                                  resolvedUnselectedIconColor,
-                                              selectedLabelColor:
-                                                  widget.selectedLabelColor,
-                                              unselectedLabelColor:
-                                                  widget.unselectedLabelColor,
-                                              selectedLabelStyle:
-                                                  widget.selectedLabelStyle,
-                                              unselectedLabelStyle:
-                                                  widget.unselectedLabelStyle,
-                                              iconSize: widget.iconSize,
-                                              labelFontSize:
-                                                  widget.labelFontSize,
-                                              textStyle: widget.textStyle,
-                                              iconLabelSpacing:
-                                                  widget.iconLabelSpacing,
-                                              glowDuration: widget.glowDuration,
-                                              glowBlurRadius:
-                                                  widget.glowBlurRadius,
-                                              glowSpreadRadius:
-                                                  widget.glowSpreadRadius,
-                                              glowOpacity: widget.glowOpacity,
-                                              semanticsSelected:
-                                                  i == selectedIndex,
-                                              onTap: null,
-                                            ),
-                                          ),
-                                      ],
-                                    ),
-                                    selectedTabBuilder:
-                                        (context, intensity, alignment) =>
-                                            _buildSelectedTabs(
-                                                intensity,
-                                                alignment,
-                                                tabs,
+                            // Keep the morphing pill un-clipped so its press
+                            // interaction can overflow horizontally the same
+                            // way GlassTabBar.searchable does.
+                            child: FittedBox(
+                              fit: BoxFit.fill,
+                              alignment: collapsedContentAlignment,
+                              child: SizedBox(
+                                width: tabPillW,
+                                height: widget.barHeight,
+                                child: TabIndicator(
+                                  quality: effectiveQuality,
+                                  springDescription: widget.springDescription,
+                                  visible: widget.showIndicator,
+                                  tabIndex: selectedIndex,
+                                  tabCount: tabs.length,
+                                  indicatorColor: widget.indicatorColor,
+                                  indicatorSettings: widget.indicatorSettings,
+                                  indicatorPinchStrength:
+                                      widget.indicatorPinchStrength,
+                                  onTabChanged: onTabSelected,
+                                  barHeight: widget.barHeight,
+                                  barBorderRadius: widget.barBorderRadius,
+                                  indicatorBorderRadius:
+                                      widget.indicatorBorderRadius,
+                                  tabPadding: widget.tabPadding,
+                                  backgroundKey: widget.backgroundKey,
+                                  maskingQuality: widget.maskingQuality,
+                                  indicatorExpansion: widget.indicatorExpansion,
+                                  platformViewBackdrop:
+                                      widget.platformViewBackdrop,
+                                  interactionGlowColor:
+                                      widget.interactionBehavior.hasGlow
+                                          ? effectiveInteractionGlowColor
+                                          : const Color(0x00000000),
+                                  interactionGlowRadius:
+                                      widget.interactionGlowRadius,
+                                  interactionGlowBlurRadius:
+                                      effectiveGlowBlurRadius,
+                                  interactionGlowSpreadRadius:
+                                      effectiveGlowSpreadRadius,
+                                  interactionGlowOpacity:
+                                      effectiveGlowOpacity,
+                                  interactionScale:
+                                      widget.interactionBehavior.hasScale
+                                          ? widget.pressScale
+                                          : 1.0,
+                                  childUnselected: _ltrTabRow(
+                                    children: [
+                                      for (var i = 0; i < tabs.length; i++)
+                                        Expanded(
+                                          child: BottomBarTabItem(
+                                            tab: tabs[i],
+                                            selected: false,
+                                            selectedIconColor:
                                                 resolvedSelectedIconColor,
-                                                resolvedUnselectedIconColor),
-                                    magnification: widget.magnification,
-                                    innerBlur: widget.innerBlur,
+                                            unselectedIconColor:
+                                                resolvedUnselectedIconColor,
+                                            selectedLabelColor:
+                                                widget.selectedLabelColor,
+                                            unselectedLabelColor:
+                                                widget.unselectedLabelColor,
+                                            selectedLabelStyle:
+                                                widget.selectedLabelStyle,
+                                            unselectedLabelStyle:
+                                                widget.unselectedLabelStyle,
+                                            iconSize: widget.iconSize,
+                                            labelFontSize: widget.labelFontSize,
+                                            textStyle: widget.textStyle,
+                                            iconLabelSpacing:
+                                                widget.iconLabelSpacing,
+                                            glowDuration: widget.glowDuration,
+                                            glowBlurRadius:
+                                                widget.glowBlurRadius,
+                                            glowSpreadRadius:
+                                                widget.glowSpreadRadius,
+                                            glowOpacity: widget.glowOpacity,
+                                            semanticsSelected:
+                                                i == selectedIndex,
+                                            onTap: null,
+                                          ),
+                                        ),
+                                    ],
                                   ),
+                                  selectedTabBuilder:
+                                      (context, intensity, alignment) =>
+                                          _buildSelectedTabs(
+                                              intensity,
+                                              alignment,
+                                              tabs,
+                                              resolvedSelectedIconColor,
+                                              resolvedUnselectedIconColor),
+                                  magnification: widget.magnification,
+                                  innerBlur: widget.innerBlur,
                                 ),
                               ),
                             ),

--- a/lib/widgets/surfaces/shared/tab_bar_bottom_layout.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_bottom_layout.dart
@@ -7,6 +7,7 @@
 //
 // Do NOT import this file directly — use [GlassTabBar.bottom()] instead.
 
+import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart' show ValueListenable;
@@ -18,7 +19,12 @@ import '../../shared/glass_content_aware_scope.dart';
 import '../../../theme/glass_theme_data.dart';
 import '../../../theme/glass_theme_helpers.dart';
 import '../glass_bottom_bar.dart'
-    show GlassExtraButtonPlacement, GlassTabBarExtraButton, MaskingQuality;
+    show
+        GlassBottomBarCollapseConfig,
+        GlassBottomBarCollapseDirection,
+        GlassExtraButtonPlacement,
+        GlassTabBarExtraButton,
+        MaskingQuality;
 import '../glass_tab_bar.dart' show GlassTab;
 import 'tab_bar_bottom_internal.dart'
     show
@@ -40,6 +46,7 @@ class TabBarBottomLayout extends StatefulWidget {
     required this.onTabSelected,
     super.key,
     this.extraButton,
+    this.collapseConfig,
     this.spacing = 8,
     this.horizontalPadding = 20,
     this.verticalPadding = 20,
@@ -84,6 +91,7 @@ class TabBarBottomLayout extends StatefulWidget {
     this.adaptiveBrightness = false,
     this.onBrightnessChanged,
     this.brightnessOverride,
+    this.scrollController,
     this.springDescription,
   });
 
@@ -93,6 +101,7 @@ class TabBarBottomLayout extends StatefulWidget {
   final int selectedIndex;
   final ValueChanged<int> onTabSelected;
   final GlassTabBarExtraButton? extraButton;
+  final GlassBottomBarCollapseConfig? collapseConfig;
   final double spacing;
   final double horizontalPadding;
   final double verticalPadding;
@@ -136,16 +145,45 @@ class TabBarBottomLayout extends StatefulWidget {
   final bool adaptiveBrightness;
   final ValueChanged<Brightness>? onBrightnessChanged;
   final ValueListenable<Brightness>? brightnessOverride;
+  final ScrollController? scrollController;
   final SpringDescription? springDescription;
 
   @override
   State<TabBarBottomLayout> createState() => _TabBarBottomLayoutState();
 }
 
-class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
+class _TabBarBottomLayoutState extends State<TabBarBottomLayout>
+    with TickerProviderStateMixin {
   // Delegate to the shared const — single source of truth in tab_bar_bottom_internal.dart.
   // Both bars reference kBottomBarGlassDefaults so their glass is guaranteed identical.
   static const _defaultGlassSettings = kBottomBarGlassDefaults;
+  static const _kCollapsedTabSize = 0.01;
+  static const _kCollapseCurve = Curves.easeOutCubic;
+  static const _kExpandCurve = Curves.easeOutBack;
+  static const _kExtraButtonCollapseDelay = 0.08;
+  static const _kSwipeVelocityThreshold = 250.0;
+  static const _kGestureRegionKey = ValueKey<String>(
+    'glass_bottom_bar_gesture_region',
+  );
+  static const _kTabPillKey = ValueKey<String>('glass_bottom_bar_tab_pill');
+  static const _kExtraButtonScaleKey = ValueKey<String>(
+    'glass_bottom_bar_extra_button_scale',
+  );
+  static const _kScrollDeltaThreshold = 12.0;
+
+  bool _isCollapsed = false;
+  double? _lastScrollPixels;
+  late final AnimationController _collapseController;
+
+  bool get _collapseEnabled =>
+      widget.collapseConfig != null && widget.extraButton != null;
+  bool get _scrollCollapseEnabled =>
+      _collapseEnabled && widget.scrollController != null;
+  Duration get _collapseDuration =>
+      widget.collapseConfig?.animationDuration ??
+      const Duration(milliseconds: 220);
+  double get _collapsedExtraButtonScale =>
+      widget.collapseConfig?.collapsedExtraButtonScale ?? 0.9;
 
   /// Lays out the tab [Row] in physical (LTR) order regardless of the ambient
   /// direction, so the first child is on the left — matching the indicator and
@@ -157,6 +195,160 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
     return Directionality(
       textDirection: TextDirection.ltr,
       child: Row(children: children),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _collapseController = AnimationController(
+      vsync: this,
+      value: _isCollapsed ? 1.0 : 0.0,
+      lowerBound: 0.0,
+      upperBound: 1.0,
+    );
+    widget.scrollController?.addListener(_handleScrollChanged);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _syncScrollBaseline());
+  }
+
+  @override
+  void didUpdateWidget(covariant TabBarBottomLayout oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!_collapseEnabled && _isCollapsed) {
+      _isCollapsed = false;
+    }
+    if (oldWidget.scrollController != widget.scrollController) {
+      oldWidget.scrollController?.removeListener(_handleScrollChanged);
+      _lastScrollPixels = null;
+      widget.scrollController?.addListener(_handleScrollChanged);
+      WidgetsBinding.instance
+          .addPostFrameCallback((_) => _syncScrollBaseline());
+    }
+  }
+
+  @override
+  void dispose() {
+    _collapseController.dispose();
+    widget.scrollController?.removeListener(_handleScrollChanged);
+    super.dispose();
+  }
+
+  void _collapse() {
+    if (!_collapseEnabled || _isCollapsed) return;
+    setState(() => _isCollapsed = true);
+    _collapseController.animateTo(
+      1.0,
+      duration: _collapseDuration,
+      curve: Curves.linear,
+    );
+  }
+
+  void _expand() {
+    if (!_isCollapsed) return;
+    setState(() => _isCollapsed = false);
+    _collapseController.animateTo(
+      0.0,
+      duration: _collapseDuration,
+      curve: Curves.linear,
+    );
+  }
+
+  void _handleVerticalDragEnd(DragEndDetails details) {
+    if (!_collapseEnabled) return;
+    final velocity = details.primaryVelocity ?? 0.0;
+    if (velocity <= -_kSwipeVelocityThreshold) {
+      _collapse();
+    } else if (velocity >= _kSwipeVelocityThreshold) {
+      _expand();
+    }
+  }
+
+  void _syncScrollBaseline() {
+    if (!mounted) return;
+    final controller = widget.scrollController;
+    if (controller == null || !controller.hasClients) return;
+    _lastScrollPixels = controller.position.pixels;
+  }
+
+  void _handleScrollChanged() {
+    if (!_scrollCollapseEnabled) return;
+    final controller = widget.scrollController;
+    if (controller == null || !controller.hasClients) return;
+
+    final position = controller.position;
+    final currentPixels = position.pixels;
+    final previousPixels = _lastScrollPixels;
+    _lastScrollPixels = currentPixels;
+
+    if (previousPixels == null || position.outOfRange) return;
+
+    final delta = currentPixels - previousPixels;
+    if (delta >= _kScrollDeltaThreshold) {
+      _collapse();
+    } else if (delta <= -_kScrollDeltaThreshold) {
+      _expand();
+    }
+  }
+
+  double _collapsedTabLeft({
+    required bool extraOnLeft,
+    required double expandedLeft,
+    required double expandedWidth,
+  }) {
+    final collapseTowardsRightEdge =
+        _collapseTowardsRightEdge(extraOnLeft: extraOnLeft);
+    if (!collapseTowardsRightEdge) return expandedLeft;
+    return expandedLeft + math.max(0.0, expandedWidth - _kCollapsedTabSize);
+  }
+
+  bool _collapseTowardsRightEdge({required bool extraOnLeft}) {
+    if (!_collapseEnabled) return false;
+    final direction = widget.collapseConfig!.direction;
+    return extraOnLeft
+        ? direction == GlassBottomBarCollapseDirection.awayFromExtraButton
+        : direction == GlassBottomBarCollapseDirection.towardsExtraButton;
+  }
+
+  Alignment _collapsedContentAlignment({required bool extraOnLeft}) {
+    return _collapseTowardsRightEdge(extraOnLeft: extraOnLeft)
+        ? Alignment.centerRight
+        : Alignment.centerLeft;
+  }
+
+  double _pillCollapseProgress() {
+    final raw = _collapseController.value;
+    if (_isCollapsed) return _kCollapseCurve.transform(raw);
+    final expandedT = _kExpandCurve.transform(1.0 - raw);
+    return 1.0 - expandedT;
+  }
+
+  double _extraButtonCollapseProgress() {
+    final raw = _collapseController.value;
+    if (_isCollapsed) {
+      final delayed = ((raw - _kExtraButtonCollapseDelay) /
+              (1.0 - _kExtraButtonCollapseDelay))
+          .clamp(0.0, 1.0)
+          .toDouble();
+      return _kCollapseCurve.transform(delayed);
+    }
+    final expandedT = _kCollapseCurve.transform(1.0 - raw);
+    return 1.0 - expandedT;
+  }
+
+  GlassTabBarExtraButton _resolvedExtraButtonConfig() {
+    final config = widget.extraButton!;
+    if (!_isCollapsed || !(widget.collapseConfig?.expandOnTap ?? false)) {
+      return config;
+    }
+    return GlassTabBarExtraButton(
+      icon: config.icon,
+      onTap: _expand,
+      label: config.label,
+      iconColor: config.iconColor,
+      size: config.size,
+      placement: config.placement,
+      position: config.position,
+      collapseOnSearchFocus: config.collapseOnSearchFocus,
     );
   }
 
@@ -249,12 +441,15 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
         ),
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final extraPlacement = widget.extraButton?.placement ??
+            final resolvedExtraButton = widget.extraButton != null
+                ? _resolvedExtraButtonConfig()
+                : null;
+            final extraPlacement = resolvedExtraButton?.placement ??
                 GlassExtraButtonPlacement.right;
             final extraOnLeft =
                 extraPlacement == GlassExtraButtonPlacement.left;
-            final extraBtnW = widget.extraButton != null
-                ? widget.extraButton!.size + widget.spacing
+            final extraBtnW = resolvedExtraButton != null
+                ? resolvedExtraButton.size + widget.spacing
                 : 0.0;
             final maxTabW = constraints.maxWidth - extraBtnW;
             final tabPillW = resolveTabPillWidth(
@@ -262,11 +457,41 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
               tabCount: tabs.length,
               maxAvailable: maxTabW,
             );
+            final expandedTabLeft = extraOnLeft ? extraBtnW : 0.0;
+            final collapsedContentAlignment =
+                _collapsedContentAlignment(extraOnLeft: extraOnLeft);
 
-            return SizedBox(
+            final content = SizedBox(
+              key: _kGestureRegionKey,
               height: widget.barHeight,
-              child: Builder(
-                builder: (context) {
+              child: AnimatedBuilder(
+                animation: _collapseController,
+                builder: (context, _) {
+                  final collapsedTabLeft = _collapseEnabled
+                      ? _collapsedTabLeft(
+                          extraOnLeft: extraOnLeft,
+                          expandedLeft: expandedTabLeft,
+                          expandedWidth: tabPillW,
+                        )
+                      : expandedTabLeft;
+                  final pillProgress = _pillCollapseProgress();
+                  final extraProgress = _extraButtonCollapseProgress();
+                  final tabLeft = ui.lerpDouble(
+                      expandedTabLeft, collapsedTabLeft, pillProgress)!;
+                  final tabWidth = ui.lerpDouble(
+                      tabPillW, _kCollapsedTabSize, pillProgress)!;
+                  final tabHeight = ui.lerpDouble(
+                    widget.barHeight,
+                    _kCollapsedTabSize,
+                    pillProgress,
+                  )!;
+                  final tabTop = (widget.barHeight - tabHeight) / 2;
+                  final extraScale = ui.lerpDouble(
+                    1.0,
+                    _collapsedExtraButtonScale,
+                    extraProgress,
+                  )!;
+
                   return Stack(
                     clipBehavior: Clip.none,
                     children: [
@@ -274,114 +499,159 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout> {
                       // Painted before the tab pill so the jelly indicator's
                       // glass effect correctly overlaps and refracts the extra
                       // button during horizontal stretch physics.
-                      if (widget.extraButton != null)
+                      if (resolvedExtraButton != null)
                         Positioned(
                           left: extraOnLeft ? 0 : null,
                           right: extraOnLeft ? null : 0,
                           top: 0,
                           bottom: 0,
                           child: SizedBox(
-                            width: widget.extraButton!.size,
+                            width: resolvedExtraButton.size,
                             height: widget.barHeight,
-                            child: BottomBarExtraBtn(
-                              config: widget.extraButton!,
-                              quality: effectiveQuality,
-                              iconColor: widget.extraButton!.iconColor ??
-                                  resolvedUnselectedIconColor,
-                              enableBlend: widget.enableBlend,
-                              borderRadius: widget.barBorderRadius ==
-                                      TabBarBottomLayout._kDefaultBorderRadius
-                                  ? null
-                                  : widget.barBorderRadius,
-                              platformViewBackdrop: widget.platformViewBackdrop,
+                            child: ScaleTransition(
+                              key: _kExtraButtonScaleKey,
+                              scale: AlwaysStoppedAnimation<double>(extraScale),
+                              child: BottomBarExtraBtn(
+                                config: resolvedExtraButton,
+                                quality: effectiveQuality,
+                                iconColor: resolvedExtraButton.iconColor ??
+                                    resolvedUnselectedIconColor,
+                                enableBlend: widget.enableBlend,
+                                borderRadius: widget.barBorderRadius ==
+                                        TabBarBottomLayout._kDefaultBorderRadius
+                                    ? null
+                                    : widget.barBorderRadius,
+                                platformViewBackdrop:
+                                    widget.platformViewBackdrop,
+                              ),
                             ),
                           ),
                         ),
 
                       // 2. Tab pill — painted last (top of z-order).
                       Positioned(
-                        left: extraOnLeft ? extraBtnW : 0,
-                        top: 0,
-                        width: tabPillW,
-                        height: widget.barHeight,
-                        child: TabIndicator(
-                          quality: effectiveQuality,
-                          springDescription: widget.springDescription,
-                          visible: widget.showIndicator,
-                          tabIndex: selectedIndex,
-                          tabCount: tabs.length,
-                          indicatorColor: widget.indicatorColor,
-                          indicatorSettings: widget.indicatorSettings,
-                          indicatorPinchStrength: widget.indicatorPinchStrength,
-                          onTabChanged: onTabSelected,
-                          barHeight: widget.barHeight,
-                          barBorderRadius: widget.barBorderRadius,
-                          indicatorBorderRadius: widget.indicatorBorderRadius,
-                          tabPadding: widget.tabPadding,
-                          backgroundKey: widget.backgroundKey,
-                          maskingQuality: widget.maskingQuality,
-                          indicatorExpansion: widget.indicatorExpansion,
-                          platformViewBackdrop: widget.platformViewBackdrop,
-                          interactionGlowColor:
-                              widget.interactionBehavior.hasGlow
-                                  ? effectiveInteractionGlowColor
-                                  : const Color(0x00000000),
-                          interactionGlowRadius: widget.interactionGlowRadius,
-                          interactionGlowBlurRadius: effectiveGlowBlurRadius,
-                          interactionGlowSpreadRadius:
-                              effectiveGlowSpreadRadius,
-                          interactionGlowOpacity: effectiveGlowOpacity,
-                          interactionScale: widget.interactionBehavior.hasScale
-                              ? widget.pressScale
-                              : 1.0,
-                          childUnselected: _ltrTabRow(
-                            children: [
-                              for (var i = 0; i < tabs.length; i++)
-                                Expanded(
-                                  child: BottomBarTabItem(
-                                    tab: tabs[i],
-                                    selected: false,
-                                    selectedIconColor:
-                                        resolvedSelectedIconColor,
-                                    unselectedIconColor:
-                                        resolvedUnselectedIconColor,
-                                    selectedLabelColor:
-                                        widget.selectedLabelColor,
-                                    unselectedLabelColor:
-                                        widget.unselectedLabelColor,
-                                    selectedLabelStyle:
-                                        widget.selectedLabelStyle,
-                                    unselectedLabelStyle:
-                                        widget.unselectedLabelStyle,
-                                    iconSize: widget.iconSize,
-                                    labelFontSize: widget.labelFontSize,
-                                    textStyle: widget.textStyle,
-                                    iconLabelSpacing: widget.iconLabelSpacing,
-                                    glowDuration: widget.glowDuration,
-                                    glowBlurRadius: widget.glowBlurRadius,
-                                    glowSpreadRadius: widget.glowSpreadRadius,
-                                    glowOpacity: widget.glowOpacity,
-                                    semanticsSelected: i == selectedIndex,
-                                    onTap: null,
+                        left: tabLeft,
+                        top: tabTop,
+                        width: tabWidth,
+                        height: tabHeight,
+                        child: KeyedSubtree(
+                          key: _kTabPillKey,
+                          child: IgnorePointer(
+                            ignoring: _isCollapsed,
+                            child: ClipRect(
+                              child: FittedBox(
+                                fit: BoxFit.fill,
+                                alignment: collapsedContentAlignment,
+                                child: SizedBox(
+                                  width: tabPillW,
+                                  height: widget.barHeight,
+                                  child: TabIndicator(
+                                    quality: effectiveQuality,
+                                    springDescription: widget.springDescription,
+                                    visible: widget.showIndicator,
+                                    tabIndex: selectedIndex,
+                                    tabCount: tabs.length,
+                                    indicatorColor: widget.indicatorColor,
+                                    indicatorSettings: widget.indicatorSettings,
+                                    indicatorPinchStrength:
+                                        widget.indicatorPinchStrength,
+                                    onTabChanged: onTabSelected,
+                                    barHeight: widget.barHeight,
+                                    barBorderRadius: widget.barBorderRadius,
+                                    indicatorBorderRadius:
+                                        widget.indicatorBorderRadius,
+                                    tabPadding: widget.tabPadding,
+                                    backgroundKey: widget.backgroundKey,
+                                    maskingQuality: widget.maskingQuality,
+                                    indicatorExpansion:
+                                        widget.indicatorExpansion,
+                                    platformViewBackdrop:
+                                        widget.platformViewBackdrop,
+                                    interactionGlowColor:
+                                        widget.interactionBehavior.hasGlow
+                                            ? effectiveInteractionGlowColor
+                                            : const Color(0x00000000),
+                                    interactionGlowRadius:
+                                        widget.interactionGlowRadius,
+                                    interactionGlowBlurRadius:
+                                        effectiveGlowBlurRadius,
+                                    interactionGlowSpreadRadius:
+                                        effectiveGlowSpreadRadius,
+                                    interactionGlowOpacity:
+                                        effectiveGlowOpacity,
+                                    interactionScale:
+                                        widget.interactionBehavior.hasScale
+                                            ? widget.pressScale
+                                            : 1.0,
+                                    childUnselected: _ltrTabRow(
+                                      children: [
+                                        for (var i = 0; i < tabs.length; i++)
+                                          Expanded(
+                                            child: BottomBarTabItem(
+                                              tab: tabs[i],
+                                              selected: false,
+                                              selectedIconColor:
+                                                  resolvedSelectedIconColor,
+                                              unselectedIconColor:
+                                                  resolvedUnselectedIconColor,
+                                              selectedLabelColor:
+                                                  widget.selectedLabelColor,
+                                              unselectedLabelColor:
+                                                  widget.unselectedLabelColor,
+                                              selectedLabelStyle:
+                                                  widget.selectedLabelStyle,
+                                              unselectedLabelStyle:
+                                                  widget.unselectedLabelStyle,
+                                              iconSize: widget.iconSize,
+                                              labelFontSize:
+                                                  widget.labelFontSize,
+                                              textStyle: widget.textStyle,
+                                              iconLabelSpacing:
+                                                  widget.iconLabelSpacing,
+                                              glowDuration: widget.glowDuration,
+                                              glowBlurRadius:
+                                                  widget.glowBlurRadius,
+                                              glowSpreadRadius:
+                                                  widget.glowSpreadRadius,
+                                              glowOpacity: widget.glowOpacity,
+                                              semanticsSelected:
+                                                  i == selectedIndex,
+                                              onTap: null,
+                                            ),
+                                          ),
+                                      ],
+                                    ),
+                                    selectedTabBuilder:
+                                        (context, intensity, alignment) =>
+                                            _buildSelectedTabs(
+                                                intensity,
+                                                alignment,
+                                                tabs,
+                                                resolvedSelectedIconColor,
+                                                resolvedUnselectedIconColor),
+                                    magnification: widget.magnification,
+                                    innerBlur: widget.innerBlur,
                                   ),
                                 ),
-                            ],
+                              ),
+                            ),
                           ),
-                          selectedTabBuilder: (context, intensity, alignment) =>
-                              _buildSelectedTabs(
-                                  intensity,
-                                  alignment,
-                                  tabs,
-                                  resolvedSelectedIconColor,
-                                  resolvedUnselectedIconColor),
-                          magnification: widget.magnification,
-                          innerBlur: widget.innerBlur,
                         ),
                       ),
                     ],
                   );
                 },
               ),
+            );
+            if (!_collapseEnabled) return content;
+            return GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap:
+                  _isCollapsed && (widget.collapseConfig?.expandOnTap ?? false)
+                      ? _expand
+                      : null,
+              onVerticalDragEnd: _handleVerticalDragEnd,
+              child: content,
             );
           },
         ),

--- a/test/widgets/surfaces/glass_bottom_bar_test.dart
+++ b/test/widgets/surfaces/glass_bottom_bar_test.dart
@@ -114,6 +114,32 @@ void main() {
       expect(find.byIcon(CupertinoIcons.add), findsOneWidget);
     });
 
+    testWidgets('places extra button on the left when configured',
+        (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassBottomBar(
+            tabs: testTabs,
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            maskingQuality: MaskingQuality.off,
+            extraButton: GlassTabBarExtraButton(
+              icon: const Icon(CupertinoIcons.add),
+              label: 'Add',
+              onTap: () {},
+              placement: GlassExtraButtonPlacement.left,
+            ),
+          ),
+        ),
+      );
+
+      final addCenter = tester.getCenter(find.byIcon(CupertinoIcons.add));
+      final homeCenter =
+          tester.getCenter(find.byIcon(CupertinoIcons.home).first);
+
+      expect(addCenter.dx, lessThan(homeCenter.dx));
+    });
+
     testWidgets('extra button calls onTap when pressed', (tester) async {
       var tapped = false;
 
@@ -219,6 +245,25 @@ void main() {
         onTap: () {},
       );
       expect(button.position, GlassExtraButtonPosition.beforeSearch);
+    });
+
+    test('placement defaults to right', () {
+      final button = GlassTabBarExtraButton(
+        icon: Icon(CupertinoIcons.add),
+        label: 'Create',
+        onTap: () {},
+      );
+      expect(button.placement, GlassExtraButtonPlacement.right);
+    });
+
+    test('left placement works', () {
+      final button = GlassTabBarExtraButton(
+        icon: Icon(CupertinoIcons.add),
+        label: 'Create',
+        onTap: () {},
+        placement: GlassExtraButtonPlacement.left,
+      );
+      expect(button.placement, GlassExtraButtonPlacement.left);
     });
 
     test('afterSearch position works', () {


### PR DESCRIPTION
## Summary

Adds `GlassExtraButtonPlacement` for non-searchable bottom bars so `GlassTabBarExtraButton` can be placed on either side of `GlassBottomBar` / `GlassTabBar.bottom`.

The default remains `GlassExtraButtonPlacement.right`, preserving existing behavior.

## Changes

- Added `GlassExtraButtonPlacement.left/right`
- Added `placement` to `GlassTabBarExtraButton`
- Updated bottom bar layout to position the extra button on the configured side
- Added tests for the default placement and left-side rendering

## Testing

- `git diff --check`