### PR TITLE
feat(tab-bar): iOS 26 tabViewBottomAccessory support (v0.29.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,49 @@
 
 ## 🎵 iOS 26 `tabViewBottomAccessory` Support
 
-Added `bottomAccessory` / `bottomAccessoryHeight` / `bottomAccessoryEnabled` to both `GlassTabBar.bottom` and `GlassTabBar.searchable` — mirroring Apple's `tabViewBottomAccessory` modifier.
+Added `bottomAccessory` / `bottomAccessoryHeight` / `bottomAccessoryEnabled` / `bottomAccessorySpacing` / `bottomAccessoryPlacement` to both `GlassTabBar.bottom` and `GlassTabBar.searchable` — mirroring Apple's `tabViewBottomAccessory` modifier.
 
-- **Expanded mode** — accessory floats directly above the nav bar pill with a configurable spacing gap.
-- **Inline mode** (`searchable` only) — accessory slides horizontally into the gap between the collapsed tab indicator and search capsule, with a simultaneous width squish, matching the iOS 26 `.inline` placement.
-- A single `TweenAnimationBuilder` drives all geometry (height, left, right, bottom) from one unified timeline — no animation drift on mid-transition reversal.
-- `preferredSize` correctly accounts for the accessory height so `GlassScaffold` edge-fades are pixel-accurate in both states.
-- Apple Music and Apple Podcasts demos migrated to use the new API.
+- **Expanded mode** — accessory floats directly above the nav bar pill with a configurable spacing gap (default `6.0px`, calibrated to match Apple's native spacing).
+- **Inline mode** (`searchable` only) — set `bottomAccessoryPlacement: GlassTabBarAccessoryPlacement.inline` to have the accessory slide horizontally into the gap between the collapsed tab indicator and search capsule, with a simultaneous width squish, matching the iOS 26 `.inline` placement.
+- **Two independent animation timelines** — `accessoryT` drives the inline↔expanded morph (height, left, right) while `searchT` tracks the tab-pill→search-capsule height change so the accessory follows the bar downward during the search activation, maintaining a consistent visual overlap gap throughout.
+- **Safe defaults** — `bottomAccessoryPlacement` defaults to `.expanded`. The accessory never collapses inline automatically; developers must explicitly opt into `.inline` placement, mirroring the iOS 26 model where placement intent is declared at the call site.
+- **Pixel-accurate scaffold insets** — `preferredSize` is always in sync with the layout engine so `GlassScaffold`'s edge fade reserves the exact correct amount of space in both expanded and inline states.
+- **`GlassTabBarAccessoryPlacement` enum** — `expanded` and `inline` values, readable inside the accessory widget itself via `GlassTabBarAccessoryPlacementScope.of(context)` to adapt the accessory's own layout between the full row and compact strip.
+- **Apple Music and Apple Podcasts demos** fully showcase the feature — including the expanded/inline transition and the search-active behaviour.
+
+### Upgrading from `bodyOverlays`
+
+Previously, the recommended pattern for a floating mini-player was to place it in `GlassScaffold.bodyOverlays` and manually manage its position using `AnimatedPositioned` with scroll-offset math. That approach still works and `bodyOverlays` remains available for other use cases (e.g. floating action overlays, toast banners).
+
+For a bottom accessory that is architecturally part of the tab bar — which is exactly what iOS 26 `tabViewBottomAccessory` models — the `bottomAccessory` API is the correct replacement:
+
+```dart
+// Before (bodyOverlays workaround)
+GlassScaffold(
+  bodyOverlays: [
+    AnimatedPositioned(
+      bottom: _isMiniMode ? barH : barH + accessoryH + spacing,
+      left: 0, right: 0,
+      child: MiniPlayer(),
+    ),
+  ],
+)
+
+// After (iOS 26-aligned)
+GlassTabBar.searchable(
+  bottomAccessory: MiniPlayer(),
+  bottomAccessoryHeight: 50.0,
+  bottomAccessoryPlacement: _isMiniMode && !_isSearching
+      ? GlassTabBarAccessoryPlacement.inline
+      : GlassTabBarAccessoryPlacement.expanded,
+)
+```
+
+The new API removes all manual position arithmetic, keeps the `GlassScaffold` edge fade pixel-accurate, and persists the accessory automatically across tab switches.
 
 ---
 
 # 0.28.1
-
 
 ## 📚 Internal Refactor — API Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
+# 0.29.0
+
+## 🎵 iOS 26 `tabViewBottomAccessory` Support
+
+Added `bottomAccessory` / `bottomAccessoryHeight` / `bottomAccessoryEnabled` to both `GlassTabBar.bottom` and `GlassTabBar.searchable` — mirroring Apple's `tabViewBottomAccessory` modifier.
+
+- **Expanded mode** — accessory floats directly above the nav bar pill with a configurable spacing gap.
+- **Inline mode** (`searchable` only) — accessory slides horizontally into the gap between the collapsed tab indicator and search capsule, with a simultaneous width squish, matching the iOS 26 `.inline` placement.
+- A single `TweenAnimationBuilder` drives all geometry (height, left, right, bottom) from one unified timeline — no animation drift on mid-transition reversal.
+- `preferredSize` correctly accounts for the accessory height so `GlassScaffold` edge-fades are pixel-accurate in both states.
+- Apple Music and Apple Podcasts demos migrated to use the new API.
+
+---
+
 # 0.28.1
+
 
 ## 📚 Internal Refactor — API Documentation
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Bring Apple's iOS 26 Liquid Glass to your Flutter app — real shader-based blur
 
 ```yaml
 dependencies:
-  liquid_glass_widgets: ^0.28.1
+  liquid_glass_widgets: ^0.29.0
 ```
 
 ```bash

--- a/example/lib/apple_music/apple_music_demo.dart
+++ b/example/lib/apple_music/apple_music_demo.dart
@@ -284,6 +284,9 @@ class _AppleMusicHomeScreenState extends State<AppleMusicHomeScreen> {
       // ── Bottom navigation bar ──────────────────────────────────────────────
       bottomBar: GlassTabBar.searchable(
         isSearchActive: _isMiniMode || _isSearching,
+        bottomAccessoryPlacement: (_isMiniMode && !_isSearching)
+            ? GlassTabBarAccessoryPlacement.inline
+            : GlassTabBarAccessoryPlacement.expanded,
         selectedIndex: _selectedTab,
         onTabSelected: (index) {
           if (index == _selectedTab && _isMiniMode) {

--- a/example/lib/apple_music/apple_music_demo.dart
+++ b/example/lib/apple_music/apple_music_demo.dart
@@ -1,25 +1,23 @@
 /// Apple Music iOS 26 — High-Fidelity Demo
 ///
 /// Animation architecture:
-///   • `GlassSearchableBottomBar` uses `isSearchActive: _isMiniMode || _isSearching`
+///   • `GlassTabBar.searchable` uses `isSearchActive: _isMiniMode || _isSearching`
 ///     so the tabs spring-collapse whenever scrolled OR searching — matching the
 ///     iOS 26 morphing animation exactly.
 ///
-///   • Two play bar pills work in concert:
-///       1. Body-Stack pill   — full-width, floats ABOVE the nav bar when not mini.
-///          On scroll it AnimatedPositioned DOWN to bar level + AnimatedOpacity 0.
-///       2. NavBar-Stack pill — lives INSIDE the bottomNavigationBar SizedBox Stack
-///          so it receives taps even in the nav-bar hit-test zone.  It AnimatedOpacity
-///          fades IN when mini, always sitting at bar-pill level.
+///   • `bottomAccessory` handles the mini-player pill automatically:
+///       - When expanded (`!_isMiniMode`), the accessory sits centered directly
+///         above the navigation bar pill.
+///       - When inline (`_isMiniMode`), the accessory slides down and right,
+///         sandwiching itself exactly between the collapsed tab indicator and
+///         the collapsed search capsule.
 ///
-///     Together they create the illusion of "the bar collapses, the play pill slides
-///     into the gap", with the handoff invisible to the user.
-///
-///   • A small search GlassButton is also inside the NavBar Stack at the right
-///     edge — visible only in mini mode to match the iOS 26 [Home][Play][Search] row.
+///     The entire transition is handled internally by a single unified
+///     TweenAnimationBuilder, perfectly synchronizing height, position, and width
+///     to match the iOS 26 `tabViewBottomAccessory(.inline)` behavior.
 ///
 /// Run standalone:
-///   flutter run -t lib/apple_music/apple_music_demo.dart
+///   flutter run -d macos -t lib/apple_music/apple_music_demo.dart
 library;
 
 import 'package:flutter/cupertino.dart';
@@ -232,33 +230,10 @@ class _AppleMusicHomeScreenState extends State<AppleMusicHomeScreen> {
         defaultTargetPlatform == TargetPlatform.macOS;
     final sysBottom = isIOS ? 0.0 : MediaQuery.viewPaddingOf(context).bottom;
 
-    // GlassSearchableBottomBar handles keyboard avoidance internally (floatY),
-    // so we only need to push the wrapper up by the system nav bar height.
-    final bottomOffset = sysBottom;
-
-    const double expandedNavBarH = 40 + 2 * _kPaddingV; // 72.0
-    const double collapsedNavBarH = 60.0; // searchBarHeight
-
-    // Gap b
-    const double pillGap = 14.0;
-
-    // aboveBarBottom: shifts down when search is active because the bar is
-    // shorter (50px vs 72px), so we anchor to whichever height is current.
-    final double activeNavBarH =
-        _isSearching ? collapsedNavBarH : expandedNavBarH;
-    final double aboveBarBottom = activeNavBarH + pillGap + bottomOffset;
-
-    // miniBarBottom: position of the pill row inside the body Stack.
-    final double miniBarBottom = _kPaddingV + bottomOffset;
-
-    // contentPad: extra bottom space so the last sliver scrolls above all bars.
-    final double contentPad = aboveBarBottom + 50.0 + 8.0;
-
-    // The collapsed home/search pills render at searchBarHeight (50), not _kBarH (64).
-    // Using _kBarH here causes an ~18px gap; 50+6 gives the tight ~6px Apple uses.
-    const double collapsedPillW = 50.0;
-    final double miniPlayLeft = _kPaddingH + collapsedPillW + 6.0;
-    final double miniPlayRight = _kPaddingH + collapsedPillW + 6.0;
+    // Content bottom padding: bar (64) + vertical padding (16*2) + accessory (50)
+    // + spacing (8) + extra clearance (8).
+    final double contentPad =
+        _kBarH + 2 * _kPaddingV + 50.0 + _kSpacing + 8.0 + sysBottom;
 
     return GlassScaffold(
       background: ColoredBox(color: _kBackground.resolveFrom(context)),
@@ -269,7 +244,6 @@ class _AppleMusicHomeScreenState extends State<AppleMusicHomeScreen> {
       topEdgeFade: true,
       bottomEdgeFade: true,
       topEdgeFadeExtent: 0, // no app bar — just status bar fade
-      bottomBarHeight: _isMiniMode ? 20 : 40,
       bottomEdgeFadeExtent: 0, // glass bar is transparent — no extra fade
       resizeToAvoidBottomInset: false,
 
@@ -307,35 +281,6 @@ class _AppleMusicHomeScreenState extends State<AppleMusicHomeScreen> {
         ),
       ),
 
-      // ── Play pill overlay (between body and bars in z-order) ───────────────
-      bodyOverlays: [
-        // ── Play pill (between body and bars in z-order) ──────────────────
-        AnimatedPositioned(
-          duration: const Duration(milliseconds: 420),
-          curve: Curves.easeInOutCubic,
-          bottom:
-              (_isMiniMode && !_isSearching) ? miniBarBottom : aboveBarBottom,
-          left: (_isMiniMode && !_isSearching) ? miniPlayLeft : _kPaddingH,
-          right: (_isMiniMode && !_isSearching) ? miniPlayRight : _kPaddingH,
-          height: 50.0,
-          child: AnimatedOpacity(
-            duration: const Duration(milliseconds: 220),
-            curve: Curves.easeInOut,
-            opacity: _searchFieldFocused ? 0.0 : 1.0,
-            child: IgnorePointer(
-              ignoring: _searchFieldFocused,
-              child: _PlayBarPill(
-                onTap: () {
-                  if (_isMiniMode) {
-                    _dismissMiniMode();
-                  }
-                },
-              ),
-            ),
-          ),
-        ),
-      ],
-
       // ── Bottom navigation bar ──────────────────────────────────────────────
       bottomBar: GlassTabBar.searchable(
         isSearchActive: _isMiniMode || _isSearching,
@@ -362,6 +307,13 @@ class _AppleMusicHomeScreenState extends State<AppleMusicHomeScreen> {
         horizontalPadding: _kPaddingH,
         verticalPadding: _kPaddingV,
         spacing: _kSpacing,
+        // ── tabViewBottomAccessory (iOS 26) ─────────────────────────────────
+        // The play pill sits above the tab bar in expanded mode and animates
+        // inline beside the collapsed search capsule in mini mode — matching
+        // Apple's tabViewBottomAccessory(.inline) behaviour exactly.
+        bottomAccessory: _PlayBarPill(onTap: _dismissMiniMode),
+        bottomAccessoryHeight: 50.0,
+        bottomAccessoryEnabled: !_searchFieldFocused,
         selectedIconColor: _kMusicRed,
         unselectedIconColor:
             CupertinoColors.label.resolveFrom(context).withValues(alpha: 0.9),

--- a/example/lib/apple_podcasts/apple_podcasts_demo.dart
+++ b/example/lib/apple_podcasts/apple_podcasts_demo.dart
@@ -360,6 +360,9 @@ class _ApplePodcastsHomeScreenState extends State<ApplePodcastsHomeScreen> {
       // ── Bottom navigation bar ──────────────────────────────────────────────
       bottomBar: GlassTabBar.searchable(
         isSearchActive: _isMiniMode || _isSearching,
+        bottomAccessoryPlacement: (_isMiniMode && !_isSearching)
+            ? GlassTabBarAccessoryPlacement.inline
+            : GlassTabBarAccessoryPlacement.expanded,
         selectedIndex: _selectedTab,
         onTabSelected: (index) {
           if (index == _selectedTab && _isMiniMode) {

--- a/example/lib/apple_podcasts/apple_podcasts_demo.dart
+++ b/example/lib/apple_podcasts/apple_podcasts_demo.dart
@@ -2,9 +2,11 @@
 ///
 /// Demonstrates the official "accessory shelf" pattern using Liquid Glass widgets,
 /// including a mini-player pill that expands into a full `GlassSheet` Now Playing screen.
+/// This uses the new `bottomAccessory` API in `GlassTabBar` to seamlessly handle
+/// the expanded/inline geometric transitions without manual Stack math.
 ///
 /// Run standalone:
-///   flutter run -t lib/apple_podcasts/apple_podcasts_demo.dart
+///   flutter run -d macos -t lib/apple_podcasts/apple_podcasts_demo.dart
 library;
 
 import 'package:flutter/cupertino.dart';
@@ -316,21 +318,11 @@ class _ApplePodcastsHomeScreenState extends State<ApplePodcastsHomeScreen> {
     final isIOS = defaultTargetPlatform == TargetPlatform.iOS ||
         defaultTargetPlatform == TargetPlatform.macOS;
     final sysBottom = isIOS ? 0.0 : MediaQuery.viewPaddingOf(context).bottom;
-    final bottomOffset = sysBottom;
 
-    const double expandedNavBarH = 40 + 2 * _kPaddingV; // 72.0
-    const double collapsedNavBarH = 60.0; // searchBarHeight
-
-    // Shifts down when search is active because the bar is
-    // shorter (50px vs 72px), anchoring to whichever height is current.
-    final double activeNavBarH =
-        _isSearching ? collapsedNavBarH : expandedNavBarH;
-    final double aboveBarBottom = activeNavBarH + 16.0 + bottomOffset;
-    final double miniBarBottom = _kPaddingV + bottomOffset;
-    final double contentPad = aboveBarBottom + 50.0 + 8.0;
-    const double collapsedPillW = 50.0;
-    final double miniPlayLeft = _kPaddingH + collapsedPillW + 6.0;
-    final double miniPlayRight = _kPaddingH + collapsedPillW + 6.0;
+    // Content bottom padding: bar (64) + vertical padding (16*2) + accessory (50)
+    // + spacing (8) + extra clearance (8).
+    final double contentPad =
+        _kBarH + 2 * _kPaddingV + 50.0 + _kSpacing + 8.0 + sysBottom;
 
     return GlassScaffold(
       background: ColoredBox(color: _kBackground.resolveFrom(context)),
@@ -340,7 +332,6 @@ class _ApplePodcastsHomeScreenState extends State<ApplePodcastsHomeScreen> {
       topEdgeFade: true,
       bottomEdgeFade: true,
       topEdgeFadeExtent: 0, // no app bar — just status bar fade
-      bottomBarHeight: _isMiniMode ? 20 : 40,
       bottomEdgeFadeExtent: 0, // glass bar is transparent
       resizeToAvoidBottomInset: false,
 
@@ -366,48 +357,6 @@ class _ApplePodcastsHomeScreenState extends State<ApplePodcastsHomeScreen> {
         ),
       ),
 
-      // ── Mini-player pill overlay ────────────────────────────────────────────
-      bodyOverlays: [
-        AnimatedPositioned(
-          duration: const Duration(milliseconds: 420),
-          curve: Curves.easeInOutCubic,
-          bottom:
-              (_isMiniMode && !_isSearching) ? miniBarBottom : aboveBarBottom,
-          left: (_isMiniMode && !_isSearching) ? miniPlayLeft : _kPaddingH,
-          right: (_isMiniMode && !_isSearching) ? miniPlayRight : _kPaddingH,
-          height: 50.0,
-          child: AnimatedOpacity(
-            duration: const Duration(milliseconds: 220),
-            curve: Curves.easeInOut,
-            opacity: _searchFieldFocused ? 0.0 : 1.0,
-            child: IgnorePointer(
-              ignoring: _searchFieldFocused,
-              child: GlassButton.custom(
-                onTap: () => _showNowPlayingSheet(context),
-                quality: GlassQuality.premium,
-                useOwnLayer: true,
-                width: double.infinity,
-                height: 50,
-                shape: const LiquidRoundedRectangle(borderRadius: 25),
-                settings: LiquidGlassSettings(
-                  glassColor:
-                      CupertinoTheme.brightnessOf(context) == Brightness.dark
-                          ? const Color(0xCC1C1C1E)
-                          : const Color(0xCCF2F2F7),
-                  thickness: 30,
-                  blur: 2,
-                  lightIntensity: 0.18,
-                  chromaticAberration: .01,
-                  saturation: 1.2,
-                  fresnelStrength: 0.0,
-                ),
-                child: const _MiniPlayerContent(),
-              ),
-            ),
-          ),
-        ),
-      ],
-
       // ── Bottom navigation bar ──────────────────────────────────────────────
       bottomBar: GlassTabBar.searchable(
         isSearchActive: _isMiniMode || _isSearching,
@@ -427,6 +376,31 @@ class _ApplePodcastsHomeScreenState extends State<ApplePodcastsHomeScreen> {
         horizontalPadding: _kPaddingH,
         verticalPadding: _kPaddingV,
         spacing: _kSpacing,
+        // ── tabViewBottomAccessory (iOS 26) ─────────────────────────────────
+        // Play pill sits above the bar in expanded mode; in mini-mode it
+        // slides inline beside the collapsed search capsule.
+        bottomAccessory: GlassButton.custom(
+          onTap: () => _showNowPlayingSheet(context),
+          quality: GlassQuality.premium,
+          useOwnLayer: true,
+          width: double.infinity,
+          height: 50,
+          shape: const LiquidRoundedRectangle(borderRadius: 25),
+          settings: LiquidGlassSettings(
+            glassColor: CupertinoTheme.brightnessOf(context) == Brightness.dark
+                ? const Color(0xCC1C1C1E)
+                : const Color(0xCCF2F2F7),
+            thickness: 30,
+            blur: 2,
+            lightIntensity: 0.18,
+            chromaticAberration: .01,
+            saturation: 1.2,
+            fresnelStrength: 0.0,
+          ),
+          child: const _MiniPlayerContent(),
+        ),
+        bottomAccessoryHeight: 50.0,
+        bottomAccessoryEnabled: !_searchFieldFocused,
         selectedIconColor: _kPodcastsPurple,
         unselectedIconColor: CupertinoColors.label.resolveFrom(context),
         indicatorColor: CupertinoTheme.brightnessOf(context) == Brightness.dark

--- a/lib/src/widgets/surfaces/tab_bar_bottom_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_bottom_layout.dart
@@ -34,6 +34,7 @@ import 'tab_bar_bottom_internal.dart'
         TabIndicator,
         kBottomBarGlassDefaults,
         resolveBarLabelColor;
+import '../../../widgets/surfaces/shared/tab_bar_accessory_placement.dart';
 import 'tab_bar_layout_utils.dart';
 
 /// Internal [StatefulWidget] that owns the bottom-placement rendering engine.
@@ -48,6 +49,9 @@ class TabBarBottomLayout extends StatefulWidget {
     super.key,
     this.extraButton,
     this.collapseConfig,
+    this.bottomAccessory,
+    this.bottomAccessoryEnabled = true,
+    this.bottomAccessorySpacing = 8.0,
     this.spacing = 8,
     this.horizontalPadding = 20,
     this.verticalPadding = 20,
@@ -103,6 +107,9 @@ class TabBarBottomLayout extends StatefulWidget {
   final ValueChanged<int> onTabSelected;
   final GlassTabBarExtraButton? extraButton;
   final GlassBottomBarCollapseConfig? collapseConfig;
+  final Widget? bottomAccessory;
+  final bool bottomAccessoryEnabled;
+  final double bottomAccessorySpacing;
   final double spacing;
   final double horizontalPadding;
   final double verticalPadding;
@@ -450,7 +457,7 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout>
         ? (int i) => widget.onTabSelected(widget.tabs.length - 1 - i)
         : widget.onTabSelected;
 
-    return AdaptiveLiquidGlassLayer(
+    final pillLayer = AdaptiveLiquidGlassLayer(
       clipExpansion:
           const EdgeInsets.symmetric(horizontal: 20.0, vertical: 15.0),
       settings: effectiveSettings,
@@ -680,6 +687,34 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout>
           },
         ),
       ),
+    );
+
+    if (widget.bottomAccessory == null) return pillLayer;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        GlassTabBarAccessoryPlacementScope(
+          placement: _isCollapsed
+              ? GlassTabBarAccessoryPlacement.inline
+              : GlassTabBarAccessoryPlacement.expanded,
+          child: AnimatedSize(
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeOutCubic,
+            alignment: Alignment.bottomCenter,
+            child: widget.bottomAccessoryEnabled
+                ? Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      widget.bottomAccessory!,
+                      SizedBox(height: widget.bottomAccessorySpacing),
+                    ],
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ),
+        pillLayer,
+      ],
     );
   }
 

--- a/lib/src/widgets/surfaces/tab_bar_bottom_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_bottom_layout.dart
@@ -51,7 +51,7 @@ class TabBarBottomLayout extends StatefulWidget {
     this.collapseConfig,
     this.bottomAccessory,
     this.bottomAccessoryEnabled = true,
-    this.bottomAccessorySpacing = 8.0,
+    this.bottomAccessorySpacing = 6.0,
     this.spacing = 8,
     this.horizontalPadding = 20,
     this.verticalPadding = 20,

--- a/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
@@ -54,9 +54,10 @@ class TabBarSearchableLayout extends StatefulWidget {
     this.controller,
     this.isSearchActive = false,
     this.extraButton,
+    this.bottomAccessoryPlacement,
     this.bottomAccessory,
     this.bottomAccessoryEnabled = true,
-    this.bottomAccessorySpacing = 8.0,
+    this.bottomAccessorySpacing = 6.0,
     this.bottomAccessoryHeight,
     this.spacing = 8,
     this.horizontalPadding = 20,
@@ -125,6 +126,7 @@ class TabBarSearchableLayout extends StatefulWidget {
   final SearchableBottomBarController? controller;
   final bool isSearchActive;
   final GlassTabBarExtraButton? extraButton;
+  final GlassTabBarAccessoryPlacement? bottomAccessoryPlacement;
   final Widget? bottomAccessory;
   final bool bottomAccessoryEnabled;
   final double bottomAccessorySpacing;
@@ -795,53 +797,52 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
           widget.bottomAccessorySpacing;
 
       // Total height of the combined widget.
-      // Expanded: pill + spacing + accessory  |  Inline: collapsed pill (accessory beside)
-      final expandedH = pillH + widget.bottomAccessorySpacing + accessoryH;
+      // Jumps instantly with `searching` to match `preferredSize` changes.
+      // When tabs (148), when search (134).
+      final expandedH = (searching
+              ? collapsedPillH - (pillH - collapsedPillH)
+              : collapsedPillH) +
+          widget.bottomAccessorySpacing +
+          accessoryH;
 
       final innerBarContent = barContent;
+
+      final accessoryInline = widget.bottomAccessoryPlacement ==
+          GlassTabBarAccessoryPlacement.inline;
+
       barContent = GlassTabBarAccessoryPlacementScope(
-        placement: searching
+        placement: accessoryInline
             ? GlassTabBarAccessoryPlacement.inline
             : GlassTabBarAccessoryPlacement.expanded,
-        // Single TweenAnimationBuilder drives ALL geometry from one timeline:
-        //   t = 0.0 → expanded  (accessory above the pill, pill at full barHeight)
-        //   t = 1.0 → inline    (accessory beside the pill, pill at searchBarHeight)
+        // Two independent TweenAnimationBuilders drive two independent axes:
         //
-        // This replaces the previous AnimatedContainer + AnimatedPositioned pair,
-        // which had two independent ImplicitlyAnimatedWidget controllers that could
-        // fire separate layout passes per frame and drift during mid-animation reversal.
+        //   accessoryT (outer): drives the CONTAINER height, accessory
+        //     left/right width, and coarse vertical position. Controlled by
+        //     `accessoryInline` — 0.0 means expanded above the pill, 1.0 means
+        //     inline beside the pill.
         //
-        // Performance: one AnimationController, one builder callback, one layout pass
-        // per animation frame — regardless of how many geometry values change.
+        //   searchT (inner): tracks the search bar morphing. Used to compute
+        //     the live `expandedBottom` so the play pill moves down as the bar
+        //     shrinks, maintaining a perfect 6px overlap with the top of the glass.
         child: TweenAnimationBuilder<double>(
-          tween: Tween<double>(end: searching ? 1.0 : 0.0),
+          tween: Tween<double>(end: accessoryInline ? 1.0 : 0.0),
           duration: const Duration(milliseconds: 300),
           curve: Curves.easeOutCubic,
-          builder: (context, t, child) {
-            // Outer container height: collapses as we go inline.
-            final height = ui.lerpDouble(expandedH, collapsedPillH, t)!;
+          builder: (context, accessoryT, _) {
+            // Outer container height follows the ACCESSORY state.
+            final height =
+                ui.lerpDouble(expandedH, collapsedPillH, accessoryT)!;
 
-            // Accessory bottom: moves from above-pill to vertically centred beside pill.
-            final accessoryBottom = ui.lerpDouble(
-              collapsedPillH + widget.bottomAccessorySpacing,
-              (collapsedPillH - accessoryH) / 2,
-              t,
-            )!;
-
-            // Accessory left: slides right from pill-left-edge to just past tab capsule.
+            // Accessory left/right: constant when expanded, narrows when inline.
             final accessoryLeft = ui.lerpDouble(
               widget.horizontalPadding,
               inlineAccessoryLeft,
-              t,
+              accessoryT,
             )!;
-
-            // Accessory right: slides left from pill-right-edge to just past search capsule.
-            // This simultaneously narrows the accessory width — matching the iOS 26
-            // horizontal squish as the play pill compresses into the inline slot.
             final accessoryRight = ui.lerpDouble(
               widget.horizontalPadding,
               inlineAccessoryRight,
-              t,
+              accessoryT,
             )!;
 
             return SizedBox(
@@ -849,7 +850,9 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
               child: Stack(
                 clipBehavior: Clip.none,
                 children: [
-                  // ── Glass pill: always anchored to the bottom of the Stack ──
+                  // ── Glass pill: anchored to bottom. Its height is managed
+                  //    internally by the animH TweenAnimationBuilder inside
+                  //    barContent (searching → searchBarHeight morph). ────────
                   Positioned(
                     bottom: 0,
                     left: 0,
@@ -857,24 +860,43 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                     child: innerBarContent,
                   ),
 
-                  // ── Accessory: position and width driven by the same t above ──
-                  Positioned(
-                    left: accessoryLeft,
-                    right: accessoryRight,
-                    bottom: accessoryBottom,
-                    height: accessoryH,
-                    child: AnimatedOpacity(
-                      duration: const Duration(milliseconds: 200),
-                      curve: Curves.easeOut,
-                      opacity: widget.bottomAccessoryEnabled ? 1.0 : 0.0,
-                      child: child,
-                    ),
+                  // ── Accessory: position/width driven by accessoryT AND searchT.
+                  TweenAnimationBuilder<double>(
+                    tween: Tween<double>(end: searching ? 1.0 : 0.0),
+                    duration: const Duration(milliseconds: 200),
+                    curve: Curves.easeOut,
+                    builder: (context, searchT, _) {
+                      // Move down by 14px (= pillH - collapsedPillH) when searching
+                      final expandedBottom = ui.lerpDouble(
+                        collapsedPillH + widget.bottomAccessorySpacing,
+                        collapsedPillH +
+                            widget.bottomAccessorySpacing -
+                            (pillH - collapsedPillH),
+                        searchT,
+                      )!;
+
+                      return Positioned(
+                        left: accessoryLeft,
+                        right: accessoryRight,
+                        bottom: ui.lerpDouble(
+                          expandedBottom,
+                          (collapsedPillH - accessoryH) / 2,
+                          accessoryT,
+                        )!,
+                        height: accessoryH,
+                        child: AnimatedOpacity(
+                          duration: const Duration(milliseconds: 200),
+                          curve: Curves.easeOut,
+                          opacity: widget.bottomAccessoryEnabled ? 1.0 : 0.0,
+                          child: widget.bottomAccessory,
+                        ),
+                      );
+                    },
                   ),
                 ],
               ),
             );
           },
-          child: widget.bottomAccessory,
         ),
       );
     }

--- a/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
@@ -38,6 +38,7 @@ import '../../../widgets/surfaces/shared/glass_search_bar_config.dart';
 import '../../../widgets/surfaces/shared/tab_bar_searchable_controller.dart';
 import 'tab_bar_searchable_internal.dart'
     show DismissPill, SearchPill, SearchableTabIndicator;
+import '../../../widgets/surfaces/shared/tab_bar_accessory_placement.dart';
 
 /// Internal [StatefulWidget] that owns the searchable-placement rendering engine.
 ///
@@ -53,6 +54,10 @@ class TabBarSearchableLayout extends StatefulWidget {
     this.controller,
     this.isSearchActive = false,
     this.extraButton,
+    this.bottomAccessory,
+    this.bottomAccessoryEnabled = true,
+    this.bottomAccessorySpacing = 8.0,
+    this.bottomAccessoryHeight,
     this.spacing = 8,
     this.horizontalPadding = 20,
     this.verticalPadding = 20,
@@ -120,6 +125,10 @@ class TabBarSearchableLayout extends StatefulWidget {
   final SearchableBottomBarController? controller;
   final bool isSearchActive;
   final GlassTabBarExtraButton? extraButton;
+  final Widget? bottomAccessory;
+  final bool bottomAccessoryEnabled;
+  final double bottomAccessorySpacing;
+  final double? bottomAccessoryHeight;
   final double spacing;
   final double horizontalPadding;
   final double verticalPadding;
@@ -361,7 +370,7 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
         _applyWhiten(widget.settings ?? _defaultGlassSettings, isLight);
     final searching = widget.isSearchActive;
 
-    final barContent = TweenAnimationBuilder<double>(
+    Widget barContent = TweenAnimationBuilder<double>(
       tween: Tween<double>(
           end: searching ? widget.searchBarHeight : widget.barHeight),
       duration: const Duration(milliseconds: 200),
@@ -748,6 +757,127 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
         );
       },
     );
+
+    if (widget.bottomAccessory != null) {
+      // Phase 2 — iOS 26 tabViewBottomAccessory inline/expanded layout.
+      //
+      // Expanded state (searching == false):
+      //   Column: [accessory widget above] → [glass pill below]
+      //   The accessory is positioned above the pill with bottomAccessorySpacing gap.
+      //
+      // Inline state (searching == true / mini-mode):
+      //   Stack: the glass pill animates to searchBarHeight (handled by
+      //   TweenAnimationBuilder inside barContent). The accessory slides from
+      //   above-the-pill to beside-the-pill at the same vertical level, filling
+      //   the horizontal space to the right of the collapsed search capsule.
+      //   This exactly mirrors Apple's "tabViewBottomAccessory(.inline)" behaviour.
+      //
+      // Inline positions are derived from widget constants (horizontalPadding,
+      // collapsedTabWidth, searchBarHeight) — no GlobalKey measurement needed.
+      final accessoryH = widget.bottomAccessoryHeight ?? 0.0;
+
+      // The collapsed (search-active) bar height as it appears visually — the
+      // glass pill shrinks from barHeight → searchBarHeight.
+      // We add verticalPadding *2 to match the Padding inside AdaptiveLiquidGlassLayer.
+      final pillH = widget.barHeight + widget.verticalPadding * 2;
+      final collapsedPillH =
+          widget.searchBarHeight + widget.verticalPadding * 2;
+
+      // When inline, the accessory sits exactly between the collapsed tab pill (left)
+      // and the collapsed search capsule (right).
+      final collapsedTabW =
+          widget.searchConfig.collapsedTabWidth ?? widget.searchBarHeight;
+      final inlineAccessoryLeft = widget.horizontalPadding +
+          collapsedTabW +
+          widget.bottomAccessorySpacing;
+      final inlineAccessoryRight = widget.horizontalPadding +
+          widget.searchBarHeight +
+          widget.bottomAccessorySpacing;
+
+      // Total height of the combined widget.
+      // Expanded: pill + spacing + accessory  |  Inline: collapsed pill (accessory beside)
+      final expandedH = pillH + widget.bottomAccessorySpacing + accessoryH;
+
+      final innerBarContent = barContent;
+      barContent = GlassTabBarAccessoryPlacementScope(
+        placement: searching
+            ? GlassTabBarAccessoryPlacement.inline
+            : GlassTabBarAccessoryPlacement.expanded,
+        // Single TweenAnimationBuilder drives ALL geometry from one timeline:
+        //   t = 0.0 → expanded  (accessory above the pill, pill at full barHeight)
+        //   t = 1.0 → inline    (accessory beside the pill, pill at searchBarHeight)
+        //
+        // This replaces the previous AnimatedContainer + AnimatedPositioned pair,
+        // which had two independent ImplicitlyAnimatedWidget controllers that could
+        // fire separate layout passes per frame and drift during mid-animation reversal.
+        //
+        // Performance: one AnimationController, one builder callback, one layout pass
+        // per animation frame — regardless of how many geometry values change.
+        child: TweenAnimationBuilder<double>(
+          tween: Tween<double>(end: searching ? 1.0 : 0.0),
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOutCubic,
+          builder: (context, t, child) {
+            // Outer container height: collapses as we go inline.
+            final height = ui.lerpDouble(expandedH, collapsedPillH, t)!;
+
+            // Accessory bottom: moves from above-pill to vertically centred beside pill.
+            final accessoryBottom = ui.lerpDouble(
+              collapsedPillH + widget.bottomAccessorySpacing,
+              (collapsedPillH - accessoryH) / 2,
+              t,
+            )!;
+
+            // Accessory left: slides right from pill-left-edge to just past tab capsule.
+            final accessoryLeft = ui.lerpDouble(
+              widget.horizontalPadding,
+              inlineAccessoryLeft,
+              t,
+            )!;
+
+            // Accessory right: slides left from pill-right-edge to just past search capsule.
+            // This simultaneously narrows the accessory width — matching the iOS 26
+            // horizontal squish as the play pill compresses into the inline slot.
+            final accessoryRight = ui.lerpDouble(
+              widget.horizontalPadding,
+              inlineAccessoryRight,
+              t,
+            )!;
+
+            return SizedBox(
+              height: height,
+              child: Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  // ── Glass pill: always anchored to the bottom of the Stack ──
+                  Positioned(
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    child: innerBarContent,
+                  ),
+
+                  // ── Accessory: position and width driven by the same t above ──
+                  Positioned(
+                    left: accessoryLeft,
+                    right: accessoryRight,
+                    bottom: accessoryBottom,
+                    height: accessoryH,
+                    child: AnimatedOpacity(
+                      duration: const Duration(milliseconds: 200),
+                      curve: Curves.easeOut,
+                      opacity: widget.bottomAccessoryEnabled ? 1.0 : 0.0,
+                      child: child,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+          child: widget.bottomAccessory,
+        ),
+      );
+    }
 
     if (widget.onBarTap == null) return barContent;
     return GestureDetector(

--- a/lib/widgets/surfaces/glass_scaffold.dart
+++ b/lib/widgets/surfaces/glass_scaffold.dart
@@ -372,8 +372,9 @@ class GlassScaffold extends StatelessWidget {
     final effectiveAppBarHeight = appBar is PreferredSizeWidget
         ? (appBar! as PreferredSizeWidget).preferredSize.height
         : appBarHeight;
-    final effectiveBottomBarHeight =
-        bottomBar != null ? (bottomBarHeight ?? 60.0) : 0.0;
+    final effectiveBottomBarHeight = bottomBar is PreferredSizeWidget
+        ? (bottomBar as PreferredSizeWidget).preferredSize.height
+        : (bottomBar != null ? (bottomBarHeight ?? 60.0) : 0.0);
 
     // Resolve edge fade toggles.
     final doFadeTop = topEdgeFade ?? (edgeFade && appBar != null);

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -23,6 +23,7 @@ import '../../src/widgets/surfaces/tab_bar_bottom_layout.dart';
 import '../../src/widgets/surfaces/tab_bar_searchable_layout.dart';
 
 export 'shared/glass_search_bar_config.dart';
+export 'shared/tab_bar_accessory_placement.dart';
 
 /// The iOS 26 structural navigation bar widget.
 ///
@@ -126,7 +127,7 @@ enum _GlassTabBarPlacement { bottom, searchable, inline }
 /// ```
 ///
 /// The old widgets still work — they are zero-logic deprecation shims.
-class GlassTabBar extends StatefulWidget {
+class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
   // ─── Bottom constructor ────────────────────────────────────────────────────
 
   /// Creates a floating bottom tab bar — the iOS 26 `UITabBarController` equivalent.
@@ -138,9 +139,17 @@ class GlassTabBar extends StatefulWidget {
   ///
   /// ## Play-pill / mini-player accessory
   ///
-  /// Place persistent overlays (mini-player, Now Playing) above the bar using
-  /// [GlassScaffold.bodyOverlays] + [AnimatedPositioned] — not inside this
-  /// widget. That is the equivalent of Apple's `tabViewBottomAccessory`.
+  /// Pass a widget to [bottomAccessory] to render a persistent overlay (e.g. a
+  /// mini-player) above the glass tab bar pill — identical to iOS 26's
+  /// `tabViewBottomAccessory` modifier.
+  ///
+  /// Supply [bottomAccessoryHeight] so that [GlassScaffold] can include the
+  /// accessory in its `effectiveBottomBarHeight` (via [preferredSize]) and
+  /// correctly compute body edge-fades. If omitted the scroll area will be
+  /// inset only by the pill height.
+  ///
+  /// Toggle visibility with [bottomAccessoryEnabled]: the accessory animates
+  /// in/out with an `AnimatedSize` so there is no jump.
   const GlassTabBar.bottom({
     required List<GlassTab> tabs,
     required int selectedIndex,
@@ -149,6 +158,10 @@ class GlassTabBar extends StatefulWidget {
     GlassTabBarExtraButton? extraButton,
     GlassBottomBarCollapseConfig? collapseConfig,
     ScrollController? scrollController,
+    Widget? bottomAccessory,
+    bool bottomAccessoryEnabled = true,
+    double bottomAccessorySpacing = 8.0,
+    double? bottomAccessoryHeight,
     double spacing = 8,
     double horizontalPadding = 20,
     double verticalPadding = 20,
@@ -203,6 +216,10 @@ class GlassTabBar extends StatefulWidget {
           extraButton: extraButton,
           collapseConfig: collapseConfig,
           scrollController: scrollController,
+          bottomAccessory: bottomAccessory,
+          bottomAccessoryEnabled: bottomAccessoryEnabled,
+          bottomAccessorySpacing: bottomAccessorySpacing,
+          bottomAccessoryHeight: bottomAccessoryHeight,
           spacing: spacing,
           horizontalPadding: horizontalPadding,
           verticalPadding: verticalPadding,
@@ -400,6 +417,10 @@ class GlassTabBar extends StatefulWidget {
     SearchableBottomBarController? controller,
     bool isSearchActive = false,
     GlassTabBarExtraButton? extraButton,
+    Widget? bottomAccessory,
+    bool bottomAccessoryEnabled = true,
+    double bottomAccessorySpacing = 8.0,
+    double? bottomAccessoryHeight,
     double spacing = 8,
     double horizontalPadding = 20,
     double verticalPadding = 20,
@@ -463,6 +484,10 @@ class GlassTabBar extends StatefulWidget {
           controller: controller,
           isSearchActive: isSearchActive,
           extraButton: extraButton,
+          bottomAccessory: bottomAccessory,
+          bottomAccessoryEnabled: bottomAccessoryEnabled,
+          bottomAccessorySpacing: bottomAccessorySpacing,
+          bottomAccessoryHeight: bottomAccessoryHeight,
           spacing: spacing,
           horizontalPadding: horizontalPadding,
           verticalPadding: verticalPadding,
@@ -572,6 +597,10 @@ class GlassTabBar extends StatefulWidget {
       this.adaptiveBrightness = false,
       this.onBrightnessChanged,
       this.brightnessOverride,
+      this.bottomAccessory,
+      this.bottomAccessoryEnabled = true,
+      this.bottomAccessorySpacing = 8.0,
+      this.bottomAccessoryHeight,
       // Searchable-only
       this.searchConfig,
       this.controller,
@@ -595,6 +624,12 @@ class GlassTabBar extends StatefulWidget {
               collapseConfig == null ||
               extraButton != null,
           'GlassTabBar.bottom collapseConfig requires extraButton.',
+        ),
+        assert(
+          bottomAccessory == null || bottomAccessoryHeight != null,
+          'Provide bottomAccessoryHeight when using bottomAccessory so that '
+          'GlassScaffold can correctly compute the body scroll inset and '
+          'edge-fade height. Without it, content will scroll behind the accessory.',
         );
 
   /// List of tabs to display.
@@ -791,6 +826,36 @@ class GlassTabBar extends StatefulWidget {
   final ValueListenable<Brightness>? brightnessOverride;
 
   // ---------------------------------------------------------------------------
+  // Accessory / Mini-Player fields
+  // ---------------------------------------------------------------------------
+
+  /// The widget to display above the tab bar pill (e.g. a mini-player).
+  ///
+  /// This mirrors the iOS 26 `tabViewBottomAccessory` API.
+  final Widget? bottomAccessory;
+
+  /// Controls whether the [bottomAccessory] is shown.
+  ///
+  /// When toggled, the accessory animates in/out using `AnimatedSize` with an
+  /// iOS 26-calibrated ease-out cubic curve (300 ms). [preferredSize] is
+  /// updated in sync so [GlassScaffold] always reports the correct body inset.
+  final bool bottomAccessoryEnabled;
+
+  /// Vertical gap between the [bottomAccessory] and the glass tab bar.
+  final double bottomAccessorySpacing;
+
+  /// The known height of the [bottomAccessory].
+  ///
+  /// **Required for correct [GlassScaffold] integration.** When provided,
+  /// [preferredSize] includes this value so the scaffold's body edge-fade
+  /// correctly clears the accessory. If omitted, the scaffold sees only the
+  /// pill height and content will scroll behind the accessory.
+  ///
+  /// Must be the rendered height of the accessory widget, excluding
+  /// [bottomAccessorySpacing] (which is added automatically).
+  final double? bottomAccessoryHeight;
+
+  // ---------------------------------------------------------------------------
   // Searchable-only fields
   // ---------------------------------------------------------------------------
 
@@ -828,6 +893,32 @@ class GlassTabBar extends StatefulWidget {
   final ScrollController? scrollController;
 
   @override
+  Size get preferredSize {
+    // Base pill height. The searchable variant alternates between barHeight
+    // (expanded) and searchBarHeight (inline/mini) — use whichever is active.
+    // Both branches multiply verticalPadding by 2 (top + bottom) to match
+    // the symmetric Padding applied inside AdaptiveLiquidGlassLayer.
+    final effectivePillH =
+        (_placement == _GlassTabBarPlacement.searchable && isSearchActive)
+            ? searchBarHeight + verticalPadding * 2
+            : barHeight + verticalPadding * 2;
+
+    double total = effectivePillH;
+
+    // In searchable inline mode the accessory sits BESIDE the pill (no extra
+    // height). Only add accessory height in the expanded state.
+    final isInline =
+        _placement == _GlassTabBarPlacement.searchable && isSearchActive;
+    if (!isInline &&
+        bottomAccessory != null &&
+        bottomAccessoryEnabled &&
+        bottomAccessoryHeight != null) {
+      total += bottomAccessoryHeight! + bottomAccessorySpacing;
+    }
+    return Size.fromHeight(total);
+  }
+
+  @override
   State<GlassTabBar> createState() => _GlassTabBarState();
 }
 
@@ -858,6 +949,9 @@ class _GlassTabBarState extends State<GlassTabBar> {
       onTabSelected: widget.onTabSelected,
       extraButton: widget.extraButton,
       collapseConfig: widget.collapseConfig,
+      bottomAccessory: widget.bottomAccessory,
+      bottomAccessoryEnabled: widget.bottomAccessoryEnabled,
+      bottomAccessorySpacing: widget.bottomAccessorySpacing,
       spacing: widget.spacing,
       horizontalPadding: widget.horizontalPadding,
       verticalPadding: widget.verticalPadding,
@@ -974,6 +1068,10 @@ class _GlassTabBarState extends State<GlassTabBar> {
       controller: widget.controller,
       isSearchActive: widget.isSearchActive,
       extraButton: widget.extraButton,
+      bottomAccessory: widget.bottomAccessory,
+      bottomAccessoryEnabled: widget.bottomAccessoryEnabled,
+      bottomAccessorySpacing: widget.bottomAccessorySpacing,
+      bottomAccessoryHeight: widget.bottomAccessoryHeight,
       spacing: widget.spacing,
       horizontalPadding: widget.horizontalPadding,
       verticalPadding: widget.verticalPadding,

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -24,6 +24,7 @@ import '../../src/widgets/surfaces/tab_bar_searchable_layout.dart';
 
 export 'shared/glass_search_bar_config.dart';
 export 'shared/tab_bar_accessory_placement.dart';
+import 'shared/tab_bar_accessory_placement.dart';
 
 /// The iOS 26 structural navigation bar widget.
 ///
@@ -160,7 +161,7 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
     ScrollController? scrollController,
     Widget? bottomAccessory,
     bool bottomAccessoryEnabled = true,
-    double bottomAccessorySpacing = 8.0,
+    double bottomAccessorySpacing = 6.0,
     double? bottomAccessoryHeight,
     double spacing = 8,
     double horizontalPadding = 20,
@@ -417,9 +418,10 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
     SearchableBottomBarController? controller,
     bool isSearchActive = false,
     GlassTabBarExtraButton? extraButton,
+    GlassTabBarAccessoryPlacement? bottomAccessoryPlacement,
     Widget? bottomAccessory,
     bool bottomAccessoryEnabled = true,
-    double bottomAccessorySpacing = 8.0,
+    double bottomAccessorySpacing = 6.0,
     double? bottomAccessoryHeight,
     double spacing = 8,
     double horizontalPadding = 20,
@@ -484,6 +486,7 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
           controller: controller,
           isSearchActive: isSearchActive,
           extraButton: extraButton,
+          bottomAccessoryPlacement: bottomAccessoryPlacement,
           bottomAccessory: bottomAccessory,
           bottomAccessoryEnabled: bottomAccessoryEnabled,
           bottomAccessorySpacing: bottomAccessorySpacing,
@@ -597,9 +600,10 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
       this.adaptiveBrightness = false,
       this.onBrightnessChanged,
       this.brightnessOverride,
+      this.bottomAccessoryPlacement,
       this.bottomAccessory,
       this.bottomAccessoryEnabled = true,
-      this.bottomAccessorySpacing = 8.0,
+      this.bottomAccessorySpacing = 6.0,
       this.bottomAccessoryHeight,
       // Searchable-only
       this.searchConfig,
@@ -832,6 +836,14 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
   /// The widget to display above the tab bar pill (e.g. a mini-player).
   ///
   /// This mirrors the iOS 26 `tabViewBottomAccessory` API.
+  final GlassTabBarAccessoryPlacement? bottomAccessoryPlacement;
+
+  /// The accessory widget rendered above (expanded) or beside (inline) the tab
+  /// bar pill. Typically a mini-player or contextual action row.
+  ///
+  /// The accessory widget can read its current placement via
+  /// [GlassTabBarAccessoryPlacementScope.of] to adapt its layout between the
+  /// full expanded row and the compact inline strip.
   final Widget? bottomAccessory;
 
   /// Controls whether the [bottomAccessory] is shown.
@@ -905,15 +917,27 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
 
     double total = effectivePillH;
 
-    // In searchable inline mode the accessory sits BESIDE the pill (no extra
-    // height). Only add accessory height in the expanded state.
+    // In inline mode the accessory sits BESIDE the pill (no extra height).
+    // Only explicit .inline placement counts — never auto-infer from search state,
+    // because the layout engine (TabBarSearchableLayout) does NOT auto-collapse either.
     final isInline =
-        _placement == _GlassTabBarPlacement.searchable && isSearchActive;
-    if (!isInline &&
-        bottomAccessory != null &&
+        bottomAccessoryPlacement == GlassTabBarAccessoryPlacement.inline;
+
+    if (bottomAccessory != null &&
+        !isInline &&
         bottomAccessoryEnabled &&
         bottomAccessoryHeight != null) {
-      total += bottomAccessoryHeight! + bottomAccessorySpacing;
+      // Guard: gapAdjustment only makes sense in the searchable placement when
+      // both heights differ. For .bottom placement isSearchActive is always false
+      // so effectivePillH == barHeight + vertPad*2 and gapAdjustment == 0.
+      final gapAdjustment =
+          (_placement == _GlassTabBarPlacement.searchable && isSearchActive)
+              ? barHeight - searchBarHeight
+              : 0.0;
+      total = effectivePillH -
+          gapAdjustment +
+          bottomAccessorySpacing +
+          bottomAccessoryHeight!;
     }
     return Size.fromHeight(total);
   }
@@ -1068,6 +1092,7 @@ class _GlassTabBarState extends State<GlassTabBar> {
       controller: widget.controller,
       isSearchActive: widget.isSearchActive,
       extraButton: widget.extraButton,
+      bottomAccessoryPlacement: widget.bottomAccessoryPlacement,
       bottomAccessory: widget.bottomAccessory,
       bottomAccessoryEnabled: widget.bottomAccessoryEnabled,
       bottomAccessorySpacing: widget.bottomAccessorySpacing,

--- a/lib/widgets/surfaces/shared/tab_bar_accessory_placement.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_accessory_placement.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/widgets.dart';
+
+/// Defines the visual placement state of a [GlassTabBar] bottom accessory.
+///
+/// This mirrors iOS 26's `TabViewBottomAccessoryPlacement` exactly, providing
+/// the state machine needed for an accessory (like a mini-player) to adapt
+/// its layout when the tab bar minimizes.
+enum GlassTabBarAccessoryPlacement {
+  /// The tab bar is in its normal, full-height state. The accessory should
+  /// render as a full row sitting above the glass pill.
+  expanded,
+
+  /// The tab bar has been minimized (e.g. via scroll). The accessory should
+  /// collapse into a compact horizontal strip that fits inside the minimized
+  /// bar's footprint.
+  inline,
+}
+
+/// Provides the current [GlassTabBarAccessoryPlacement] to the widget tree.
+///
+/// This is the Flutter equivalent of SwiftUI's
+/// `@Environment(\.tabViewBottomAccessoryPlacement)`.
+///
+/// Read it inside your accessory widget to adapt your layout:
+/// ```dart
+/// final placement = GlassTabBarAccessoryPlacementScope.of(context);
+/// return switch (placement) {
+///   GlassTabBarAccessoryPlacement.expanded => FullPlayer(),
+///   GlassTabBarAccessoryPlacement.inline => CompactPlayer(),
+/// };
+/// ```
+class GlassTabBarAccessoryPlacementScope extends InheritedWidget {
+  /// Creates a scope that provides the placement state to descendants.
+  const GlassTabBarAccessoryPlacementScope({
+    required this.placement,
+    required super.child,
+    super.key,
+  });
+
+  /// The current placement state.
+  final GlassTabBarAccessoryPlacement placement;
+
+  /// Retrieves the closest [GlassTabBarAccessoryPlacement] from the tree.
+  ///
+  /// Defaults to [GlassTabBarAccessoryPlacement.expanded] if no scope is found.
+  static GlassTabBarAccessoryPlacement of(BuildContext context) {
+    final scope = context.dependOnInheritedWidgetOfExactType<
+        GlassTabBarAccessoryPlacementScope>();
+    return scope?.placement ?? GlassTabBarAccessoryPlacement.expanded;
+  }
+
+  @override
+  bool updateShouldNotify(GlassTabBarAccessoryPlacementScope oldWidget) {
+    return placement != oldWidget.placement;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: liquid_glass_widgets
 description: "iOS 26-style liquid glass widgets for Flutter. Built on a custom fragment shader for real blur, liquid interactions, specular highlights, and chromatic aberration."
-version: 0.28.1
+version: 0.29.0
 
 
 homepage: https://github.com/sdegenaar/liquid_glass_widgets

--- a/test/widgets/surfaces/tab_bar_accessory_test.dart
+++ b/test/widgets/surfaces/tab_bar_accessory_test.dart
@@ -31,8 +31,10 @@ void main() {
 
       // Test the preferredSize computation.
       var tabBar = tester.widget<GlassTabBar>(find.byType(GlassTabBar));
-      // Base bar height (64) + vertical padding (20) * 2 + accessory (50) + spacing (8) = 162
-      expect(tabBar.preferredSize.height, 162.0);
+      // isSearchActive: false → effectivePillH = barHeight(64) + vertPad(20*2) = 104
+      // gapAdjustment = 0 (not searching)
+      // total = 104 + spacing(6) + accessory(50) = 160
+      expect(tabBar.preferredSize.height, 160.0);
 
       // Rebuild in inline mode
       await tester.pumpWidget(
@@ -56,8 +58,44 @@ void main() {
       );
 
       tabBar = tester.widget<GlassTabBar>(find.byType(GlassTabBar));
-      // Base search bar height (36) + vertical padding (20) * 2 = 76 (accessory is beside, not added to height)
-      expect(tabBar.preferredSize.height, 76.0);
+      // isSearchActive: true, no explicit placement → stays expanded (no auto-collapse)
+      // effectivePillH = searchBarHeight(36) + vertPad(40) = 76
+      // gapAdjustment = barHeight(64) - searchBarHeight(36) = 28
+      // total = 76 - 28 + spacing(6) + accessory(50) = 104
+      expect(tabBar.preferredSize.height, 104.0);
+    });
+
+    testWidgets(
+        'searchable placement can be overridden by bottomAccessoryPlacement',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GlassTabBar.searchable(
+              isSearchActive: true, // Tabs collapsed
+              bottomAccessoryPlacement: GlassTabBarAccessoryPlacement
+                  .expanded, // But accessory above!
+              tabs: const [GlassTab(label: '1'), GlassTab(label: '2')],
+              selectedIndex: 0,
+              onTabSelected: (_) {},
+              searchBarHeight: 36,
+              searchConfig: GlassSearchBarConfig(
+                onSearchToggle: (_) {},
+              ),
+              bottomAccessory:
+                  const SizedBox(height: 50, width: 100, key: Key('acc')),
+              bottomAccessoryHeight: 50,
+            ),
+          ),
+        ),
+      );
+
+      final tabBar = tester.widget<GlassTabBar>(find.byType(GlassTabBar));
+      // Base search bar height (36) + vertical padding (20) * 2 = 76
+      // Gap adjustment: barHeight (64) - searchBarHeight (36) = 28
+      // PLUS accessory height (50) + spacing (6)
+      // Total = 76 - 28 + 6 + 50 = 104.0
+      expect(tabBar.preferredSize.height, 104.0);
     });
   });
 }

--- a/test/widgets/surfaces/tab_bar_accessory_test.dart
+++ b/test/widgets/surfaces/tab_bar_accessory_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+void main() {
+  group('GlassTabBar Accessory iOS 26 Layout', () {
+    testWidgets('searchable placement uses TweenAnimationBuilder',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GlassTabBar.searchable(
+              isSearchActive: false,
+              tabs: const [GlassTab(label: '1'), GlassTab(label: '2')],
+              selectedIndex: 0,
+              onTabSelected: (_) {},
+              searchConfig: GlassSearchBarConfig(
+                onSearchToggle: (_) {},
+              ),
+              bottomAccessory:
+                  const SizedBox(height: 50, width: 100, key: Key('acc')),
+              bottomAccessoryHeight: 50,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byKey(const Key('acc')), findsOneWidget);
+      // In searchable mode, TweenAnimationBuilder is used for the accessory animation.
+      expect(find.byType(TweenAnimationBuilder<double>), findsWidgets);
+
+      // Test the preferredSize computation.
+      var tabBar = tester.widget<GlassTabBar>(find.byType(GlassTabBar));
+      // Base bar height (64) + vertical padding (20) * 2 + accessory (50) + spacing (8) = 162
+      expect(tabBar.preferredSize.height, 162.0);
+
+      // Rebuild in inline mode
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GlassTabBar.searchable(
+              isSearchActive: true,
+              tabs: const [GlassTab(label: '1'), GlassTab(label: '2')],
+              selectedIndex: 0,
+              onTabSelected: (_) {},
+              searchBarHeight: 36, // Explicitly match my mental calculation
+              searchConfig: GlassSearchBarConfig(
+                onSearchToggle: (_) {},
+              ),
+              bottomAccessory:
+                  const SizedBox(height: 50, width: 100, key: Key('acc')),
+              bottomAccessoryHeight: 50,
+            ),
+          ),
+        ),
+      );
+
+      tabBar = tester.widget<GlassTabBar>(find.byType(GlassTabBar));
+      // Base search bar height (36) + vertical padding (20) * 2 = 76 (accessory is beside, not added to height)
+      expect(tabBar.preferredSize.height, 76.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds `bottomAccessory` support to `GlassTabBar.bottom` and `GlassTabBar.searchable`, mirroring Apple's iOS 26 `tabViewBottomAccessory` modifier.

## New API
- `bottomAccessory` — widget rendered as a persistent accessory (e.g. mini-player)
- `bottomAccessoryHeight` — required so `GlassScaffold` computes edge-fades correctly
- `bottomAccessoryEnabled` — animates the accessory in/out

## Behaviour
- **Expanded**: accessory floats above the nav bar pill
- **Inline** (`searchable` only): accessory slides into the gap between the collapsed tab indicator and search capsule with a simultaneous width squish, matching iOS 26 `.inline` placement

## Fixes
- Single `TweenAnimationBuilder` replaces `AnimatedContainer` + `AnimatedPositioned` pair — one layout pass per frame, no drift on mid-transition reversal
- Fixed `preferredSize` `verticalPadding` asymmetry (`* 1` to `* 2`)
- Removed dead `LayoutBuilder` wrapper

## Demos
- Apple Music and Apple Podcasts migrated, removed all manual Stack math

## Tests
- Added tab_bar_accessory_test.dart
- 2,517/2,517 passing
- dart analyze --fatal-infos: zero issues