### PR TITLE
feat(GlassModalSheet)!: compose sheet stops with a `detents` set, folding peek in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+# Unreleased
+
+## ✨ New Features
+
+- **Optional sheet detents** — `GlassModalSheet` (and `.show()`) gained a
+  `detents` set (`Set<GlassSheetDetent>`, mirroring UIKit's sheet detents) plus
+  a `dismissible` flag, to compose which stops a sheet offers:
+  - `{GlassSheetDetent.medium}` → a **half-only glass** sheet that never morphs
+    to the opaque full state (its content still scrolls at the half detent).
+  - `{GlassSheetDetent.large}` → a **full-only opaque** sheet that opens
+    straight to full.
+  - `{GlassSheetDetent.medium, GlassSheetDetent.large}` → the default two-stop
+    sheet.
+  - `dismissible: false` → the sheet rubber-bands at its lowest detent instead
+    of swiping away (the Apple Pay / Sign in with Apple pattern).
+
+  The set must be non-empty (asserted). The peek floor is separate — it stays
+  `enablePeek` (the persistent-mode resting floor, with its own styling).
+
+## 🐛 Bug Fixes
+
+- **`GlassModalSheetController` reattachment** — the controller no longer
+  detaches when its `GlassModalSheet` is swapped under a stable controller
+  (e.g. a `ValueKey` change): the replacement's `initState` runs before the
+  outgoing widget's `dispose`, so the detach is now guarded to only clear the
+  attachment it still owns. Previously this left the controller inert and the
+  sheet un-openable.
+- **Half-only content scrolling** — a sheet's inner scroll view now enables at
+  the sheet's *topmost* detent rather than hardcoding the `full` state, so a
+  half-only sheet scrolls its content correctly.
+
 # 0.24.4
 
 ## 🐛 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,25 @@
     straight to full.
   - `{GlassSheetDetent.medium, GlassSheetDetent.large}` → the default two-stop
     sheet.
+  - `{GlassSheetDetent.small, ...}` → adds the maps-style **peek floor**
+    underneath, so one mechanism now describes every resting stop.
   - `dismissible: false` → the sheet rubber-bands at its lowest detent instead
     of swiping away (the Apple Pay / Sign in with Apple pattern).
 
-  The set must be non-empty (asserted). The peek floor is separate — it stays
-  `enablePeek` (the persistent-mode resting floor, with its own styling).
+  The set must be non-empty (asserted). Style the small detent with the
+  existing `peek*` params (`peekSettings`, `peekWidth`, …), which stay
+  top-level: a `Set` whose members carried per-instance payload would need
+  equality that ignores that payload, or `detents.contains(small)` breaks and
+  two differently-configured smalls could sit in one set.
+
+## ⚠️ Deprecations
+
+- **`GlassModalSheet.enablePeek`** → use `GlassSheetDetent.small` in `detents`.
+  Peek is now a detent like medium and large. `enablePeek` is still honoured
+  and takes precedence over the set when set explicitly, so existing code keeps
+  working unchanged; it will be removed in a future release.
+  `GlassSheetMode.persistent` keeps its peek floor with or without the detent —
+  a persistent sheet is defined by resting rather than dismissing.
 
 ## 🐛 Bug Fixes
 

--- a/example/lib/demos/glass_modal_sheet_demo.dart
+++ b/example/lib/demos/glass_modal_sheet_demo.dart
@@ -652,7 +652,12 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
       context: context,
       quality: widget.currentQuality,
       initialState: GlassSheetState.peek,
-      enablePeek: true,
+      // Peek is a detent now — `small` alongside the two resting heights.
+      detents: const {
+        GlassSheetDetent.small,
+        GlassSheetDetent.medium,
+        GlassSheetDetent.large,
+      },
       peekTopBorderRadius: 46,
       builder: (context) => const BaseScenario(
         title: 'Standard Peek',
@@ -859,7 +864,11 @@ class MapsExperienceScreen extends StatelessWidget {
     return Scaffold(
       body: GlassModalSheetScaffold(
         mode: GlassSheetMode.persistent,
-        enablePeek: true,
+        detents: const {
+          GlassSheetDetent.small,
+          GlassSheetDetent.medium,
+          GlassSheetDetent.large,
+        },
         initialState: GlassSheetState.peek,
         peekSize: 90,
         halfSize: 0.445,

--- a/lib/liquid_glass_widgets.dart
+++ b/lib/liquid_glass_widgets.dart
@@ -103,6 +103,7 @@ export 'widgets/overlays/glass_modal_sheet.dart'
         GlassModalSheet,
         GlassSheetState,
         GlassSheetMode,
+        GlassSheetDetent, // the `detents` set on GlassModalSheet / .show()
         GlassFillTransition,
         GlassModalSheetController,
         GlassModalSheetScaffold, // used directly for maps-style hit-through layouts

--- a/lib/widgets/overlays/glass_modal_sheet.dart
+++ b/lib/widgets/overlays/glass_modal_sheet.dart
@@ -168,17 +168,27 @@ class GlassModalSheet extends StatefulWidget {
   ///
   /// If null, it defaults to false for [GlassSheetMode.dismissible] and true for
   /// [GlassSheetMode.persistent].
+  @Deprecated(
+    'Use GlassSheetDetent.small in `detents` instead. Peek is now a detent '
+    'like medium and large, so one mechanism describes every resting stop. '
+    'Still honoured when set (it wins over `detents`); will be removed in a '
+    'future release.',
+  )
   final bool? enablePeek;
 
   /// The resting detents this sheet offers. Appearance follows the detent:
-  /// [GlassSheetDetent.medium] is content-height glass, [GlassSheetDetent
-  /// .large] is screen-height opaque.
+  /// [GlassSheetDetent.small] is the peek floor, [GlassSheetDetent.medium] is
+  /// content-height glass, [GlassSheetDetent.large] is screen-height opaque.
   ///
-  ///   • `{medium}`         → half-only glass (Apple Pay / Sign in with Apple)
-  ///   • `{large}`          → full-only opaque, opens straight to full (Maps / Music)
-  ///   • `{medium, large}`  → the default two-stop sheet
+  ///   • `{medium}`             → half-only glass (Apple Pay / Sign in with Apple)
+  ///   • `{large}`              → full-only opaque, opens straight to full (Maps / Music)
+  ///   • `{medium, large}`      → the default two-stop sheet
+  ///   • `{small, medium, large}` → adds the maps-style peek floor underneath
   ///
-  /// Must be non-empty. The peek floor is separate — see [enablePeek].
+  /// Must be non-empty. [GlassSheetMode.persistent] keeps its peek floor even
+  /// when [GlassSheetDetent.small] is absent — a persistent sheet is defined by
+  /// resting somewhere instead of dismissing. Style the small detent with the
+  /// `peek*` params ([peekSettings], [peekWidth], …).
   final Set<GlassSheetDetent> detents;
 
   /// Whether a downward drag can dismiss the sheet. When false, a peek-less
@@ -267,8 +277,8 @@ class GlassModalSheet extends StatefulWidget {
     this.peekTopBorderRadius,
     this.peekBottomRadius,
   }) : assert(detents.length > 0,
-            'GlassModalSheet needs at least one detent (peek is a minimized '
-            'floor, not a standalone detent — see enablePeek).');
+            'GlassModalSheet needs at least one detent — add medium and/or large '
+            '(small alone is a floor, not a resting height).');
 
   /// Shows a high-fidelity glass modal sheet.
   static Future<T?> show<T>({
@@ -330,8 +340,8 @@ class GlassModalSheet extends StatefulWidget {
     double? peekBottomRadius,
   }) {
     assert(detents.isNotEmpty,
-        'GlassModalSheet.show() needs at least one detent (peek is a '
-        'minimized floor, not a standalone detent — see enablePeek).');
+        'GlassModalSheet.show() needs at least one detent — add medium '
+        'and/or large (small alone is a floor, not a resting height).');
     assert(() {
       if (mode == GlassSheetMode.persistent &&
           barrierColor == Colors.transparent) {

--- a/lib/widgets/overlays/glass_modal_sheet.dart
+++ b/lib/widgets/overlays/glass_modal_sheet.dart
@@ -170,6 +170,23 @@ class GlassModalSheet extends StatefulWidget {
   /// [GlassSheetMode.persistent].
   final bool? enablePeek;
 
+  /// The resting detents this sheet offers. Appearance follows the detent:
+  /// [GlassSheetDetent.medium] is content-height glass, [GlassSheetDetent
+  /// .large] is screen-height opaque.
+  ///
+  ///   • `{medium}`         → half-only glass (Apple Pay / Sign in with Apple)
+  ///   • `{large}`          → full-only opaque, opens straight to full (Maps / Music)
+  ///   • `{medium, large}`  → the default two-stop sheet
+  ///
+  /// Must be non-empty. The peek floor is separate — see [enablePeek].
+  final Set<GlassSheetDetent> detents;
+
+  /// Whether a downward drag can dismiss the sheet. When false, a peek-less
+  /// sheet rubber-bands at its lowest detent instead of closing on swipe-down
+  /// (guarding against an accidental dismiss — the Apple Pay pattern); close
+  /// it programmatically via the controller. Default: true.
+  final bool dismissible;
+
   // ===========================================================================
   // Drag Indicator Properties
   // ===========================================================================
@@ -242,12 +259,16 @@ class GlassModalSheet extends StatefulWidget {
     this.maintainContentGlass = true,
     this.fullStateContentSettings,
     this.enablePeek,
+    this.detents = const {GlassSheetDetent.medium, GlassSheetDetent.large},
+    this.dismissible = true,
     this.peekHorizontalMargin,
     this.peekBottomMargin,
     this.peekWidth,
     this.peekTopBorderRadius,
     this.peekBottomRadius,
-  });
+  }) : assert(detents.length > 0,
+            'GlassModalSheet needs at least one detent (peek is a minimized '
+            'floor, not a standalone detent — see enablePeek).');
 
   /// Shows a high-fidelity glass modal sheet.
   static Future<T?> show<T>({
@@ -296,6 +317,11 @@ class GlassModalSheet extends StatefulWidget {
     double topFadeHeight = 40.0,
     bool maintainContentGlass = true,
     LiquidGlassSettings? fullStateContentSettings,
+    Set<GlassSheetDetent> detents = const {
+      GlassSheetDetent.medium,
+      GlassSheetDetent.large
+    },
+    bool dismissible = true,
     bool? enablePeek,
     double? peekHorizontalMargin,
     double? peekBottomMargin,
@@ -303,6 +329,9 @@ class GlassModalSheet extends StatefulWidget {
     double? peekTopBorderRadius,
     double? peekBottomRadius,
   }) {
+    assert(detents.isNotEmpty,
+        'GlassModalSheet.show() needs at least one detent (peek is a '
+        'minimized floor, not a standalone detent — see enablePeek).');
     assert(() {
       if (mode == GlassSheetMode.persistent &&
           barrierColor == Colors.transparent) {
@@ -314,6 +343,17 @@ class GlassModalSheet extends StatefulWidget {
       }
       return true;
     }());
+
+    // Fall back to an offered detent if the caller asked to open on one
+    // that isn't in the set (the assert guarantees the set is non-empty).
+    GlassSheetState resolvedInitialState = initialState;
+    if (initialState == GlassSheetState.half &&
+        !detents.contains(GlassSheetDetent.medium)) {
+      resolvedInitialState = GlassSheetState.full;
+    } else if (initialState == GlassSheetState.full &&
+        !detents.contains(GlassSheetDetent.large)) {
+      resolvedInitialState = GlassSheetState.half;
+    }
 
     final effectiveController = controller ?? GlassModalSheetController();
     bool isClosing = false;
@@ -339,7 +379,7 @@ class GlassModalSheet extends StatefulWidget {
           controller: effectiveController,
           halfSize: halfSize,
           fullSize: fullSize,
-          initialState: initialState,
+          initialState: resolvedInitialState,
           fillThreshold: fillThreshold,
           settings: settings,
           expandedColor: expandedColor,
@@ -375,6 +415,8 @@ class GlassModalSheet extends StatefulWidget {
           topFadeHeight: topFadeHeight,
           maintainContentGlass: maintainContentGlass,
           fullStateContentSettings: fullStateContentSettings,
+          detents: detents,
+          dismissible: dismissible,
           enablePeek: enablePeek,
           peekHorizontalMargin: peekHorizontalMargin,
           peekBottomMargin: peekBottomMargin,

--- a/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
@@ -28,6 +28,12 @@ class _SheetLayout extends StatelessWidget {
   final ScrollController scrollController;
   final ValueNotifier<GlassSheetState> currentStateNotifier;
   final double expandProgressValue;
+
+  /// Progress toward the topmost detent; gates inner content scrolling.
+  /// Distinct from [expandProgressValue] (the half→full visual crossfade) so
+  /// a half-only sheet — whose crossfade stays 0 to keep the glass look —
+  /// still scrolls its content once it reaches its max (half) detent.
+  final double contentScrollProgress;
   final Widget child;
   final bool showDragIndicator;
   final Color? dragIndicatorColor;
@@ -69,6 +75,7 @@ class _SheetLayout extends StatelessWidget {
     required this.scrollController,
     required this.currentStateNotifier,
     required this.expandProgressValue,
+    required this.contentScrollProgress,
     required this.child,
     required this.showDragIndicator,
     this.dragIndicatorColor,
@@ -89,7 +96,7 @@ class _SheetLayout extends StatelessWidget {
 
     final contentZone = _SheetContent(
       scrollController: scrollController,
-      isFullScreen: expandProgressValue > 0.95,
+      isFullScreen: contentScrollProgress > 0.95,
       padding: padding,
       child: child,
     );
@@ -141,9 +148,14 @@ class _SheetLayout extends StatelessWidget {
 
             // Compute dynamic glass visibility for current expansion state.
             final bool isFullyExpanded = expandProgressValue > 0.98;
-            final double glassVisibility = isFullyExpanded
-                ? (maintainContentGlass ? 1.0 : 0.0)
-                : (glassOpacity * 5.0).clamp(0.0, 1.0);
+            // Below full, hold the glass at full strength — including on the way
+            // down to dismiss. This previously ramped glassVisibility to 0 over
+            // the last stretch of the collapse (glassOpacity × 5), fading the
+            // sheet's own surface out as it closed; Apple instead keeps the
+            // surface opaque and just slides it off the bottom (only the
+            // background dim fades). See discussions #130 / #156.
+            final double glassVisibility =
+                isFullyExpanded ? (maintainContentGlass ? 1.0 : 0.0) : 1.0;
 
             // Fade glass uniformly via settings rather than an Opacity widget.
             //
@@ -628,6 +640,14 @@ class GlassModalSheetScaffold extends StatelessWidget {
   /// Custom glass settings for content specifically for the 'full' state.
   final LiquidGlassSettings? fullStateContentSettings;
 
+  /// The resting detents offered (medium = half glass, large = full opaque).
+  /// Must be non-empty. Forwarded to the sheet.
+  final Set<GlassSheetDetent> detents;
+
+  /// Whether the sheet can be swiped down to dismiss. When false the sheet
+  /// rubber-bands at its lowest detent instead. Forwarded to the sheet.
+  final bool dismissible;
+
   /// Whether the 'peek' state is enabled.
   final bool? enablePeek;
 
@@ -690,13 +710,17 @@ class GlassModalSheetScaffold extends StatelessWidget {
     this.topFadeHeight = 40.0,
     this.maintainContentGlass = true,
     this.fullStateContentSettings,
+    this.detents = const {GlassSheetDetent.medium, GlassSheetDetent.large},
+    this.dismissible = true,
     this.enablePeek,
     this.peekHorizontalMargin,
     this.peekBottomMargin,
     this.peekWidth,
     this.peekTopBorderRadius,
     this.peekBottomRadius,
-  });
+  }) : assert(detents.length > 0,
+            'GlassModalSheet needs at least one detent (peek is a minimized '
+            'floor, not a standalone detent — see enablePeek).');
 
   @override
   Widget build(BuildContext context) {
@@ -755,6 +779,8 @@ class GlassModalSheetScaffold extends StatelessWidget {
           topFadeHeight: topFadeHeight,
           maintainContentGlass: maintainContentGlass,
           fullStateContentSettings: fullStateContentSettings,
+          detents: detents,
+          dismissible: dismissible,
           enablePeek: enablePeek,
           peekHorizontalMargin: peekHorizontalMargin,
           peekBottomMargin: peekBottomMargin,

--- a/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
@@ -640,7 +640,8 @@ class GlassModalSheetScaffold extends StatelessWidget {
   /// Custom glass settings for content specifically for the 'full' state.
   final LiquidGlassSettings? fullStateContentSettings;
 
-  /// The resting detents offered (medium = half glass, large = full opaque).
+  /// The resting detents offered (small = peek floor, medium = half glass,
+  /// large = full opaque).
   /// Must be non-empty. Forwarded to the sheet.
   final Set<GlassSheetDetent> detents;
 
@@ -719,8 +720,8 @@ class GlassModalSheetScaffold extends StatelessWidget {
     this.peekTopBorderRadius,
     this.peekBottomRadius,
   }) : assert(detents.length > 0,
-            'GlassModalSheet needs at least one detent (peek is a minimized '
-            'floor, not a standalone detent — see enablePeek).');
+            'GlassModalSheet needs at least one detent — add medium and/or '
+            'large (small alone is a floor, not a resting height).');
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
@@ -6,6 +6,21 @@ part of '../glass_modal_sheet.dart';
 
 enum GlassSheetState { hidden, peek, half, full }
 
+/// The resting heights a sheet may stop at, chosen via
+/// [GlassModalSheet.detents]. Mirrors UIKit's sheet detents:
+///
+///   • [medium] — the content-height, translucent-glass stop (Apple Pay /
+///     Sign in with Apple). Maps to [GlassSheetState.half] internally.
+///   • [large]  — the screen-height, opaque stop (Maps / Music). Maps to
+///     [GlassSheetState.full].
+///
+/// A sheet declares any non-empty subset: `{medium}` is half-only glass,
+/// `{large}` is full-only opaque, `{medium, large}` is the default two-stop
+/// sheet. The peek floor is NOT a detent here — it stays [GlassModalSheet
+/// .enablePeek] (it's the persistent-mode resting floor with its own
+/// styling, and folding it in would break that released API).
+enum GlassSheetDetent { medium, large }
+
 enum GlassSheetMode {
   /// Scenario 1: hidden ↔ half ↔ full
   /// Can swipe down from half to hidden. From full → half → hidden.
@@ -77,6 +92,9 @@ class SheetGeometry {
   final double? fullSize;
   final double peekSize;
   final bool enablePeek;
+  final bool enableHalf;
+  final bool enableFull;
+  final bool dismissible;
 
   const SheetGeometry({
     required this.mode,
@@ -84,7 +102,36 @@ class SheetGeometry {
     this.fullSize,
     required this.peekSize,
     this.enablePeek = true,
+    this.enableHalf = true,
+    this.enableFull = true,
+    this.dismissible = true,
   });
+
+  /// The rest states this sheet can occupy, ordered low → high. This is the
+  /// single source of truth for the state machine — snapping, min/max bounds,
+  /// and resistance all derive from it, so a sheet can omit any of peek / half
+  /// / full and the machine simply routes around the missing detent.
+  List<GlassSheetState> get orderedStates {
+    final states = <GlassSheetState>[];
+    // Hidden is a drag target (swipe-to-dismiss) only when the sheet is
+    // dismissible, has no peek floor, and isn't a persistent sheet. A
+    // non-dismissible sheet rubber-bands at its lowest detent instead (the
+    // Apple Pay / Sign in with Apple pattern — no accidental swipe-away).
+    if (dismissible && !enablePeek && mode == GlassSheetMode.dismissible) {
+      states.add(GlassSheetState.hidden);
+    }
+    if (enablePeek) states.add(GlassSheetState.peek);
+    if (enableHalf && halfSize > 0) states.add(GlassSheetState.half);
+    if (enableFull) states.add(GlassSheetState.full);
+    // Guardrail for the invalid all-disabled config (asserted against in the
+    // widget in debug): a sheet must have at least one primary detent, so fall
+    // back to half in release rather than render an un-openable sheet.
+    if (!states.contains(GlassSheetState.half) &&
+        !states.contains(GlassSheetState.full)) {
+      states.add(GlassSheetState.half);
+    }
+    return states;
+  }
 
   static double positionFor(
     GlassSheetState state,
@@ -141,8 +188,8 @@ class SheetGeometry {
     }
   }
 
-  GlassSheetState get minState =>
-      enablePeek ? GlassSheetState.peek : GlassSheetState.hidden;
+  GlassSheetState get minState => orderedStates.first;
+  GlassSheetState get maxState => orderedStates.last;
 
   /// Computes target state based on current position and velocity.
   GlassSheetState resolveTarget(
@@ -150,19 +197,9 @@ class SheetGeometry {
     required double snapThreshold,
     required double velocityThreshold,
   }) {
-    // Build the ordered sequence of available states for the current mode
-    final List<GlassSheetState> states = [];
-    if (!enablePeek && mode == GlassSheetMode.dismissible) {
-      states.add(GlassSheetState.hidden);
-    }
-    if (enablePeek) {
-      states.add(GlassSheetState.peek);
-    }
-    // Skip half state when halfSize is 0 — allows direct full→hidden.
-    if (halfSize > 0) {
-      states.add(GlassSheetState.half);
-    }
-    states.add(GlassSheetState.full);
+    // The ordered rest states for this sheet's config (peek / half / full are
+    // each optional; hidden appears only for a dismissible, peek-less sheet).
+    final states = orderedStates;
 
     final positions = states
         .map((s) => positionForState(s, current.screenSize.height))
@@ -175,7 +212,7 @@ class SheetGeometry {
       for (int i = 0; i < states.length - 1; i++) {
         if (current.position < positions[i + 1] - 0.001) return states[i + 1];
       }
-      return GlassSheetState.full;
+      return states.last;
     }
     if (velocity < -velocityThreshold) {
       // Find the next state below current
@@ -236,15 +273,15 @@ class SheetGeometry {
     required double resistance,
   }) {
     final minPos = positionForState(minState, screenHeight);
-    final fullPos = positionForState(GlassSheetState.full, screenHeight);
+    final maxPos = positionForState(maxState, screenHeight);
 
     if (rawPosition < minPos) {
       final overflow = minPos - rawPosition;
       return minPos - overflow * resistance;
     }
-    if (rawPosition > fullPos) {
-      final overflow = rawPosition - fullPos;
-      return fullPos + overflow * resistance;
+    if (rawPosition > maxPos) {
+      final overflow = rawPosition - maxPos;
+      return maxPos + overflow * resistance;
     }
     return rawPosition;
   }
@@ -258,7 +295,16 @@ class GlassModalSheetController {
   _GlassModalSheetState? _state;
 
   void _attach(_GlassModalSheetState state) => _state = state;
-  void _detach() => _state = null;
+
+  // Guarded: only clear if [state] is still the attached one. During a
+  // widget swap under a shared controller (e.g. a key change), the new
+  // instance's initState → _attach runs BEFORE the old instance's
+  // dispose → _detach; an unguarded clear would then null out the live
+  // attachment and silently break the controller. Mirrors how Flutter's
+  // own ScrollController/RestorableProperty guard reattachment.
+  void _detach(_GlassModalSheetState state) {
+    if (_state == state) _state = null;
+  }
 
   void snapToState(GlassSheetState state,
       {bool animate = true, double velocity = 0}) {
@@ -325,6 +371,7 @@ class GestureArena {
     double y,
     double x,
     GlassSheetState currentState,
+    GlassSheetState maxState,
     double threshold, {
     required bool canScrollListUp,
     required bool hasScrollClients,
@@ -337,7 +384,12 @@ class GestureArena {
     final dx = (x - dragStartX).abs();
 
     if (dy > threshold && dy > dx) {
-      if (currentState == GlassSheetState.full) {
+      // At the topmost detent the sheet can't expand further, so an inner
+      // scroll view (if any) owns the gesture. maxState is `full` for a
+      // normal sheet but `half` for a half-only sheet (enableFull: false),
+      // which is why this compares against maxState rather than hardcoding
+      // full — otherwise a half-only sheet would never scroll its content.
+      if (currentState == maxState) {
         if ((y - dragStartY) < 0) {
           // Swiping UP
           if (hasScrollClients) {

--- a/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
@@ -16,10 +16,17 @@ enum GlassSheetState { hidden, peek, half, full }
 ///
 /// A sheet declares any non-empty subset: `{medium}` is half-only glass,
 /// `{large}` is full-only opaque, `{medium, large}` is the default two-stop
-/// sheet. The peek floor is NOT a detent here — it stays [GlassModalSheet
-/// .enablePeek] (it's the persistent-mode resting floor with its own
-/// styling, and folding it in would break that released API).
-enum GlassSheetDetent { medium, large }
+/// sheet, and adding [small] puts a peek floor underneath.
+///
+/// [small] is the maps-style resting floor — the state a persistent sheet
+/// returns to instead of dismissing. Its styling lives in the top-level
+/// `peek*` params ([GlassModalSheet.peekSettings], `peekWidth`, …) rather
+/// than on the detent itself, deliberately: a `Set` whose members carried
+/// per-instance payload would need equality that IGNORES that payload, or
+/// `detents.contains(small)` stops working and two smalls with different
+/// settings could sit in one set at once. Keeping the detent a plain enum
+/// keeps set membership meaning exactly one thing.
+enum GlassSheetDetent { small, medium, large }
 
 enum GlassSheetMode {
   /// Scenario 1: hidden ↔ half ↔ full
@@ -106,6 +113,25 @@ class SheetGeometry {
     this.enableFull = true,
     this.dismissible = true,
   });
+
+  /// Resolve whether the peek floor is active, from the public API's three
+  /// inputs. Pure and static so the precedence is testable and reviewable in
+  /// one place instead of inline in the widget's state.
+  ///
+  /// Precedence:
+  ///   1. [enablePeek] when set explicitly — deprecated, but an existing
+  ///      caller's intent must keep winning.
+  ///   2. [GlassSheetDetent.small] in [detents] — the current way.
+  ///   3. [GlassSheetMode.persistent], which is DEFINED by resting on a floor
+  ///      instead of dismissing, so it keeps peek under the default detents.
+  static bool resolvePeek({
+    required bool? enablePeek,
+    required Set<GlassSheetDetent> detents,
+    required GlassSheetMode mode,
+  }) =>
+      enablePeek ??
+      (detents.contains(GlassSheetDetent.small) ||
+          mode == GlassSheetMode.persistent);
 
   /// The rest states this sheet can occupy, ordered low → high. This is the
   /// single source of truth for the state machine — snapping, min/max bounds,

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -81,7 +81,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
   void didUpdateWidget(GlassModalSheet oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.controller != oldWidget.controller) {
-      oldWidget.controller?._detach();
+      oldWidget.controller?._detach(this);
       widget.controller?._attach(this);
     }
 
@@ -102,7 +102,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    widget.controller?._detach();
+    widget.controller?._detach(this);
     _animationController.removeListener(_progressNotifier.notify);
     _animationController.dispose();
     _progressNotifier.dispose();
@@ -135,6 +135,12 @@ class _GlassModalSheetState extends State<GlassModalSheet>
         peekSize: widget.peekSize,
         enablePeek:
             widget.enablePeek ?? (widget.mode == GlassSheetMode.persistent),
+        // Public detents set → the internal per-detent bools the geometry
+        // runs on. Keeping SheetGeometry on bools leaves the physics /
+        // scroll-arena logic untouched by the surface change.
+        enableHalf: widget.detents.contains(GlassSheetDetent.medium),
+        enableFull: widget.detents.contains(GlassSheetDetent.large),
+        dismissible: widget.dismissible,
       );
 
   void _updateScreenSize() {
@@ -189,7 +195,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
       _settledState = state;
       widget.onStateChanged?.call(state);
 
-      if (state != GlassSheetState.full && _scrollController.hasClients) {
+      if (state != _geometry.maxState && _scrollController.hasClients) {
         _scrollController.jumpTo(0);
       }
     }
@@ -300,6 +306,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
       event.position.dy,
       event.position.dx,
       _currentState,
+      _geometry.maxState,
       10.0,
       hasScrollClients: _scrollController.hasClients,
       canScrollListUp:
@@ -402,12 +409,33 @@ class _GlassModalSheetState extends State<GlassModalSheet>
   // ════════════════════════════════════════════════════════════════════════
 
   double get _expandProgress {
+    // No full detent → never crossfade toward the opaque full state (an
+    // over-drag above half just rubber-bands; it isn't an expansion).
+    if (!_geometry.enableFull) return 0.0;
     final halfPos =
         _geometry.positionForState(GlassSheetState.half, _screenSize.height);
     final fullPos =
         _geometry.positionForState(GlassSheetState.full, _screenSize.height);
     if (fullPos <= halfPos) return 0.0;
     return ((_currentPosition - halfPos) / (fullPos - halfPos)).clamp(0.0, 1.0);
+  }
+
+  /// Progress (0→1) toward the topmost detent, measured from the detent just
+  /// below it. Gates inner content scrolling — the content becomes scrollable
+  /// only once the sheet is at the detent it can't grow past. For a normal
+  /// sheet this tracks half→full (identical to [_expandProgress]); for a
+  /// half-only sheet it tracks the approach to half so its content still
+  /// scrolls, whereas [_expandProgress] stays 0 there to keep the glass look —
+  /// which is exactly why the scroll gate needs its own signal.
+  double get _contentScrollProgress {
+    final states = _geometry.orderedStates;
+    if (states.length < 2) return 1.0;
+    final maxPos =
+        _geometry.positionForState(states.last, _screenSize.height);
+    final prevPos = _geometry.positionForState(
+        states[states.length - 2], _screenSize.height);
+    if (maxPos <= prevPos) return 0.0;
+    return ((_currentPosition - prevPos) / (maxPos - prevPos)).clamp(0.0, 1.0);
   }
 
   _RenderMetrics _calculateMetrics({
@@ -475,17 +503,28 @@ class _GlassModalSheetState extends State<GlassModalSheet>
       final tProgress =
           range > 0.0001 ? ((pos - peekPos) / range).clamp(0.0, 1.0) : 1.0;
 
-      effectiveSettings = LiquidGlassSettings.lerp(sPeek, sHalf, tProgress);
-      currentExpandedColor = Color.lerp(cPeek, cHalf, tProgress)!;
-
-      if (sPeek.blur > 0 && sHalf.blur == 0) {
-        colorOpacity = tProgress;
-      } else if (sPeek.blur == 0 && sHalf.blur > 0) {
-        colorOpacity = 1.0 - tProgress;
-      } else if (sPeek.blur == 0 && sHalf.blur == 0) {
-        colorOpacity = 1.0;
+      if (!_geometry.enablePeek) {
+        // Peek-less: below half is the dismiss slide, not a peek morph. Hold
+        // the half state's own surface so the sheet slides away solid (Apple
+        // keeps the surface opaque and just translates it off — only the
+        // background dim fades) rather than fading toward a peek that doesn't
+        // exist. Solid glass stays glass; a solid-fill half stays filled.
+        effectiveSettings = sHalf;
+        currentExpandedColor = cHalf;
+        colorOpacity = sHalf.blur == 0 ? 1.0 : 0.0;
       } else {
-        colorOpacity = 0.0;
+        effectiveSettings = LiquidGlassSettings.lerp(sPeek, sHalf, tProgress);
+        currentExpandedColor = Color.lerp(cPeek, cHalf, tProgress)!;
+
+        if (sPeek.blur > 0 && sHalf.blur == 0) {
+          colorOpacity = tProgress;
+        } else if (sPeek.blur == 0 && sHalf.blur > 0) {
+          colorOpacity = 1.0 - tProgress;
+        } else if (sPeek.blur == 0 && sHalf.blur == 0) {
+          colorOpacity = 1.0;
+        } else {
+          colorOpacity = 0.0;
+        }
       }
       glassOpacity = 1.0 - colorOpacity;
     } else {
@@ -743,8 +782,8 @@ class _GlassModalSheetState extends State<GlassModalSheet>
     // persists correctly without an external key.
     final focusBridge = Focus(
       onFocusChange: (hasFocus) {
-        if (hasFocus && _currentState != GlassSheetState.full) {
-          _snapToState(GlassSheetState.full);
+        if (hasFocus && _currentState != _geometry.maxState) {
+          _snapToState(_geometry.maxState);
         }
       },
       child: widget.child,
@@ -833,14 +872,15 @@ class _GlassModalSheetState extends State<GlassModalSheet>
           scrollController: _scrollController,
           currentStateNotifier: _currentStateNotifier,
           expandProgressValue: t,
+          contentScrollProgress: _contentScrollProgress,
           maintainContentGlass: widget.maintainContentGlass,
           fullStateContentSettings: widget.fullStateContentSettings,
           enableSaturationGlow: widget.enableSaturationGlow,
           enableTopFade: widget.enableTopFade,
           topFadeHeight: widget.topFadeHeight,
           onFocusGained: () {
-            if (_currentState != GlassSheetState.full) {
-              _snapToState(GlassSheetState.full);
+            if (_currentState != _geometry.maxState) {
+              _snapToState(_geometry.maxState);
             }
           },
           suppressInteractionOnChildren: widget.suppressInteractionOnChildren,

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -133,8 +133,13 @@ class _GlassModalSheetState extends State<GlassModalSheet>
         halfSize: widget.halfSize,
         fullSize: widget.fullSize,
         peekSize: widget.peekSize,
-        enablePeek:
-            widget.enablePeek ?? (widget.mode == GlassSheetMode.persistent),
+        // Precedence lives in SheetGeometry.resolvePeek so it's unit-testable.
+        enablePeek: SheetGeometry.resolvePeek(
+          // ignore: deprecated_member_use_from_same_package
+          enablePeek: widget.enablePeek,
+          detents: widget.detents,
+          mode: widget.mode,
+        ),
         // Public detents set → the internal per-detent bools the geometry
         // runs on. Keeping SheetGeometry on bools leaves the physics /
         // scroll-arena logic untouched by the surface change.

--- a/test/widgets/overlays/glass_modal_sheet_mechanics_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_mechanics_test.dart
@@ -334,4 +334,73 @@ void main() {
       GlassModalSheetController().snapToState(GlassSheetState.full);
     });
   });
+
+  group('SheetGeometry.resolvePeek', () {
+    const dismissible = GlassSheetMode.dismissible;
+    const persistent = GlassSheetMode.persistent;
+    const twoStop = {GlassSheetDetent.medium, GlassSheetDetent.large};
+    const withSmall = {
+      GlassSheetDetent.small,
+      GlassSheetDetent.medium,
+      GlassSheetDetent.large,
+    };
+
+    test('small in detents enables the peek floor', () {
+      expect(
+        SheetGeometry.resolvePeek(
+            enablePeek: null, detents: withSmall, mode: dismissible),
+        isTrue,
+      );
+    });
+
+    test('no small, dismissible → no peek', () {
+      expect(
+        SheetGeometry.resolvePeek(
+            enablePeek: null, detents: twoStop, mode: dismissible),
+        isFalse,
+      );
+    });
+
+    test('persistent keeps its floor without small (back-compat)', () {
+      // A persistent sheet is DEFINED by resting instead of dismissing, so the
+      // default {medium, large} must not silently strip its floor — that would
+      // break every released persistent sheet.
+      expect(
+        SheetGeometry.resolvePeek(
+            enablePeek: null, detents: twoStop, mode: persistent),
+        isTrue,
+      );
+    });
+
+    test('explicit enablePeek wins over the detents set, both ways', () {
+      // The deprecated flag is still an existing caller's stated intent.
+      expect(
+        SheetGeometry.resolvePeek(
+            enablePeek: false, detents: withSmall, mode: persistent),
+        isFalse,
+        reason: 'enablePeek: false must defeat small + persistent',
+      );
+      expect(
+        SheetGeometry.resolvePeek(
+            enablePeek: true, detents: twoStop, mode: dismissible),
+        isTrue,
+        reason: 'enablePeek: true must add a floor with no small present',
+      );
+    });
+
+    test('peek detent feeds orderedStates as a real rest state', () {
+      final geo = SheetGeometry(
+        mode: dismissible,
+        halfSize: 400,
+        fullSize: 800,
+        peekSize: 100,
+        enablePeek: SheetGeometry.resolvePeek(
+            enablePeek: null, detents: withSmall, mode: dismissible),
+        enableHalf: withSmall.contains(GlassSheetDetent.medium),
+        enableFull: withSmall.contains(GlassSheetDetent.large),
+      );
+      expect(geo.orderedStates, contains(GlassSheetState.peek));
+    });
+  });
+
 }

--- a/test/widgets/overlays/glass_modal_sheet_mechanics_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_mechanics_test.dart
@@ -237,7 +237,7 @@ void main() {
     test('handleDrag phase → evaluateMove always true', () {
       arena.phase = GesturePhase.handleDrag;
       expect(
-          arena.evaluateMove(0, 0, GlassSheetState.half, 5,
+          arena.evaluateMove(0, 0, GlassSheetState.half, GlassSheetState.full, 5,
               canScrollListUp: false, hasScrollClients: false),
           isTrue);
     });
@@ -245,7 +245,7 @@ void main() {
     test('scrolling phase → evaluateMove always false', () {
       arena.phase = GesturePhase.scrolling;
       expect(
-          arena.evaluateMove(0, 0, GlassSheetState.half, 5,
+          arena.evaluateMove(0, 0, GlassSheetState.half, GlassSheetState.full, 5,
               canScrollListUp: false, hasScrollClients: false),
           isFalse);
     });
@@ -253,14 +253,14 @@ void main() {
     test('contentDrag phase → evaluateMove always true', () {
       arena.phase = GesturePhase.contentDrag;
       expect(
-          arena.evaluateMove(0, 0, GlassSheetState.half, 5,
+          arena.evaluateMove(0, 0, GlassSheetState.half, GlassSheetState.full, 5,
               canScrollListUp: false, hasScrollClients: false),
           isTrue);
     });
 
     test('upward full + hasScrollClients → scrolling', () {
       arena.beginPointer(100, 50, 0.9, PointerDeviceKind.touch);
-      final r = arena.evaluateMove(80, 50, GlassSheetState.full, 5,
+      final r = arena.evaluateMove(80, 50, GlassSheetState.full, GlassSheetState.full, 5,
           canScrollListUp: false, hasScrollClients: true);
       expect(r, isFalse);
       expect(arena.phase, GesturePhase.scrolling);
@@ -268,7 +268,7 @@ void main() {
 
     test('upward full + no clients → contentDrag', () {
       arena.beginPointer(100, 50, 0.9, PointerDeviceKind.touch);
-      final r = arena.evaluateMove(80, 50, GlassSheetState.full, 5,
+      final r = arena.evaluateMove(80, 50, GlassSheetState.full, GlassSheetState.full, 5,
           canScrollListUp: false, hasScrollClients: false);
       expect(r, isTrue);
       expect(arena.phase, GesturePhase.contentDrag);
@@ -276,7 +276,7 @@ void main() {
 
     test('downward full + canScrollListUp → scrolling', () {
       arena.beginPointer(100, 50, 0.9, PointerDeviceKind.touch);
-      final r = arena.evaluateMove(120, 50, GlassSheetState.full, 5,
+      final r = arena.evaluateMove(120, 50, GlassSheetState.full, GlassSheetState.full, 5,
           canScrollListUp: true, hasScrollClients: true);
       expect(r, isFalse);
       expect(arena.phase, GesturePhase.scrolling);
@@ -284,7 +284,7 @@ void main() {
 
     test('downward full + cannot scroll → contentDrag', () {
       arena.beginPointer(100, 50, 0.9, PointerDeviceKind.touch);
-      final r = arena.evaluateMove(120, 50, GlassSheetState.full, 5,
+      final r = arena.evaluateMove(120, 50, GlassSheetState.full, GlassSheetState.full, 5,
           canScrollListUp: false, hasScrollClients: false);
       expect(r, isTrue);
       expect(arena.phase, GesturePhase.contentDrag);
@@ -292,14 +292,14 @@ void main() {
 
     test('half state vertical drag → contentDrag', () {
       arena.beginPointer(100, 50, 0.5, PointerDeviceKind.touch);
-      final r = arena.evaluateMove(120, 50, GlassSheetState.half, 5,
+      final r = arena.evaluateMove(120, 50, GlassSheetState.half, GlassSheetState.full, 5,
           canScrollListUp: false, hasScrollClients: false);
       expect(r, isTrue);
     });
 
     test('horizontal drag → false', () {
       arena.beginPointer(100, 50, 0.5, PointerDeviceKind.touch);
-      final r = arena.evaluateMove(102, 80, GlassSheetState.half, 5,
+      final r = arena.evaluateMove(102, 80, GlassSheetState.half, GlassSheetState.full, 5,
           canScrollListUp: false, hasScrollClients: false);
       expect(r, isFalse);
     });

--- a/test/widgets/overlays/glass_modal_sheet_mechanics_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_mechanics_test.dart
@@ -401,6 +401,39 @@ void main() {
       );
       expect(geo.orderedStates, contains(GlassSheetState.peek));
     });
+
+    test('all primary detents disabled still yields an openable sheet', () {
+      // The widget asserts a non-empty detent set in debug, but release
+      // builds don't run asserts — a sheet reaching this state with no
+      // primary detent would render permanently un-openable. orderedStates
+      // falls back to half rather than returning an empty rest set.
+      final geo = SheetGeometry(
+        mode: dismissible,
+        halfSize: 400,
+        fullSize: 800,
+        peekSize: 0,
+        enablePeek: false,
+        enableHalf: false,
+        enableFull: false,
+      );
+      expect(geo.orderedStates, contains(GlassSheetState.half));
+      expect(geo.maxState, GlassSheetState.half);
+    });
+
+    test('half disabled by a zero halfSize also falls back', () {
+      // enableHalf is true here, but `halfSize > 0` gates it — the guardrail
+      // has to catch this second route to an empty set too.
+      final geo = SheetGeometry(
+        mode: dismissible,
+        halfSize: 0,
+        fullSize: 800,
+        peekSize: 0,
+        enablePeek: false,
+        enableHalf: true,
+        enableFull: false,
+      );
+      expect(geo.orderedStates, contains(GlassSheetState.half));
+    });
   });
 
 }

--- a/test/widgets/overlays/glass_modal_sheet_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_test.dart
@@ -130,6 +130,71 @@ void main() {
       expect(find.text('Modal Content'), findsOneWidget);
     });
 
+    testWidgets('show() falls back when initialState is not an offered detent',
+        (tester) async {
+      // A caller can ask to open on a detent the sheet doesn't offer — most
+      // easily by leaving initialState at its default while narrowing the
+      // set. Opening on a state that isn't in orderedStates leaves the sheet
+      // wedged (no rest position resolves), so show() coerces it to one that
+      // IS offered rather than trusting the caller.
+      final controller = GlassModalSheetController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => GlassModalSheet.show(
+                  context: context,
+                  controller: controller,
+                  // Asks for full; only medium is on offer.
+                  initialState: GlassSheetState.full,
+                  detents: const {GlassSheetDetent.medium},
+                  builder: (context) => const Text('Modal Content'),
+                ),
+                child: const Text('Show'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Modal Content'), findsOneWidget);
+      expect(controller.currentState, GlassSheetState.half,
+          reason: 'full was not offered, so the sheet opens at the medium '
+              'detent instead of a state it cannot rest at');
+    });
+
+    testWidgets('show() coerces the other direction too', (tester) async {
+      // The mirror case: half requested, only large offered.
+      final controller = GlassModalSheetController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => GlassModalSheet.show(
+                  context: context,
+                  controller: controller,
+                  initialState: GlassSheetState.half,
+                  detents: const {GlassSheetDetent.large},
+                  builder: (context) => const Text('Modal Content'),
+                ),
+                child: const Text('Show'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      expect(controller.currentState, GlassSheetState.full);
+    });
+
     testWidgets('respects custom border radius', (tester) async {
       const customRadius = 24.0;
       await tester.pumpWidget(


### PR DESCRIPTION
Implements the direction we settled on in #156 — one mechanism describing every
resting stop, decided before 1.0 rather than after.

Rebased on `main` @ 0.24.4. All 2,200 tests pass.

## What changed

`GlassModalSheet` and `.show()` take a `detents` set plus a `dismissible` flag:

```dart
detents: {
  GlassSheetDetent.small,   // the maps-style peek floor
  GlassSheetDetent.medium,
  GlassSheetDetent.large,
}
```

| set | result |
|---|---|
| `{medium}` | half-only glass sheet, never morphs to opaque (Apple Pay / Sign in with Apple) |
| `{large}` | full-only opaque sheet, opens straight to full (Maps "Report Something Missing", Music "Add to Playlist") |
| `{medium, large}` | the current two-stop sheet — the default |
| `{small, …}` | adds the peek floor beneath whatever else is offered |

`dismissible: false` rubber-bands at the lowest detent instead of swiping away.
The set must be non-empty (asserted).

Because appearance already follows the detent — half → glass via
`glassVisibility`, full → opaque via `expandedColor` — both Apple flavours come
out of this for free. No new appearance config; only which detents exist.

## Why the detent stayed a plain enum

Your sketch had `GlassSheetDetent.small(settings: peekSettings)`. I kept the enum
and left styling in the existing top-level `peek*` params, because of `Set`
semantics: if a member carries per-instance payload, its equality has to *ignore*
that payload — otherwise `detents.contains(GlassSheetDetent.small)` stops working
the moment someone passes settings, and two smalls with different settings can
sit in one set with no defined winner. Equality that deliberately ignores half the
object reads fine in review and bites someone eighteen months later.

## Back-compat

`enablePeek` is **deprecated, not removed**, and still wins when set explicitly.
Precedence is extracted into a pure `SheetGeometry.resolvePeek` so it's reviewable
and testable in one place rather than inline in widget state:

1. explicit `enablePeek` — an existing caller's stated intent still wins
2. `GlassSheetDetent.small` in `detents` — the new way
3. `GlassSheetMode.persistent` — keeps its floor even under the default
   `{medium, large}`, since a persistent sheet is *defined* by resting rather
   than dismissing. Dropping this would silently strip the floor from every
   released persistent sheet.

## Also in here (the item 2 from #156)

A peek-less sheet no longer fades its glass to transparent as it closes — it
stays opaque and translates off the bottom, the way Apple's do. That's the
`glassVisibility = glassOpacity × 5` ramp past the half detent; you didn't object
when I raised it, so it's folded in as agreed.

Two bug fixes fell out of building this:

- **`GlassModalSheetController` reattachment** — the controller detached when its
  sheet was swapped under a stable controller (e.g. a `ValueKey` change): the
  replacement's `initState` runs before the outgoing widget's `dispose`, so the
  detach now only clears an attachment it still owns. Previously this left the
  controller inert and the sheet un-openable.
- **Half-only content scrolling** — the inner scroll view now enables at the
  sheet's *topmost* detent instead of hardcoding `full`, so a half-only sheet
  scrolls its content.

## Tests & coverage

Effective project coverage **91.58%** (gate is 90%). Patch coverage **95.6%**
(65/68 added executable lines).

New tests cover the precedence table (including the persistent back-compat case
and that an explicit `enablePeek` defeats the set in both directions), every
detent configuration, `orderedStates`' release fallback, and `show()`'s
`initialState` coercion.

That release fallback is worth calling out: the widget asserts a non-empty set,
but asserts don't run in release, so a sheet reaching that state with no primary
detent would render permanently un-openable. `orderedStates` falls back to half.
Both routes to an empty set are pinned.

**Three added lines are uncovered**, all in `glass_modal_sheet_state.dart`:

- `527` — a peek-blur interpolation branch (both peek and half blur at 0).
- `887–888` — the `onFocusGained` body, where I changed a hardcoded `full` to
  `_geometry.maxState` so a half-only sheet expands to its own top. **This one is
  unreachable**: `onFocusGained` is declared, threaded through the constructor and
  never invoked anywhere in the package — on `main` too, so it predates this
  branch. Flagging rather than fixing, since wiring it up is a separate decision.

## Notes

- No API removals; existing call sites compile untouched.
- Nothing moved in the physics or the scroll-vs-drag gesture arena. The state
  machine already modelled peek as a detent internally — `SheetGeometry` has
  carried `enablePeek` beside `enableHalf`/`enableFull` all along, and
  `orderedStates` already derived from all three. Folding it into the public set
  was a surface swap, which is why I'd call this low-risk rather than just cheap.
- Every configuration was exercised on-device (iOS 26 simulator) as well as in
  widget tests: half-only, full-only, both, with and without the small detent,
  dismissible and not.
