### PR TITLE
feat: prevent adaptive glass quality oscillation

### DIFF
--- a/lib/utils/glass_quality_adapter.dart
+++ b/lib/utils/glass_quality_adapter.dart
@@ -130,10 +130,11 @@ class GlassQualityAdapter {
   /// from this value.
   final int targetFrameMs;
 
-  /// When `true`, the adapter may step quality **up** after a sustained period
-  /// of good performance. When `false` (the default), only step-downs occur —
-  /// the starting quality from Phase 2 is the permanent ceiling for the
-  /// session (or until [reset] is called).
+  /// Whether the adapter may increase quality after sustained good performance.
+  ///
+  /// When `false`, quality can only stay the same or decrease for the lifetime
+  /// of this adapter. A warm-up triggered by [reset] cannot restore a higher
+  /// quality either; recreate the adapter to clear this restriction.
   final bool allowStepUp;
 
   /// The quality tier to start at, bypassing Phase 2 (the warm-up benchmark).
@@ -524,8 +525,15 @@ class GlassQualityAdapter {
       decided = _capQuality(maxQuality, GlassQuality.minimal);
     }
 
-    // Ensure we never go below minQuality floor.
-    final effective = _floorQuality(decided, minQuality);
+    // Apply the warm-up result while respecting [minQuality] and [allowStepUp].
+    // When [allowStepUp] is false, warm-up may lower the current quality but
+    // never raises it after the quality has been selected.
+    final effective = allowStepUp
+        ? _floorQuality(decided, minQuality)
+        : _floorQuality(
+            _capQuality(decided, _currentQuality),
+            minQuality,
+          );
 
     // Write to session cache so remounts within this app process skip Phase 2.
     _sessionSettledQuality = effective;

--- a/lib/widgets/shared/glass_adaptive_scope.dart
+++ b/lib/widgets/shared/glass_adaptive_scope.dart
@@ -290,11 +290,12 @@ class GlassAdaptiveScopeConfig {
   /// The raster frame duration target in milliseconds. Defaults to `16` (60 fps).
   final int targetFrameMs;
 
-  /// When `true`, the scope may step quality **up** after a sustained period
-  /// of good performance (e.g. after thermal recovery).
-  /// Defaults to `true` — allows Phase 3 to self-correct a conservative Phase 2
-  /// warmup decision. Step-up requires 10 consecutive under-budget windows
-  /// (≈ 20 seconds) plus an 8-second cooldown, so the transition is invisible.
+  /// Whether the scope may increase quality after sustained good performance.
+  /// Defaults to `true`.
+  ///
+  /// When enabled, recovery requires 10 consecutive under-budget windows
+  /// (about 20 seconds) plus an 8-second cooldown, keeping the transition
+  /// stable and unobtrusive.
   final bool allowStepUp;
 
   /// The P75 warmup threshold (ms) below which the device is classified as
@@ -469,14 +470,13 @@ class GlassAdaptiveScope extends StatefulWidget {
   /// Defaults to `16` (60 fps budget).
   final int targetFrameMs;
 
-  /// When `true`, the scope may step quality **up** to [maxQuality] after a
-  /// sustained period of good performance (e.g. after thermal recovery or a
-  /// conservative Phase 2 warmup decision).
+  /// Whether the scope may increase quality to [maxQuality] after sustained
+  /// good performance, such as after thermal recovery or a conservative warm-up
+  /// decision.
   ///
-  /// Defaults to `true`. Step-up uses a 10-window window (≈ 20 seconds) plus
-  /// an 8-second cooldown to prevent oscillation — users should not perceive
-  /// any flicker. Setting this to `false` locks quality at whatever Phase 2
-  /// decided for the entire session.
+  /// Defaults to `true`. Recovery uses 10 consecutive under-budget windows
+  /// (about 20 seconds) plus an 8-second cooldown to prevent oscillation.
+  /// Set this to `false` to keep quality from increasing after warm-up.
   final bool allowStepUp;
 
   /// The P75 warmup threshold (ms) below which the device is classified as

--- a/test/utils/glass_quality_adapter_test.dart
+++ b/test/utils/glass_quality_adapter_test.dart
@@ -148,6 +148,25 @@ void main() {
       expect(adapter.currentQuality, GlassQuality.minimal);
     });
 
+    test('warm-up does not promote an already downgraded quality when locked',
+        () {
+      final changes = <(GlassQuality, GlassQuality)>[];
+      final adapter = _makeAdapter(
+        allowStepUp: false,
+        changes: changes,
+      );
+
+      _runWarmup(adapter, rasterUs: 25000); // premium → standard
+      expect(adapter.currentQuality, GlassQuality.standard);
+      changes.clear();
+
+      adapter.reset();
+      _runWarmup(adapter, rasterUs: 5000); // would otherwise promote to premium
+
+      expect(adapter.currentQuality, GlassQuality.standard);
+      expect(changes, isEmpty);
+    });
+
     test('minQuality floor is honoured even when P75 > 20 ms', () {
       final adapter = _makeAdapter(
         min: GlassQuality.standard,


### PR DESCRIPTION
## Summary
This PR adds an opt-in way to stabilize adaptive glass quality when temporary performance fluctuations cause repeated transitions between liquid glass and frosted glass.
Changes included:
add allowStepUp control for adaptive quality recovery
allow quality to degrade while preventing upgrades when allowStepUp is false
preserve the downgraded quality after a reset warm-up
keep the default behavior unchanged with allowStepUp: true
improve API documentation for the new behavior
add regression coverage for locked quality after warm-up
## Why
When device performance temporarily drops, the adaptive quality system can downgrade from liquid glass to frosted glass and then upgrade again shortly afterward. This repeated visual switching feels unstable and makes the interface look inconsistent.
allowStepUp: false lets applications prefer a stable lower quality after degradation, while still allowing the system to downgrade when performance requires it.
## Testing
Added a regression test covering:
quality degradation with allowStepUp: false
reset-triggered warm-up attempting to promote quality
preserving the previously downgraded quality
Also verified that flutter analyze passes for the affected files. The full flutter test suite has not been run yet.