### PR TITLE
fix(sheet): stale _currentState, overscroll axis guard, one-shot axis lock

### DIFF
--- a/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
@@ -533,7 +533,35 @@ class GestureArena {
     final dy = (y - dragStartY).abs();
     final dx = (x - dragStartX).abs();
 
-    if (dy > threshold && dy > dx) {
+    // Decide the axis ONCE per touch, on the first movement past the
+    // threshold, and hold that decision for the rest of the gesture.
+    //
+    // The comparison is still cumulative from the touch origin, but it is now
+    // only ever read at the moment of decision, which fixes two things:
+    //
+    //  * A gesture that started horizontal stays horizontal. Previously the
+    //    test was re-run on every move, so a sideways swipe would grab the
+    //    sheet the instant total vertical travel happened to exceed total
+    //    horizontal — and conversely, after a long sideways scroll the sheet
+    //    could not be dragged at all without out-travelling that distance
+    //    vertically, which on a wide swipe is most of the screen.
+    //  * The reverse latch is gone. `contentDrag` was only ever set from a
+    //    vertical-looking move and then never re-evaluated, so a horizontal
+    //    swipe that began with a slight vertical wobble dragged the sheet for
+    //    its whole duration.
+    //
+    // Below the threshold on both axes the gesture is still undecided; return
+    // false and wait rather than guessing from a few pixels of noise.
+    if (dy <= threshold && dx <= threshold) return false;
+
+    if (dx >= dy) {
+      // Horizontal. An inner scrollable owns this touch; the sheet stays out
+      // of it until the finger lifts and `reset()` clears the phase.
+      phase = GesturePhase.scrolling;
+      return false;
+    }
+
+    if (dy > threshold) {
       // At the topmost detent the sheet can't expand further, so an inner
       // scroll view (if any) owns the gesture. maxState is `full` for a
       // normal sheet but `half` for a half-only sheet (enableFull: false),

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -219,6 +219,15 @@ class _GlassModalSheetState extends State<GlassModalSheet>
     // target mid-gesture. `_settledState` only updates inside this
     // branch, ensuring side effects fire on every consumer-visible
     // state transition.
+    // Reconcile `_currentState` on EVERY snap, not just on consumer-visible
+    // transitions. `_applyDrag` and `_jumpTo` mutate it silently to the
+    // in-flight *predicted* target, so a drag that ends back at the state it
+    // started from leaves that prediction behind: the sheet rests at `half`
+    // while `_currentState` still reads `full`. `evaluateMove` then takes its
+    // `currentState == maxState` branch and refuses every upward drag, so the
+    // sheet appears stuck until a downward drag re-predicts and resyncs it.
+    _currentState = state;
+
     if (state != _settledState) {
       if (state == GlassSheetState.peek || state == GlassSheetState.hidden) {
         HapticFeedback.lightImpact();
@@ -226,7 +235,6 @@ class _GlassModalSheetState extends State<GlassModalSheet>
         HapticFeedback.mediumImpact();
       }
 
-      _currentState = state;
       _settledState = state;
       widget.onStateChanged?.call(state);
 

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -270,6 +270,14 @@ class _GlassModalSheetState extends State<GlassModalSheet>
   // ════════════════════════════════════════════════════════════════════════
 
   bool _onScrollNotification(ScrollNotification notification) {
+    // Vertical only. Scroll notifications bubble from ANY descendant, so a
+    // horizontal list inside the sheet — a date strip, a carousel — emits
+    // exactly this shape when it is pulled past its leading edge. Without the
+    // axis guard the sheet claimed the gesture and re-anchored its vertical
+    // drag origin to the finger's current y, so scrolling sideways dragged
+    // the sheet, and the re-anchoring could hold `dy` under the threshold
+    // indefinitely, leaving the sheet unable to expand.
+    if (notification.metrics.axis != Axis.vertical) return false;
     if (notification is OverscrollNotification && notification.overscroll < 0) {
       if (_gestureArena.phase == GesturePhase.scrolling ||
           _gestureArena.phase == GesturePhase.idle) {

--- a/test/widgets/overlays/glass_modal_sheet_mechanics_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_mechanics_test.dart
@@ -297,6 +297,56 @@ void main() {
       expect(arena.phase, GesturePhase.contentDrag);
     });
 
+    test('a horizontal gesture locks out the sheet for the whole touch', () {
+      // Regression: the axis test used to be re-run on every move, so a
+      // sideways swipe grabbed the sheet the moment cumulative vertical
+      // travel overtook horizontal — a wobble at the end of a scroll.
+      arena.beginPointer(100, 50, 0.3, PointerDeviceKind.touch);
+      // Decisive sideways movement first.
+      expect(
+          arena.evaluateMove(
+              102, 90, GlassSheetState.half, GlassSheetState.full, 5,
+              canScrollListUp: false, hasScrollClients: true),
+          isFalse);
+      expect(arena.phase, GesturePhase.scrolling);
+      // Now drag hard vertically WITHOUT lifting. The sheet must stay out.
+      expect(
+          arena.evaluateMove(
+              -200, 90, GlassSheetState.half, GlassSheetState.full, 5,
+              canScrollListUp: false, hasScrollClients: true),
+          isFalse);
+      expect(arena.phase, GesturePhase.scrolling);
+    });
+
+    test('a long sideways scroll does not block the NEXT drag', () {
+      // The other half of the same bug: after ~220pt sideways the sheet
+      // needed >220pt vertical before it would respond. A fresh touch must
+      // start clean.
+      arena.beginPointer(100, 50, 0.3, PointerDeviceKind.touch);
+      arena.evaluateMove(105, 270, GlassSheetState.half, GlassSheetState.full, 5,
+          canScrollListUp: false, hasScrollClients: true);
+      expect(arena.phase, GesturePhase.scrolling);
+      arena.reset();
+      arena.beginPointer(100, 270, 0.3, PointerDeviceKind.touch);
+      expect(
+          arena.evaluateMove(
+              80, 270, GlassSheetState.half, GlassSheetState.full, 5,
+              canScrollListUp: false, hasScrollClients: true),
+          isTrue);
+      expect(arena.phase, GesturePhase.contentDrag);
+    });
+
+    test('stays undecided until movement clears the threshold', () {
+      // A few pixels of noise must not pick an axis.
+      arena.beginPointer(100, 50, 0.3, PointerDeviceKind.touch);
+      expect(
+          arena.evaluateMove(
+              103, 52, GlassSheetState.half, GlassSheetState.full, 5,
+              canScrollListUp: false, hasScrollClients: true),
+          isFalse);
+      expect(arena.phase, GesturePhase.idle);
+    });
+
     test('half state vertical drag → contentDrag', () {
       arena.beginPointer(100, 50, 0.5, PointerDeviceKind.touch);
       final r = arena.evaluateMove(

--- a/test/widgets/overlays/glass_modal_sheet_state_coverage_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_state_coverage_test.dart
@@ -34,6 +34,58 @@ Widget _makeSheet({
     );
 
 void main() {
+  group('horizontal content does not hijack the sheet', () {
+    testWidgets('a sideways gesture that turns vertical never moves the sheet',
+        (tester) async {
+      // The user-visible symptom both the axis guard and the one-shot axis
+      // lock exist to prevent. Scroll notifications bubble from ANY
+      // descendant, so pulling a HORIZONTAL list past its leading edge used
+      // to make the sheet claim the gesture and re-anchor its vertical drag
+      // origin; the axis test was also re-run on every move, so the moment
+      // the finger turned upward the sheet came with it.
+      //
+      // The L-shape is the point: a pure sideways drag never moved the sheet
+      // anyway (the vertical delta is ~zero), which is why this has to keep
+      // the finger down and change direction.
+      await tester.pumpWidget(_makeSheet(
+        sheetChild: ListView(
+          scrollDirection: Axis.horizontal,
+          physics: const BouncingScrollPhysics(),
+          children: [
+            for (int i = 0; i < 20; i++)
+              SizedBox(width: 120, child: Text('col $i')),
+          ],
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      final before = tester.getTopLeft(find.text('col 0')).dy;
+      final g = await tester.startGesture(tester.getCenter(find.text('col 0')));
+      // Sideways first, past the leading edge — this is what emits
+      // OverscrollNotification with overscroll < 0.
+      for (var i = 0; i < 6; i++) {
+        await g.moveBy(const Offset(30, 0));
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      // Now upward, WITHOUT lifting.
+      for (var i = 0; i < 8; i++) {
+        await g.moveBy(const Offset(0, -25));
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      final during = tester.getTopLeft(find.text('col 0')).dy;
+      await g.up();
+      await tester.pumpAndSettle();
+
+      // Tolerance, not zero: the sheet applies `interactionScale` on
+      // pointer-down, which nudges its children a few points without any drag
+      // taking place. The bug moves the sheet by the FULL vertical travel
+      // (200pt here), so anything under ~20 cleanly separates "squeezed" from
+      // "dragged".
+      expect((during - before).abs(), lessThan(20.0),
+          reason: 'the sheet must not follow a gesture that began sideways');
+    });
+  });
+
   group('GlassModalSheetController — attach/detach', () {
     testWidgets('controller has valid currentState after mount',
         (tester) async {


### PR DESCRIPTION
Fixes #196 — all three, as suggested.

## 1. `_currentState` left holding a mid-drag prediction

`_applyDrag` and `_jumpTo` set `_currentState` to `resolveTarget(...)` — a
*prediction* of where the drag would land, not where the sheet is.
`_snapToState` only reconciled it inside `if (state != _settledState)`, so a
drag that ended at the state it started from left the prediction behind: the
sheet rests at `half` while `_currentState` reads `full`.

`evaluateMove` then takes its `currentState == maxState` branch and refuses
every upward drag, so the sheet appears stuck until a downward drag
re-predicts and resyncs it. `onStateChanged` never fires for any of it, so a
host app mirroring sheet state can't detect or work around it.

Reconciling on every snap. Side effects stay gated on `_settledState` as
intended.

## 2. `_onScrollNotification` ignored the notification's axis

It reacted to any `OverscrollNotification` with `overscroll < 0` by claiming
the gesture and re-anchoring `dragStartY` to the finger's current y. Scroll
notifications bubble from every descendant, so a **horizontal** list inside
the sheet emits exactly that shape when pulled past its leading edge.

Two consequences: scrolling sideways dragged the sheet, and the repeated
re-anchoring could hold `dy` under the 10pt threshold indefinitely, leaving
the sheet unable to expand at all.

Now ignores anything whose `metrics.axis` isn't vertical.

## 3. Axis test re-run on every move

`if (dy > threshold && dy > dx)` was evaluated continuously against cumulative
travel from the touch origin, which broke in both directions:

- A sideways swipe grabbed the sheet the instant total vertical travel
  overtook total horizontal.
- After a long sideways scroll, the sheet couldn't be dragged without
  out-travelling that distance vertically — most of the screen on a wide
  swipe.

The `contentDrag` latch compounded it: only ever set from a vertical-looking
move and never re-evaluated, so a horizontal swipe that began with a slight
wobble dragged the sheet for its whole duration.

The axis is now decided **once**, on the first movement past the threshold,
and held until the touch lifts. Below the threshold on both axes the gesture
stays undecided rather than guessing from a few pixels of noise.

## Tests

Three arena cases in `glass_modal_sheet_mechanics_test.dart`:

- a horizontal gesture locks the sheet out for the whole touch
- a long sideways scroll doesn't poison the *next* drag
- sub-threshold movement stays undecided

Plus a widget-level L-gesture in `glass_modal_sheet_state_coverage_test.dart`
— sideways past the leading edge, then upward without lifting. The L-shape is
load-bearing: a pure sideways drag never moved the sheet anyway (the vertical
delta is ~zero), so the finger has to stay down and change direction.

That test moves the sheet **202pt** without these fixes and **3.7pt** with
them, the remainder being `interactionScale` on pointer-down rather than a
drag.

All 148 existing sheet tests pass unchanged.

## Device verification

Built against a physical iPhone (iOS 26.6) with these changes in place, not
just the test harness. The original repro — drag the sheet up short of the
snap threshold, release, then try to expand — no longer sticks, and a
sideways scrub on a horizontal list inside the sheet no longer drags it.

## Note on the full suite

23 tests fail here, all golden/renderer/theme (e.g. `variant: macOS`). They
reproduce on a clean `upstream/main` checkout on this machine, so they're
environmental and unrelated — flagging in case they're green on yours.

## Provenance

Found while debugging a modal sheet over a Mapbox `PlatformView` in an iOS
app. #1 was caught by instrumenting the gesture arena on a physical device —
the state is private, so it took a probe inside the package to see
`currentState/maxState` reading `full/full` while the sheet was rendered at
`half`.
