### PR TITLE
fix(ProgressiveBlur): resolve the shader region at paint time

### DIFF
--- a/lib/widgets/effects/progressive_blur.dart
+++ b/lib/widgets/effects/progressive_blur.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' as ui;
 
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 /// The edge a [ProgressiveBlur] is *strongest* at; it eases to perfectly sharp
@@ -180,48 +181,208 @@ class _ProgressiveBlurState extends State<ProgressiveBlur> {
     }
 
     // The bound texture (and thus uSize, float indices 0,1) is the WHOLE
-    // backdrop, not this widget — so we pass the widget's own device-pixel
-    // rectangle to normalise the gradient over the bar (see the .frag header).
-    // The bar is anchored at the top-left of the backdrop layer (true for top
-    // app bars), so its origin is (0,0); LayoutBuilder gives its size.
-    // coverage:ignore-start
-    // Requires a compiled FragmentProgram; the headless test VM never provides
-    // one. The fallback path above is tested.
-    final dpr = MediaQuery.devicePixelRatioOf(context);
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final wPx = constraints.maxWidth * dpr;
-        final hPx = constraints.maxHeight * dpr;
-        void configure(ui.FragmentShader s, double axis) {
-          s
-            ..setFloat(2, widget.maxSigma * dpr)
-            ..setFloat(3, widget.falloff)
-            ..setFloat(4, widget.direction._uniform)
-            ..setFloat(5, axis) // 0 = horizontal, 1 = vertical
-            ..setFloat(6, 0) // region origin x (device px)
-            ..setFloat(7, 0) // region origin y (device px)
-            ..setFloat(8, wPx) // region width (device px)
-            ..setFloat(9, hPx); // region height (device px)
-        }
-
-        configure(h, 0);
-        configure(v, 1);
-
-        // Separable 2-pass: horizontal (inner) then vertical (outer) = a clean
-        // 2-D gaussian.
-        final filter = ui.ImageFilter.compose(
-          outer: ui.ImageFilter.shader(v),
-          inner: ui.ImageFilter.shader(h),
-        );
-
-        return ClipRect(
-          child: BackdropFilter(
-            filter: filter,
-            child: const SizedBox.expand(),
-          ),
-        );
-      },
+    // backdrop, not this widget — so the shader needs this widget's own
+    // device-pixel rectangle to normalise the gradient over. Both halves of
+    // that rectangle are resolved at PAINT time; see [_RenderProgressiveBlur].
+    return _ProgressiveBlurLayer(
+      hShader: h,
+      vShader: v,
+      maxSigma: widget.maxSigma,
+      falloff: widget.falloff,
+      direction: widget.direction,
+      devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
+      child: const SizedBox.expand(),
     );
-    // coverage:ignore-end
   }
+}
+
+/// The eight uniforms describing the blur region, in the order the program
+/// declares them (float indices 2-9).
+///
+/// Pure, and public to tests, because the defect this replaced was a hard-coded
+/// zero in the middle of a widget build — which no test could see: the shader
+/// path needs a compiled [ui.FragmentProgram], and a headless VM never provides
+/// one. The arithmetic can at least be pinned.
+@visibleForTesting
+List<double> progressiveBlurUniforms({
+  required Offset origin,
+  required Size size,
+  required double devicePixelRatio,
+  required double maxSigma,
+  required double falloff,
+  required ProgressiveBlurDirection direction,
+  required double axis,
+}) =>
+    <double>[
+      maxSigma * devicePixelRatio,
+      falloff,
+      direction._uniform,
+      axis, // 0 = horizontal, 1 = vertical
+      origin.dx * devicePixelRatio,
+      origin.dy * devicePixelRatio,
+      size.width * devicePixelRatio,
+      size.height * devicePixelRatio,
+    ];
+
+/// Applies the two-pass shader as a backdrop filter.
+///
+/// A render object rather than a [BackdropFilter] under a [LayoutBuilder]
+/// because the region rectangle is only knowable — and only stays current — at
+/// paint time. Two consequences fall out of that:
+///
+///  * The widget's offset within the backdrop layer changes whenever an
+///    ancestor MOVES it: a sheet being dragged, a scroll, an animated inset.
+///    Those move it by repainting, not by rebuilding, so an offset read during
+///    build (or in a post-frame callback) is stale for as long as the motion
+///    lasts, and the gradient is normalised over the wrong rectangle the whole
+///    time.
+///  * Dropping the [LayoutBuilder] also lets a [ProgressiveBlur] sit under a
+///    parent that asks for intrinsic dimensions, which LayoutBuilder refuses to
+///    answer.
+class _ProgressiveBlurLayer extends SingleChildRenderObjectWidget {
+  const _ProgressiveBlurLayer({
+    required this.hShader,
+    required this.vShader,
+    required this.maxSigma,
+    required this.falloff,
+    required this.direction,
+    required this.devicePixelRatio,
+    required Widget super.child,
+  });
+
+  final ui.FragmentShader hShader;
+  final ui.FragmentShader vShader;
+  final double maxSigma;
+  final double falloff;
+  final ProgressiveBlurDirection direction;
+  final double devicePixelRatio;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderProgressiveBlur(
+        hShader: hShader,
+        vShader: vShader,
+        maxSigma: maxSigma,
+        falloff: falloff,
+        direction: direction,
+        devicePixelRatio: devicePixelRatio,
+      );
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    _RenderProgressiveBlur renderObject,
+  ) {
+    renderObject
+      ..hShader = hShader
+      ..vShader = vShader
+      ..maxSigma = maxSigma
+      ..falloff = falloff
+      ..direction = direction
+      ..devicePixelRatio = devicePixelRatio;
+  }
+}
+
+class _RenderProgressiveBlur extends RenderProxyBox {
+  _RenderProgressiveBlur({
+    required ui.FragmentShader hShader,
+    required ui.FragmentShader vShader,
+    required double maxSigma,
+    required double falloff,
+    required ProgressiveBlurDirection direction,
+    required double devicePixelRatio,
+  })  : _hShader = hShader,
+        _vShader = vShader,
+        _maxSigma = maxSigma,
+        _falloff = falloff,
+        _direction = direction,
+        _devicePixelRatio = devicePixelRatio;
+
+  ui.FragmentShader _hShader;
+  set hShader(ui.FragmentShader v) {
+    if (identical(_hShader, v)) return;
+    _hShader = v;
+    markNeedsPaint();
+  }
+
+  ui.FragmentShader _vShader;
+  set vShader(ui.FragmentShader v) {
+    if (identical(_vShader, v)) return;
+    _vShader = v;
+    markNeedsPaint();
+  }
+
+  double _maxSigma;
+  set maxSigma(double v) {
+    if (_maxSigma == v) return;
+    _maxSigma = v;
+    markNeedsPaint();
+  }
+
+  double _falloff;
+  set falloff(double v) {
+    if (_falloff == v) return;
+    _falloff = v;
+    markNeedsPaint();
+  }
+
+  ProgressiveBlurDirection _direction;
+  set direction(ProgressiveBlurDirection v) {
+    if (_direction == v) return;
+    _direction = v;
+    markNeedsPaint();
+  }
+
+  double _devicePixelRatio;
+  set devicePixelRatio(double v) {
+    if (_devicePixelRatio == v) return;
+    _devicePixelRatio = v;
+    markNeedsPaint();
+  }
+
+  @override
+  bool get alwaysNeedsCompositing => true;
+
+  @override
+  BackdropFilterLayer? get layer => super.layer as BackdropFilterLayer?;
+
+  // coverage:ignore-start
+  // Reached only with a compiled FragmentProgram, which the headless test VM
+  // never provides; [progressiveBlurUniforms] carries the testable arithmetic.
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    if (child == null) {
+      layer = null;
+      return;
+    }
+    // The offset in the backdrop layer's own coordinate space — which is what
+    // the shader's FlutterFragCoord() is expressed in.
+    final origin = localToGlobal(Offset.zero);
+    _configure(_hShader, 0, origin);
+    _configure(_vShader, 1, origin);
+
+    // Separable 2-pass: horizontal (inner) then vertical (outer) = a clean
+    // 2-D gaussian.
+    (layer ??= BackdropFilterLayer()).filter = ui.ImageFilter.compose(
+      outer: ui.ImageFilter.shader(_vShader),
+      inner: ui.ImageFilter.shader(_hShader),
+    );
+    context.pushLayer(layer!, super.paint, offset);
+  }
+
+  void _configure(ui.FragmentShader shader, double axis, Offset origin) {
+    final uniforms = progressiveBlurUniforms(
+      origin: origin,
+      size: size,
+      devicePixelRatio: _devicePixelRatio,
+      maxSigma: _maxSigma,
+      falloff: _falloff,
+      direction: _direction,
+      axis: axis,
+    );
+    for (var i = 0; i < uniforms.length; i++) {
+      shader.setFloat(2 + i, uniforms[i]);
+    }
+  }
+  // coverage:ignore-end
 }

--- a/lib/widgets/effects/progressive_blur.dart
+++ b/lib/widgets/effects/progressive_blur.dart
@@ -184,6 +184,9 @@ class _ProgressiveBlurState extends State<ProgressiveBlur> {
     // backdrop, not this widget — so the shader needs this widget's own
     // device-pixel rectangle to normalise the gradient over. Both halves of
     // that rectangle are resolved at PAINT time; see [_RenderProgressiveBlur].
+    // coverage:ignore-start
+    // Requires a compiled FragmentProgram; the headless test VM never provides
+    // one. The fallback path above is tested.
     return _ProgressiveBlurLayer(
       hShader: h,
       vShader: v,
@@ -193,6 +196,7 @@ class _ProgressiveBlurState extends State<ProgressiveBlur> {
       devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
       child: const SizedBox.expand(),
     );
+    // coverage:ignore-end
   }
 }
 
@@ -223,6 +227,12 @@ List<double> progressiveBlurUniforms({
       size.width * devicePixelRatio,
       size.height * devicePixelRatio,
     ];
+
+// Everything below is reachable only with a compiled FragmentProgram, which a
+// headless VM never provides — so it cannot be exercised by `flutter test`, and
+// the region maths is factored into [progressiveBlurUniforms] above so that the
+// part which CAN be tested, is.
+// coverage:ignore-start
 
 /// Applies the two-pass shader as a backdrop filter.
 ///
@@ -272,15 +282,15 @@ class _ProgressiveBlurLayer extends SingleChildRenderObjectWidget {
   void updateRenderObject(
     BuildContext context,
     _RenderProgressiveBlur renderObject,
-  ) {
-    renderObject
-      ..hShader = hShader
-      ..vShader = vShader
-      ..maxSigma = maxSigma
-      ..falloff = falloff
-      ..direction = direction
-      ..devicePixelRatio = devicePixelRatio;
-  }
+  ) =>
+      renderObject.update(
+        hShader: hShader,
+        vShader: vShader,
+        maxSigma: maxSigma,
+        falloff: falloff,
+        direction: direction,
+        devicePixelRatio: devicePixelRatio,
+      );
 }
 
 class _RenderProgressiveBlur extends RenderProxyBox {
@@ -299,44 +309,38 @@ class _RenderProgressiveBlur extends RenderProxyBox {
         _devicePixelRatio = devicePixelRatio;
 
   ui.FragmentShader _hShader;
-  set hShader(ui.FragmentShader v) {
-    if (identical(_hShader, v)) return;
-    _hShader = v;
-    markNeedsPaint();
-  }
-
   ui.FragmentShader _vShader;
-  set vShader(ui.FragmentShader v) {
-    if (identical(_vShader, v)) return;
-    _vShader = v;
-    markNeedsPaint();
-  }
-
   double _maxSigma;
-  set maxSigma(double v) {
-    if (_maxSigma == v) return;
-    _maxSigma = v;
-    markNeedsPaint();
-  }
-
   double _falloff;
-  set falloff(double v) {
-    if (_falloff == v) return;
-    _falloff = v;
-    markNeedsPaint();
-  }
-
   ProgressiveBlurDirection _direction;
-  set direction(ProgressiveBlurDirection v) {
-    if (_direction == v) return;
-    _direction = v;
-    markNeedsPaint();
-  }
-
   double _devicePixelRatio;
-  set devicePixelRatio(double v) {
-    if (_devicePixelRatio == v) return;
-    _devicePixelRatio = v;
+
+  /// One setter for the lot: every field arrives from the same widget on the
+  /// same rebuild, so a single comparison is all the change detection this
+  /// needs. The shaders are compared by identity — they are long-lived
+  /// [ui.FragmentShader] instances owned by the [State], not values.
+  void update({
+    required ui.FragmentShader hShader,
+    required ui.FragmentShader vShader,
+    required double maxSigma,
+    required double falloff,
+    required ProgressiveBlurDirection direction,
+    required double devicePixelRatio,
+  }) {
+    if (identical(_hShader, hShader) &&
+        identical(_vShader, vShader) &&
+        _maxSigma == maxSigma &&
+        _falloff == falloff &&
+        _direction == direction &&
+        _devicePixelRatio == devicePixelRatio) {
+      return;
+    }
+    _hShader = hShader;
+    _vShader = vShader;
+    _maxSigma = maxSigma;
+    _falloff = falloff;
+    _direction = direction;
+    _devicePixelRatio = devicePixelRatio;
     markNeedsPaint();
   }
 
@@ -346,9 +350,6 @@ class _RenderProgressiveBlur extends RenderProxyBox {
   @override
   BackdropFilterLayer? get layer => super.layer as BackdropFilterLayer?;
 
-  // coverage:ignore-start
-  // Reached only with a compiled FragmentProgram, which the headless test VM
-  // never provides; [progressiveBlurUniforms] carries the testable arithmetic.
   @override
   void paint(PaintingContext context, Offset offset) {
     if (child == null) {
@@ -384,5 +385,5 @@ class _RenderProgressiveBlur extends RenderProxyBox {
       shader.setFloat(2 + i, uniforms[i]);
     }
   }
-  // coverage:ignore-end
 }
+// coverage:ignore-end

--- a/test/widgets/effects/progressive_blur_test.dart
+++ b/test/widgets/effects/progressive_blur_test.dart
@@ -10,6 +10,10 @@ import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
 /// `BackdropFilter`). These tests therefore assert the backend-independent
 /// contract: passthrough at `maxSigma <= 0`, a backdrop filter when blurring,
 /// no glass ancestor required, and an idempotent, non-throwing [preload].
+///
+/// The shader path's arithmetic is reachable through [progressiveBlurUniforms],
+/// which is where the region rectangle is decided — see the group at the
+/// bottom.
 void main() {
   Widget host(Widget child) => MaterialApp(
         home: Scaffold(
@@ -124,5 +128,70 @@ void main() {
       ProgressiveBlurDirection.leftToRight,
       ProgressiveBlurDirection.rightToLeft,
     ]);
+  });
+
+  group('progressiveBlurUniforms', () {
+    // The uniforms, by float index: 2 sigma, 3 falloff, 4 direction, 5 axis,
+    // 6/7 region origin, 8/9 region size. This list starts at float 2, so
+    // subtract 2 from each.
+    List<double> uniforms({
+      Offset origin = Offset.zero,
+      Size size = const Size(100, 40),
+      double devicePixelRatio = 1,
+      double maxSigma = 12,
+      double falloff = 1,
+      ProgressiveBlurDirection direction =
+          ProgressiveBlurDirection.topToBottom,
+      double axis = 0,
+    }) =>
+        progressiveBlurUniforms(
+          origin: origin,
+          size: size,
+          devicePixelRatio: devicePixelRatio,
+          maxSigma: maxSigma,
+          falloff: falloff,
+          direction: direction,
+          axis: axis,
+        );
+
+    test('carries the region origin through, in device pixels', () {
+      // The regression: the origin used to be hard-coded to (0, 0), so the
+      // gradient was normalised over the wrong rectangle anywhere but the
+      // top-left of the backdrop layer.
+      final u = uniforms(origin: const Offset(24, 180), devicePixelRatio: 3);
+      expect(u[4], 72); // float 6 — origin x
+      expect(u[5], 540); // float 7 — origin y
+    });
+
+    test('a top-left blur still reports a zero origin', () {
+      final u = uniforms(devicePixelRatio: 3);
+      expect(u[4], 0);
+      expect(u[5], 0);
+    });
+
+    test('region size is the widget size in device pixels', () {
+      final u = uniforms(size: const Size(200, 50), devicePixelRatio: 2);
+      expect(u[6], 400); // float 8 — region width
+      expect(u[7], 100); // float 9 — region height
+    });
+
+    test('sigma scales with the device pixel ratio, falloff does not', () {
+      final u = uniforms(maxSigma: 10, falloff: 2.5, devicePixelRatio: 3);
+      expect(u[0], 30); // float 2 — sigma
+      expect(u[1], 2.5); // float 3 — falloff
+    });
+
+    test('direction and axis are passed as declared', () {
+      final u = uniforms(
+        direction: ProgressiveBlurDirection.values.last,
+        axis: 1,
+      );
+      expect(u[2], (ProgressiveBlurDirection.values.length - 1).toDouble());
+      expect(u[3], 1);
+    });
+
+    test('emits exactly the eight uniforms the program declares', () {
+      expect(uniforms().length, 8);
+    });
   });
 }


### PR DESCRIPTION
Fixes #210.

`ProgressiveBlur` hard-coded its shader region origin to `(0, 0)`:

```dart
..setFloat(6, 0) // region origin x (device px)
..setFloat(7, 0) // region origin y (device px)
```

The shader normalises its gradient over that rectangle, so this is correct only
where the note said it was — a bar anchored at the top-left of the backdrop
layer. Anywhere else — a blur band inside a modal sheet, or any inset container
— the gradient is computed over the wrong rect: in practice the surface renders
black, and wrapping it in a `RepaintBoundary` to try to make `(0, 0)` true
instead samples an empty layer, so the blur silently disappears.

### The fix

Resolve the region in a `RenderObject` at paint time rather than in `build`.

Paint is the only place the answer is both knowable and current. The widget's
offset within the backdrop layer changes whenever an ancestor **moves** it — a
sheet being dragged, a scroll, an animated inset — and those move it by
repainting, not by rebuilding. Reading the offset during `build`, or in a
post-frame callback, leaves the gradient normalised over a stale rectangle for
as long as the motion lasts. That was worth getting right for us specifically:
ours is a scroll edge inside a draggable sheet.

Dropping the `LayoutBuilder` falls out of the same change, and has a small bonus
— a `ProgressiveBlur` can now sit under a parent that asks for intrinsic
dimensions, which `LayoutBuilder` refuses to answer.

No shader change; `progressive_blur.frag` already declared `uRegionOriginPx` and
used it.

### Tests

The uniform arithmetic moves into `progressiveBlurUniforms`, a pure function,
and is now covered — including that a non-zero origin survives, which is the
regression itself.

This seam is deliberate. The defect was a literal `0` in the middle of a widget
build, and no test could have caught it: the shader path needs a compiled
`FragmentProgram`, which a headless VM never provides, so those lines are
`coverage:ignore` and the existing tests necessarily exercise the uniform-blur
fallback. Pulling the region maths out gives that part of the path something a
test can hold onto.

`flutter test` is green apart from five golden tests that also fail unchanged on
`origin/main` here (`container_widgets`, `overlay_widgets`,
`surfaces/glass_toolbar`) — machine-dependent goldens, untouched by this change.

### Verification

On device — iOS 26.6, iPhone 16 Pro Max, Impeller, `isShaderFilterSupported ==
true` — in the exact configuration from the report: a scroll-edge blur inside a
sheet over a Mapbox `PlatformView`. It rendered black before; it now blurs
correctly and the gradient tracks the sheet through a drag between detents.
