### PR TITLE
Fix: GlassMenu mispositions inside nested Navigators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Unreleased
+
+## 🐛 Bug Fixes
+
+- **`GlassMenu` mispositioned inside nested `Navigator`s** — the menu's popup
+  is now hosted on the root `Overlay` instead of the nearest one.
+  `_openMenu()` captures the trigger's anchor via
+  `renderBox.localToGlobal(Offset.zero)`, which resolves to screen-global
+  coordinates, but the overlay content built in `_buildMorphingOverlay` was
+  positioned inside whichever `Overlay` happened to be nearest — the default
+  target for `OverlayPortal`. Those only agree when the nearest `Overlay`
+  sits at the screen's true origin. Any layout with its own nested
+  `Navigator`s not flush against the screen edge (e.g. a persistent side
+  rail/drawer next to a `StatefulShellRoute.indexedStack` branch, each branch
+  owning its own `Navigator`/`Overlay`) broke this assumption: the menu
+  rendered shifted by exactly that `Overlay`'s offset from the screen edge,
+  and the offset — and therefore the drift — grew with the rail's width.
+
 # 0.25.0
 
 ## ✨ New Features

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -190,9 +190,25 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
 
             // Overlay portal for morphing animation
             // The overlay contents fade out during the handoff so the real button shows instead
+            //
+            // Must target the ROOT overlay: _openMenu() below captures
+            // _triggerGlobalPosition via renderBox.localToGlobal(Offset.zero)
+            // with no `ancestor`, which resolves to true screen-global
+            // coordinates (relative to the root RenderView). Positioned
+            // children built in _buildMorphingOverlay are laid out relative to
+            // whichever Overlay hosts them, so that Overlay's origin must
+            // coincide with the screen's true (0,0) for the math to line up.
+            // The default `nearestOverlay` breaks this whenever GlassMenu is
+            // used inside a nested Navigator (e.g. a multi-pane/shell layout
+            // where each pane owns its own Navigator+Overlay offset from the
+            // screen edge by a sidebar) — the menu then renders shifted by
+            // exactly that Overlay's offset from the screen, and the further
+            // the nested Overlay sits from the screen edge, the further the
+            // menu drifts from its trigger.
             OverlayPortal(
               controller: _overlayController,
               overlayChildBuilder: _buildMorphingOverlay,
+              overlayLocation: OverlayChildLocation.rootOverlay,
             ),
           ],
         );


### PR DESCRIPTION
## Problem

`GlassMenu` positions its popup incorrectly when it lives inside a nested `Navigator` whose `Overlay` isn't flush against the screen's true top-left corner — e.g. a persistent side rail/drawer next to a `StatefulShellRoute.indexedStack` branch, where each branch owns its own `Navigator` (and therefore its own `Overlay`) offset from the screen edge by the rail's width.

### Root cause

`_openMenu()` (`lib/widgets/overlays/shared/glass_menu_internal.dart`) captures the trigger's anchor with:

```dart
_triggerGlobalPosition = renderBox.localToGlobal(Offset.zero); // no `ancestor` arg
```

Called with no `ancestor`, `localToGlobal` resolves to **screen-global** coordinates (relative to the root `RenderView`).

The overlay content built in `_buildMorphingOverlay` then positions itself with `Positioned(left: blobBLeft, top: blobBTop, ...)` inside whichever `Overlay` hosts it — and `OverlayPortal` (used with no explicit `overlayLocation`) defaults to `OverlayChildLocation.nearestOverlay`.

These two coordinate spaces only agree when the nearest `Overlay`'s own origin coincides with the screen's true `(0, 0)`. That's true for a plain single-`Navigator` app, but breaks as soon as `GlassMenu` is used inside a *nested* `Navigator` positioned away from the screen edge: the popup renders shifted by exactly that `Overlay`'s offset from the screen, and the drift grows with however far that offset is (in our repro, a collapsible side rail — the wider it opens, the further the menu drifts from its trigger).

### Fix

Target `OverlayChildLocation.rootOverlay` explicitly in the `OverlayPortal` call, so the popup's coordinate space always matches the anchor's regardless of how deeply nested the trigger's own `Navigator` is.

### Testing

- Existing package test suite (`glass_menu_test.dart`, `glass_menu_primitives_test.dart`, `glass_menu_item_coverage_test.dart` — 69 tests) passes unchanged.
- Verified the fix in a real app with a `StatefulShellRoute.indexedStack` shell (persistent collapsible side rail, 80px collapsed / 280px expanded) where `GlassMenu` triggers inside a branch's list items were drifting proportionally to the rail's width; after the fix the popup anchors correctly at both rail states.

Added a changelog entry describing the fix under `# Unreleased`.