### PR TITLE
fix(shaders): stop flipping sampling UVs on Impeller GLES (Flutter 3.46+)

### DIFF
--- a/docs/PROGRESSIVE_BLUR.md
+++ b/docs/PROGRESSIVE_BLUR.md
@@ -63,8 +63,11 @@ The bound texture is the **whole backdrop** (the screen), not the bar's own
 rectangle, so `uSize` is the screen size. To make the gradient run across the
 *bar* rather than the whole screen, the widget passes its own device-pixel
 rectangle (`uRegionOriginPx` / `uRegionSizePx`) into the shader and normalises
-the gradient over that. The GLES backend captures the backdrop y-flipped, which
-the shader corrects under `IMPELLER_TARGET_OPENGLES`.
+the gradient over that. On Flutter 3.44/3.45 the GLES backend captured the
+backdrop y-flipped, which the shader corrects under `LGR_GLES_FLIP_SAMPLE_Y`
+(see `shaders/gles_compat.glsl`). Flutter 3.46+ stores render-to-texture content
+top-down on every backend, so the correction is compiled out there — applying it
+anyway is what caused #201.
 
 ## Usage
 

--- a/shaders/gles_compat.glsl
+++ b/shaders/gles_compat.glsl
@@ -1,0 +1,60 @@
+// Copyright 2026, Sebastian Degenaar for pixel-innovations.com (liquid_glass_widgets)
+//
+// SPDX-License-Identifier: MIT
+//
+// OpenGL ES texture-origin compatibility.
+//
+// ## Background
+//
+// Impeller's GLES backend used to store render-to-texture content with GL's
+// native bottom-left origin, while Metal and Vulkan stored it top-down. Every
+// fragment shader that sampled a Flutter-provided texture (a BackdropFilter
+// snapshot, a `toImageSync` capture, a sampler bound via `setImageSampler`) had
+// to compensate by hand:
+//
+//     #ifdef IMPELLER_TARGET_OPENGLES
+//         uv.y = 1.0 - uv.y;
+//     #endif
+//
+// Flutter PR #186556 ("[Impeller] Retire Y-coord-scale plumbing by flipping
+// GLES at the vertex stage") absorbed that difference inside the GLES backend,
+// so render-to-texture content is now stored top-down on *every* backend. The
+// manual flip above became not merely unnecessary but actively wrong: it
+// mirrors every sample vertically.
+//
+// That change shipped in **Flutter 3.46**. It is absent from 3.44 and 3.45.
+//
+// ## How to detect which convention the toolchain uses
+//
+// `impellerc` defines `IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED` on the GLES
+// runtime stages — and *only* on engines that have removed the flip (Flutter
+// PR #187316 added it for exactly this purpose). Its presence therefore means
+// "textures are already top-down; do not flip". Its absence on a GLES stage
+// means we are being compiled by Flutter 3.44/3.45, which still needs the flip.
+//
+// [LGR_GLES_FLIP_SAMPLE_Y] encodes that decision once. Shaders sampling a
+// Flutter-provided texture must gate their Y compensation on it rather than on
+// `IMPELLER_TARGET_OPENGLES` directly:
+//
+//     #ifdef LGR_GLES_FLIP_SAMPLE_Y
+//         uv.y = 1.0 - uv.y;
+//     #endif
+//
+// Keeping the condition in one header means the eventual removal of the
+// deprecated macro from Flutter (at which point the package can drop support
+// for < 3.46) is a one-line change here, not a hunt across five shaders.
+//
+// NOTE: this is about the *texture sampling* convention only. It does not
+// affect `FlutterFragCoord()`, which has always reported Y-down fragment
+// positions on every backend.
+
+#ifndef LGR_GLES_COMPAT_GLSL_
+#define LGR_GLES_COMPAT_GLSL_
+
+#if defined(IMPELLER_TARGET_OPENGLES) && \
+    !defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)
+// Flutter 3.44 / 3.45 GLES: textures are bottom-left origin, flip by hand.
+#define LGR_GLES_FLIP_SAMPLE_Y 1
+#endif
+
+#endif  // LGR_GLES_COMPAT_GLSL_

--- a/shaders/interactive_indicator.frag
+++ b/shaders/interactive_indicator.frag
@@ -6,6 +6,7 @@
 // indicators (segmented controls, pills). Fully original implementation.
 
 #include <flutter/runtime_effect.glsl>
+#include "gles_compat.glsl"
 
 precision highp float;
 
@@ -215,10 +216,12 @@ void main() {
   vec2 edgeOffsetUV = edgeOffsetLogical / uBackgroundSize;
   
   // Apply refraction offset along the surface normal.
-  // On OpenGL ES the background texture is stored with a bottom-left Y origin,
-  // so edgeOffsetLogical.y (computed in Flutter's Y-down space) must be
+  // On pre-3.46 OpenGL ES the background texture is stored with a bottom-left Y
+  // origin, so edgeOffsetLogical.y (computed in Flutter's Y-down space) must be
   // negated to sample in the correct outward direction in the Y-up UV space.
-  #ifdef IMPELLER_TARGET_OPENGLES
+  // Flutter 3.46+ stores it top-down on every backend (see gles_compat.glsl),
+  // where negating would invert the refraction instead of correcting it.
+  #ifdef LGR_GLES_FLIP_SAMPLE_Y
     vec2 localRefracted = posInBg + vec2(edgeOffsetLogical.x, -edgeOffsetLogical.y);
   #else
     vec2 localRefracted = posInBg - edgeOffsetLogical;

--- a/shaders/lightweight_glass.frag
+++ b/shaders/lightweight_glass.frag
@@ -7,6 +7,7 @@
 // Fully original implementation.
 
 #include <flutter/runtime_effect.glsl>
+#include "gles_compat.glsl"
 
 precision highp float;
 
@@ -391,9 +392,10 @@ void main() {
       vec2 edgeOffset = surfaceNormal * edgeInfluence * uThickness * 0.5;
       vec2 refractedUV = uv + edgeOffset / uBackgroundSize;
 
-      // On OpenGL ES the background texture uses bottom-left Y origin;
+      // On pre-3.46 OpenGL ES the background texture uses bottom-left Y origin;
       // edgeOffset.y (computed in Flutter's Y-down space) must be negated.
-      #ifdef IMPELLER_TARGET_OPENGLES
+      // Flutter 3.46+ unified the convention — see gles_compat.glsl.
+      #ifdef LGR_GLES_FLIP_SAMPLE_Y
           refractedUV = uv + vec2(edgeOffset.x, -edgeOffset.y) / uBackgroundSize;
       #endif
 

--- a/shaders/liquid_glass_final_render.frag
+++ b/shaders/liquid_glass_final_render.frag
@@ -30,6 +30,7 @@ precision highp float; // mediump causes colour banding (10-bit mantissa on mobi
 
 #include <flutter/runtime_effect.glsl>
 #include "displacement_encoding.glsl"
+#include "gles_compat.glsl"
 #include "render.glsl"
 
 // Slot 0-1:  uSize           — physical-pixel size of the backdrop capture
@@ -171,12 +172,16 @@ void main() {
     // In BackdropFilter mode uCaptureOffset == vec2(0) so this is a no-op.
     vec2 screenUV = (fragCoord + uCaptureOffset) * invTexSize;
 
-    #ifdef IMPELLER_TARGET_OPENGLES
+    // Pre-3.46 GLES stored render-to-texture content bottom-up; see
+    // gles_compat.glsl. On 3.46+ the backend absorbs the difference and this
+    // flip must NOT be applied, or the glass samples the backdrop mirrored
+    // about the screen's horizontal centre line.
+    #ifdef LGR_GLES_FLIP_SAMPLE_Y
         screenUV.y = 1.0 - screenUV.y;
     #endif
 
     vec2 geometryUV = (fragCoord - uGeometryOffset) / uGeometrySize;
-    #ifdef IMPELLER_TARGET_OPENGLES
+    #ifdef LGR_GLES_FLIP_SAMPLE_Y
         geometryUV.y = 1.0 - geometryUV.y;
     #endif
 
@@ -229,13 +234,15 @@ void main() {
     // Scale displacement by uRefractScale (uOpticalProps.w) to ensure logical-pixel
     // identical refraction magnitude across all device pixel ratios.
     displacement *= uOpticalProps.w;
-    // On OpenGL ES, screenUV.y is already flipped to (1.0 - y) to compensate
-    // for the bottom-left texture-origin convention.  The displacement is
-    // computed in Flutter's native Y-down space (outward normal at the bottom
-    // edge has +Y), but adding a positive Y delta to the flipped UV moves the
-    // sample TOWARD the centre rather than away — inverting the refraction.
-    // Negating displacement.y re-aligns it with the Y-up UV sampling space.
-    #ifdef IMPELLER_TARGET_OPENGLES
+    // On pre-3.46 OpenGL ES, screenUV.y is flipped to (1.0 - y) above to
+    // compensate for the bottom-left texture-origin convention.  The
+    // displacement is computed in Flutter's native Y-down space (outward normal
+    // at the bottom edge has +Y), but adding a positive Y delta to the flipped
+    // UV moves the sample TOWARD the centre rather than away — inverting the
+    // refraction.  Negating displacement.y re-aligns it with the Y-up UV
+    // sampling space.  Gated on the same condition as the UV flip itself: on
+    // 3.46+ the UV is not flipped, so negating here would invert refraction.
+    #ifdef LGR_GLES_FLIP_SAMPLE_Y
         displacement.y = -displacement.y;
     #endif
 

--- a/shaders/progressive_blur.frag
+++ b/shaders/progressive_blur.frag
@@ -1,4 +1,5 @@
 #include <flutter/runtime_effect.glsl>
+#include "gles_compat.glsl"
 // Copyright 2026, Rebar Ahmad. Licensed under the package's MIT License.
 //
 // One axis of a SEPARABLE gaussian, used twice (horizontal then vertical) via
@@ -37,9 +38,11 @@ void main() {
   else                       g = 1.0 - rn.x;  // strong RIGHT
   float sigma = uMaxSigma * pow(1.0 - g, uFalloff);
 
-  // Screen-normalised sampling UV (GLES captures the backdrop y-flipped).
+  // Screen-normalised sampling UV. Pre-3.46 GLES captured the backdrop
+  // y-flipped; 3.46+ stores it top-down like every other backend. See
+  // gles_compat.glsl.
   vec2 uv = FlutterFragCoord().xy / uSize;
-#ifdef IMPELLER_TARGET_OPENGLES
+#ifdef LGR_GLES_FLIP_SAMPLE_Y
   uv.y = 1.0 - uv.y;
 #endif
 

--- a/test/shaders/gles_flip_guard_test.dart
+++ b/test/shaders/gles_flip_guard_test.dart
@@ -1,0 +1,114 @@
+// Guards the OpenGL ES texture-origin compatibility contract in shaders/.
+//
+// Flutter 3.46 (PR #186556) made Impeller's GLES backend store
+// render-to-texture content top-down, matching Metal and Vulkan. Shaders that
+// still compensate with `uv.y = 1.0 - uv.y` under a bare
+// `#ifdef IMPELLER_TARGET_OPENGLES` mirror every sample vertically on GLES —
+// the regression reported in issue #201 (garbled GlassTabbar on the Pixel 9
+// emulator, which falls back to Impeller GLES while physical devices run
+// Vulkan).
+//
+// The correct guard is `LGR_GLES_FLIP_SAMPLE_Y` from shaders/gles_compat.glsl,
+// which is only defined when the toolchain is a pre-3.46 SDK that still needs
+// the flip. See that header for the full explanation.
+//
+// This is a source-level test on purpose. The defect only manifests on the GLES
+// backend, which `flutter test` never exercises — it renders through Skia. A
+// widget or golden test therefore cannot catch it, but a grep over the shader
+// sources can, and it costs nothing.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('GLES texture-origin compatibility', () {
+    final shaderDir = Directory('shaders');
+
+    test('shaders/ is discoverable from the test working directory', () {
+      expect(
+        shaderDir.existsSync(),
+        isTrue,
+        reason: 'Expected to run with the package root as cwd.',
+      );
+    });
+
+    test('gles_compat.glsl gates the flip on the deprecation macro', () {
+      final header = File('shaders/gles_compat.glsl');
+      expect(header.existsSync(), isTrue);
+
+      final source = header.readAsStringSync();
+
+      // Both halves of the condition matter. Dropping IMPELLER_TARGET_OPENGLES
+      // would flip on every backend; dropping the UNFLIPPED_DEPRECATED negation
+      // would reintroduce #201 on Flutter 3.46+.
+      expect(
+        source,
+        contains('IMPELLER_TARGET_OPENGLES'),
+        reason: 'The flip must remain scoped to the GLES stages.',
+      );
+      expect(
+        source,
+        contains('!defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)'),
+        reason: 'The flip must be suppressed on Flutter 3.46+, which '
+            'no longer stores GLES render targets bottom-up.',
+      );
+      expect(source, contains('#define LGR_GLES_FLIP_SAMPLE_Y'));
+    });
+
+    test('no shader guards a Y-flip on a bare IMPELLER_TARGET_OPENGLES', () {
+      final offenders = <String>[];
+
+      for (final entity in shaderDir.listSync()) {
+        if (entity is! File) continue;
+        final path = entity.path.replaceAll(r'\', '/');
+        if (!path.endsWith('.frag') && !path.endsWith('.glsl')) continue;
+        // The compat header is the one place allowed to name the raw macro.
+        if (path.endsWith('gles_compat.glsl')) continue;
+
+        final lines = entity.readAsLinesSync();
+        for (var i = 0; i < lines.length; i++) {
+          final line = lines[i];
+          if (!line.contains('IMPELLER_TARGET_OPENGLES')) continue;
+          // A comment referring to the macro by name is fine; a preprocessor
+          // conditional branching on it directly is not.
+          final trimmed = line.trimLeft();
+          if (!trimmed.startsWith('#')) continue;
+          offenders.add('$path:${i + 1}: $trimmed');
+        }
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason: 'These shaders branch on IMPELLER_TARGET_OPENGLES directly. '
+            'Use LGR_GLES_FLIP_SAMPLE_Y (shaders/gles_compat.glsl) so the '
+            'compensation is skipped on Flutter 3.46+:\n'
+            '${offenders.join('\n')}',
+      );
+    });
+
+    test('every shader that flips a sampling UV includes gles_compat.glsl', () {
+      final missing = <String>[];
+
+      for (final entity in shaderDir.listSync()) {
+        if (entity is! File) continue;
+        final path = entity.path.replaceAll(r'\', '/');
+        if (!path.endsWith('.frag')) continue;
+
+        final source = entity.readAsStringSync();
+        if (!source.contains('LGR_GLES_FLIP_SAMPLE_Y')) continue;
+        if (source.contains('#include "gles_compat.glsl"')) continue;
+        missing.add(path);
+      }
+
+      expect(
+        missing,
+        isEmpty,
+        reason: 'LGR_GLES_FLIP_SAMPLE_Y is undefined without the header, so '
+            'the guarded branch would silently never compile in:\n'
+            '${missing.join('\n')}',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #201.

## What was wrong

Flutter PR [flutter/flutter#186556](https://github.com/flutter/flutter/pull/186556) — *"[Impeller] Retire Y-coord-scale plumbing by flipping GLES at the vertex stage"* — absorbed OpenGL ES's render-to-texture Y-axis difference inside the GLES backend, so render-to-texture content is now stored **top-down on every backend**, matching Metal and Vulkan. It shipped in **Flutter 3.46** and is absent from 3.44/3.45.

Every shader here that samples a Flutter-provided texture still compensates for the *old* bottom-left convention by hand:

```glsl
#ifdef IMPELLER_TARGET_OPENGLES
    screenUV.y = 1.0 - screenUV.y;
#endif
```

On 3.46+ that compensation is no longer a no-op — it actively mirrors every sample about the horizontal centre line. In `liquid_glass_final_render.frag` it hits three places at once: the backdrop UV, the geometry (SDF matte) UV, and the `displacement.y` negation that existed only to re-align refraction with the flipped UV space. So a `GlassTabbar` indicator samples the backdrop from the opposite side of the screen *and* reads its own surface normals upside down.

That explains the otherwise-confusing platform matrix in #201 — physical Android devices run Impeller **Vulkan** and iOS runs **Metal**, neither of which defines `IMPELLER_TARGET_OPENGLES`. Only environments where Impeller falls back to **OpenGL ES** break, which in practice is mostly the Android emulator.

## The fix

New `shaders/gles_compat.glsl` derives the convention once, from `IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED` — the macro `impellerc` defines only on SDKs that removed the flip, added by [flutter/flutter#187316](https://github.com/flutter/flutter/pull/187316) for exactly this migration:

```glsl
#if defined(IMPELLER_TARGET_OPENGLES) && \
    !defined(IMPELLER_OPENGLES_UNFLIPPED_DEPRECATED)
#define LGR_GLES_FLIP_SAMPLE_Y 1
#endif
```

Six sites across four shaders now gate on `LGR_GLES_FLIP_SAMPLE_Y` instead of `IMPELLER_TARGET_OPENGLES`:

| shader | sites |
| --- | --- |
| `liquid_glass_final_render.frag` | backdrop UV, geometry UV, `displacement.y` |
| `interactive_indicator.frag` | refraction offset direction |
| `lightweight_glass.frag` | refraction offset direction |
| `progressive_blur.frag` | backdrop sampling UV |

Because the condition keys off a macro that pre-3.46 toolchains simply don't define, this stays correct on **3.44/3.45 as well as 3.46+** — the `flutter: ">=3.41.0"` constraint in `pubspec.yaml` does not need to move. Keeping the condition in one header also means that when the deprecated macro is eventually removed from Flutter, dropping support for < 3.46 is a one-line change rather than a hunt across five shaders.

I deliberately left `CHANGELOG.md` and the `pubspec.yaml` version untouched — those are yours to decide on release.

## Verification

**Toolchain level.** Probed a shader that `#error`s on the resolved condition against every target `flutter_tools` emits, using the 3.47.0 `impellerc`:

| target stage | `LGR_GLES_FLIP_SAMPLE_Y` |
| --- | --- |
| `--runtime-stage-gles` | not defined ✅ |
| `--runtime-stage-gles3` | not defined ✅ |
| `--runtime-stage-vulkan` | not defined ✅ |
| `--runtime-stage-metal` | not defined ✅ |
| `--sksl` | not defined ✅ |
| GLES with the deprecation macro forced off (simulates ≤ 3.45) | **defined** ✅ |

**Generated-code level.** Compiling before/after with the exact Android target set (`--sksl --runtime-stage-gles --runtime-stage-gles3 --runtime-stage-vulkan`) and normalising SSA temporaries:

- GLES stage: the diff is *only* the removed flips — `_371.y = 1.0 - _371.y`, `_383.y = 1.0 - _383.y`, `_N.y = -_N.y` disappear, nothing else changes.
- SkSL / Metal / Vulkan stages: **identical**. So iOS, physical Android, desktop and web output is provably unaffected by this PR.
- `liquid_glass_geometry_blended.frag`: zero change (it never sampled a Flutter-provided texture).

**On a device.** Android emulator (API 36, x86_64) with the log confirming `Using the Impeller rendering backend (OpenGLES)`, on Flutter 3.47.0. Test page is a `GlassTabBar.bottom` over a vertically asymmetric backdrop — warm red/orange in the top half, cool blue/cyan in the bottom half, with numbered rulers 0–11:

| | what the bar's glass shows |
| --- | --- |
| **before** | warm red/orange and ruler **`0`** — content from the screen *top*, though the bar sits at the bottom over cyan |
| **after** | cyan/teal and ruler **`11`** — the content actually behind it, with refraction and rim lighting intact |

The bar sits at roughly y = 0.95 of screen height; mirrored that is 1 − 0.95 ≈ 0.05, which lands exactly on ruler `0`. Screenshots had to be taken host-side (`adb emu screenrecord screenshot`) — guest `adb shell screencap` returns an all-black frame for Flutter surfaces on this emulator, which is worth knowing if you ever try to reproduce this from a screenshot.

**Suite.** `flutter analyze` clean. `flutter test` shows the same pre-existing failures as an untouched `main` checkout (3 goldens / `liquid_glass_test`), verified by running them on both trees — none related to this change, which is expected given the SkSL output is identical.

## Regression guard

Added `test/shaders/gles_flip_guard_test.dart`. This defect is invisible to the existing suite — it only manifests on the GLES backend, and `flutter test` renders through Skia — so a widget or golden test cannot catch it. Instead it asserts at source level that no shader branches on `IMPELLER_TARGET_OPENGLES` directly, that the compat header keeps both halves of its condition, and that any shader using the guard actually includes the header. Reverting any one of the four shaders makes it fail and print the offending file and line.

## Note on authorship

I used Claude Code to help investigate and draft this fix — locating the upstream Flutter change that caused the regression, and building the compile-time and on-device verification described above. I have reviewed the diff, and the reproduction and before/after behaviour were checked by hand on a real emulator. Flagging it in the interest of the repo's AI contribution guidelines; happy to rework anything that doesn't match how you'd like this handled.
