### PR TITLE
feat(GlassModalSheet): morph presentation from a trigger button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+## Features
+
+- **`GlassModalSheet` morphs from a trigger button (#216):** `show()` gains `morphFrom` — the `GlassMorphAnchor` from a new `GlassMorphTrigger` wrapper — presenting the sheet with the iOS 26 liquid morph instead of the slide-up: the trigger empties, a glass droplet detaches and inflates as it travels, and lands as the sheet. Makes the sheet the second consumer of the Liquid Morph Engine after `GlassMenu`. `morphSpeed` tunes the spring.
+- **`GlassMorphTrigger` / `GlassMorphAnchor` added:** the wrapper owns the trigger's key *and* its opacity, so the trigger can empty itself for the morph and take the closing bounce on its own ticker. A `GlobalKey` cannot hide a widget it doesn't own, and a trigger still painting under the droplet reads as a duplicated button. `morphFromRect` remains for triggers that can't be wrapped, blooming from a point.
+- **Slide presentation untouched:** leave `morphFrom` / `morphFromRect` null and nothing changes. The morph falls back to the slide wherever the metaball blend is unavailable — Skia/web, `GlassQuality.minimal`, `platformViewBackdrop` — and Reduce Motion resolves it through the engine's instant spring.
+
+---
+
 # 0.30.2
 
 ## Bug Fixes

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Both parameters are optional — omit them and the library uses sensible default
 ## Features
 
 - **Comprehensive glass widget library** — containers, interactive controls, inputs, feedback, overlays, and navigation surfaces (see [Widget Categories](#widget-categories))
-- **Liquid Morph Engine** — a standalone physics system powering iOS 26-style liquid morphing. `GlassMenu` is the first consumer; future widgets will use the same engine for consistent liquid transitions. See [`docs/LIQUID_MORPH_ENGINE.md`](docs/LIQUID_MORPH_ENGINE.md)
+- **Liquid Morph Engine** — a standalone physics system powering iOS 26-style liquid morphing. `GlassMenu` morphs out of its trigger button, and `GlassModalSheet.show(morphFrom:)` presents a modal sheet out of a `GlassMorphTrigger` the same way — the trigger empties, a glass droplet inflates as it travels, and dismissing pours it back. See [`docs/LIQUID_MORPH_ENGINE.md`](docs/LIQUID_MORPH_ENGINE.md)
 - **Real frosted glass** — native two-pass Gaussian blur + shader refraction on Impeller; lightweight shader on Skia/Web
 - **Just works everywhere** — iOS, Android, macOS, Web, Windows, Linux; rendering path chosen automatically
 - **Adaptive quality** *(experimental)* — `GlassAdaptiveScope` benchmarks the device at startup and adjusts quality in real time: `minimal` on slow hardware, `standard` on mid-range, `premium` on fast devices. Degrades on thermal throttle, recovers when cool

--- a/docs/GLASS_MODAL_SHEETS_GUIDE.md
+++ b/docs/GLASS_MODAL_SHEETS_GUIDE.md
@@ -20,6 +20,9 @@ Settings for the primary content and the sheet's basic behavior.
 | `isDismissible` | `bool` | `true` | (In `show`) Controls `barrierDismissible`. If `true`, the `Scaffold` background triggers `snapToState(SheetState.hidden)`. |
 | `useRootNavigator` | `bool` | `false` | (In `show`) If true, pushes the modal onto the top-level `Navigator`, bypassing local navigation stacks. |
 | `barrierLabel` | `String` | `'Dismiss'` | Accessibility label for the modal barrier. |
+| `morphFrom` | `GlassMorphAnchor?` | `null` | (In `show`) Presents by morphing out of a `GlassMorphTrigger` instead of sliding up. The anchor both locates the trigger and empties it for the duration. |
+| `morphFromRect` | `Rect?` | `null` | (In `show`) For triggers that can't be wrapped — an explicit global rect. The trigger stays painted, so the anchor blob is suppressed and the droplet blooms from the rect's centre. Mutually exclusive with `morphFrom`. |
+| `morphSpeed` | `MorphSpeed` | `normal` | (In `show`) Spring profile for the morph. `normal` is the 375 ms iOS 26 native-parity profile. Also sizes the route transition so the page stays mounted for the whole morph. |
 
 ---
 
@@ -92,6 +95,37 @@ This is where you configure the physical shape-shifting "Apple Maps" effect.
 | `peekBottomRadius` | `double?` | `null` | Specific bottom radius for Peek. Morphs to `bottomBorderRadius`. |
 | `fullTopBorderRadius` | `double?` | `46.0` | Target radius for `full` state. Usually smaller than `adaptive` for a tighter look. |
 | `fullBottomBorderRadius`| `double?` | `null` | Target bottom radius for `full`. Defaults to `bottomBorderRadius` if null. |
+
+### Morphing from a Trigger (Liquid Morph Engine)
+
+`GlassModalSheet.show(morphFrom:)` swaps the slide-up entrance for the iOS 26 `glassEffectID` morph: the trigger empties, a glass droplet detaches and inflates along a J-curve, and lands exactly on the sheet's resting frame. Dismissing reverses it.
+
+Wrap the trigger in a `GlassMorphTrigger` and hand its anchor to `show()`:
+
+```dart
+GlassMorphTrigger(
+  builder: (context, anchor) => GlassButton(
+    onTap: () => GlassModalSheet.show(
+      context: context,
+      morphFrom: anchor,
+      builder: (context) => const MySheetBody(),
+    ),
+    child: const Icon(CupertinoIcons.add),
+  ),
+)
+```
+
+Everything after the morph is unchanged — detents, drag, snap, and the controller all behave exactly as they do for a slide-presented sheet. Only the presentation differs.
+
+**Why the wrapper.** A `GlobalKey` can locate the trigger but not hide it, and nothing in Flutter lets one widget hide another it doesn't own. A trigger that keeps painting while the droplet inflates on top of it reads as a duplicated button rather than a morph — so `GlassMorphTrigger` owns the key *and* the opacity. The child paints nothing while the sheet is presented, and is restored the instant the droplet is caught, displaced by the spring's closing momentum so it visibly takes the hit. Use `morphFromRect` when the trigger can't be wrapped: the morph still runs, but the anchor blob is suppressed and the droplet blooms from the rect's centre instead of stretching a teardrop out of it.
+
+**What it lands on.** The droplet aims at the *initial detent's* resting frame, resolved through `SheetGeometry.positionForState` — the same call the sheet's own render metrics use — and takes on that detent's surface, so a glass `medium` sheet hands off to glass and an opaque `large` sheet hands off to colour. At the settled instant the droplet and the sheet occupy the identical frame, and the real sheet (mounted underneath the whole time, never inserted late) takes over.
+
+**Which dismissals morph back.** A dismissal that leaves the sheet at rest — barrier tap, back gesture, `controller.snapToState(hidden)` — morphs back into the trigger. A swipe-down keeps the sheet's own slide-away instead, so it follows the finger it was thrown with rather than snapping back to its resting frame first.
+
+**When it falls back.** The teardrop neck is an Impeller-only SDF metaball blend, and a morph without it — two glass shapes and no bridge — reads worse than the slide it replaces. So the sheet presents with its ordinary `SlideTransition` on Skia/web (`ImageFilter.isShaderFilterSupported == false`), in `GlassQuality.minimal`, and under `platformViewBackdrop`. Reduce Motion is handled by the engine itself, which swaps in its instant spring.
+
+Leave `morphFrom` / `morphFromRect` null and nothing about the presentation changes.
 
 ---
 

--- a/docs/LIQUID_MORPH_ENGINE.md
+++ b/docs/LIQUID_MORPH_ENGINE.md
@@ -345,15 +345,44 @@ The separation between the position curve and the size curve represents how far 
 
 ---
 
-## Relationship to GlassMenu
+## Engine consumers
 
-`GlassMenu` / `GlassMenuItem` are the canonical reference implementation of the engine. If you want to see a production-grade integration, read:
+| Widget | What it morphs | Source |
+|---|---|---|
+| `GlassMenu` / `GlassMenuItem` | Trigger button → floating menu | `lib/widgets/overlays/shared/glass_menu_internal.dart` |
+| `GlassModalSheet.show(morphFrom:)` | Trigger button → presented modal sheet | `lib/widgets/overlays/shared/glass_modal_sheet_morph.dart` |
 
+### GlassMenu — the reference implementation
+
+`GlassMenu` is the canonical integration; if you want to see a production-grade one, start there. The key sections are `_GlassMenuState.initState` (controller lifecycle), `_buildMorphingContainer` (Blob B layout), and `_buildAnchorBlob` (Blob A + handoff logic).
+
+### GlassModalSheet — morphing into a presented route
+
+`GlassModalSheet.show(morphFrom:)` presents the sheet by morphing out of a trigger instead of sliding up from the edge. The trigger is wrapped in a `GlassMorphTrigger`, which hands its builder a `GlassMorphAnchor` to present with:
+
+```dart
+GlassMorphTrigger(
+  builder: (context, anchor) => GlassButton(
+    onTap: () => GlassModalSheet.show(
+      context: context,
+      morphFrom: anchor,
+      morphSpeed: MorphSpeed.normal,  // the engine's own vocabulary
+      builder: (context) => const MySheetBody(),
+    ),
+    child: const Icon(CupertinoIcons.add),
+  ),
+)
 ```
-lib/widgets/overlays/shared/glass_menu_internal.dart
-```
 
-The key sections are `_GlassMenuState.initState` (controller lifecycle), `_buildMorphingContainer` (Blob B layout), and `_buildAnchorBlob` (Blob A + handoff logic).
+Three things differ from `GlassMenu`, all of them consequences of the destination being a *route* rather than an overlay:
+
+- **The trigger has to be handed over, not just located.** `GlassMenu` owns its trigger and can empty it; a sheet presented from a route cannot hide a widget it does not own, and nothing in Flutter lets it. A `GlobalKey` would only resolve the rect — enough to aim the morph, but the trigger would keep painting under the droplet, which reads as a duplicated button. `GlassMorphTrigger` owns the key *and* the opacity, so the trigger empties for the duration and is handed back the instant the droplet is caught, carrying the spring's closing momentum so it visibly takes the hit. `morphFromRect` remains for triggers that can't be wrapped; the anchor blob is suppressed there and the droplet blooms from a point.
+- **The droplet is not the sheet.** The metaball neck only bridges shapes inside one glass layer's blend group, and the real sheet owns its own layer — so the morph renders its own two-blob droplet and hands off to the sheet at the settled instant, when both are motionless on the identical frame. The sheet stays mounted underneath for the whole morph; it is revealed, never inserted (remounting a glass widget mid-animation re-seeds its layers and shows as a glitch frame).
+- **The route animation is a signal, not a clock.** The engine keeps its own spring; the route's reverse status is only what tells the presenter to start closing. The route duration is sized to outlast the spring's *full* settle rather than the moment the droplet lands — the trigger's closing bounce is driven by that presenter, so unmounting early truncates it mid-swing and the button snaps instead of easing home.
+
+`SheetMorphGeometry` holds the pure part — where the sheet rests, where the droplet is on any given frame — and derives the destination from `SheetGeometry.positionForState`, the same call the sheet's own metrics use, so the two cannot drift apart.
+
+The morph falls back to the ordinary slide transition wherever the metaball blend is unavailable: Skia/web, `GlassQuality.minimal`, and `platformViewBackdrop`. A degraded morph — two glass shapes with no bridge between them — reads worse than the slide it would replace.
 
 ---
 

--- a/example/integration_test/morph_demo_test.dart
+++ b/example/integration_test/morph_demo_test.dart
@@ -1,0 +1,72 @@
+// On-device verification for GlassModalSheet's morph presentation.
+//
+// The morph needs the Impeller metaball blend, which a headless `flutter test`
+// run does not have — so this drives the real demo on a simulator/device, where
+// the capability probe actually passes, and proves the morph route is taken
+// rather than the slide fallback.
+//
+//   cd example && flutter test integration_test/morph_demo_test.dart -d <device>
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:liquid_glass_widgets/widgets/overlays/glass_modal_sheet.dart';
+
+import 'package:liquid_glass_widgets_example/demos/glass_modal_sheet_demo.dart'
+    as demo;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('GlassModalSheet morphs from its trigger on a real renderer',
+      (tester) async {
+    expect(
+      ui.ImageFilter.isShaderFilterSupported,
+      isTrue,
+      reason: 'This device reports no shader filter support, so the morph '
+          'would correctly fall back to the slide. Run it on Impeller.',
+    );
+
+    demo.main();
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+    final trigger = find.byIcon(CupertinoIcons.add);
+    expect(trigger, findsOneWidget, reason: 'the morph demo trigger');
+
+    await tester.tap(trigger);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 60));
+
+    // Mid-morph: the droplet is presenting, and the route did not wrap the
+    // page in the slide it replaces. (Scoped to the sheet's own route — the
+    // demo's home CupertinoPageRoute has a SlideTransition of its own.)
+    expect(find.byType(GlassSheetMorphPresenter), findsOneWidget);
+    expect(
+      find.ancestor(
+        of: find.byType(GlassSheetMorphPresenter),
+        matching: find.byType(SlideTransition),
+      ),
+      findsNothing,
+    );
+
+    await tester.pumpAndSettle();
+    expect(find.text('Morph from trigger'), findsWidgets);
+
+    // Let the landed sheet sit for the recording.
+    await Future<void>.delayed(const Duration(milliseconds: 900));
+    await tester.pumpAndSettle();
+
+    // Barrier tap — the dismissal that morphs back into the trigger.
+    await tester.tapAt(const Offset(200, 80));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(find.byType(GlassSheetMorphPresenter), findsOneWidget);
+
+    await tester.pumpAndSettle();
+    expect(find.byType(GlassSheetMorphPresenter), findsNothing);
+
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+  });
+}

--- a/example/lib/demos/glass_modal_sheet_demo.dart
+++ b/example/lib/demos/glass_modal_sheet_demo.dart
@@ -280,6 +280,8 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
 
           // Additional Scenarios for Standard Tab
           if (_selectedTab == 0) ...[
+            _buildMorphTriggerTile(),
+            SizedBox(height: 16),
             _buildScenarioTile(
               title: 'Static Modal',
               description: 'Disabled glow and window scaling',
@@ -554,6 +556,54 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
     );
   }
 
+  /// The morph scenario: a compact trigger the sheet grows out of, rather than
+  /// a row that opens one. The button itself is the thing that morphs, so it
+  /// carries [_morphTriggerKey] and sits apart from the other scenario tiles.
+  Widget _buildMorphTriggerTile() {
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Morph from trigger',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+              Text(
+                'The button empties, a glass droplet inflates into the sheet, '
+                'and dismissing pours it back.',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: CupertinoColors.white.withValues(alpha: 0.54),
+                ),
+              ),
+            ],
+          ),
+        ),
+        SizedBox(width: 16),
+        // The wrapper owns the button's identity AND its opacity, so the
+        // button can empty itself while the droplet stands in for it.
+        GlassMorphTrigger(
+          builder: (context, anchor) => GlassButton.custom(
+            width: 64,
+            height: 64,
+            useOwnLayer: true,
+            quality: GlassQuality.standard,
+            shape: const LiquidRoundedSuperellipse(borderRadius: 32),
+            onTap: () => _showMorphFromTrigger(context, anchor),
+            child: Icon(
+              CupertinoIcons.add,
+              size: 28,
+              color: CupertinoColors.activeBlue,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
   Widget _buildScenarioTile({
     required String title,
     required String description,
@@ -649,6 +699,24 @@ class _ShowcaseHomeScreenState extends State<ShowcaseHomeScreen> {
         title: 'Standard Experience',
         subtitle:
             'Explore how interactive glass elements behave inside a glass sheet.',
+      ),
+    );
+  }
+
+  /// Presents the sheet by morphing it out of the "+" button, using the same
+  /// Liquid Morph Engine that drives GlassMenu. Everything else — detents,
+  /// drag, snap — behaves exactly as it does in the scenarios above; only the
+  /// presentation changes.
+  void _showMorphFromTrigger(BuildContext context, GlassMorphAnchor anchor) {
+    GlassModalSheet.show(
+      context: context,
+      quality: widget.currentQuality,
+      morphFrom: anchor,
+      builder: (context) => const BaseScenario(
+        title: 'Morph from trigger',
+        subtitle:
+            'Presented straight out of the button, the way iOS 26 morphs glass '
+            'with glassEffectID. Tap outside to pour it back in.',
       ),
     );
   }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   flutter_lints: ^5.0.0
 
 flutter:

--- a/lib/liquid_glass_widgets.dart
+++ b/lib/liquid_glass_widgets.dart
@@ -106,6 +106,8 @@ export 'widgets/overlays/glass_modal_sheet.dart'
         GlassSheetDetent, // the `detents` set on GlassModalSheet / .show()
         GlassFillTransition,
         GlassModalSheetController,
+        GlassMorphTrigger, // wraps a trigger a sheet morphs out of
+        GlassMorphAnchor, // the token GlassMorphTrigger hands its builder
         GlassModalSheetScaffold, // used directly for maps-style hit-through layouts
         GlassModalSheetStateProvider, // read sheet state from descendants
         SheetStateInfo, // value type from GlassModalSheetStateProvider.of()

--- a/lib/widgets/overlays/glass_modal_sheet.dart
+++ b/lib/widgets/overlays/glass_modal_sheet.dart
@@ -1,22 +1,28 @@
 import 'dart:async';
+import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/physics.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 import '../../src/renderer/liquid_glass_renderer.dart';
 import '../../theme/glass_theme_helpers.dart';
 import '../../theme/glass_theme.dart';
 import '../../types/glass_quality.dart';
+import '../../utils/glass_morph_controller.dart';
+import '../../utils/liquid_morph_physics.dart';
 import '../shared/adaptive_glass.dart';
+import '../shared/adaptive_liquid_glass_layer.dart';
 import '../../src/renderer/internal/interaction_notification.dart';
 import '../../src/widgets/overlays/glass_sheet_defaults.dart';
 import '../../constants/glass_defaults.dart';
 
 part 'shared/glass_modal_sheet_mechanics.dart';
 part 'shared/glass_modal_sheet_internal.dart';
+part 'shared/glass_modal_sheet_morph.dart';
 part 'shared/glass_modal_sheet_state.dart';
 
 /// A high-fidelity, liquid glass modal sheet inspired by iOS 18+ design patterns.
@@ -288,6 +294,54 @@ class GlassModalSheet extends StatefulWidget {
             '(small alone is a floor, not a resting height).');
 
   /// Shows a high-fidelity glass modal sheet.
+  ///
+  /// ## Morphing from a trigger
+  ///
+  /// Wrap the trigger in a [GlassMorphTrigger] and hand its [GlassMorphAnchor]
+  /// to [morphFrom] to present the sheet with the iOS 26 liquid morph instead
+  /// of the default slide-up: the trigger empties, a glass droplet detaches and
+  /// inflates as it travels, and lands as the sheet. Dismissing reverses it
+  /// back into the trigger. This is the same [GlassMorphController] engine
+  /// `GlassMenu` uses — see `docs/LIQUID_MORPH_ENGINE.md`.
+  ///
+  /// ```dart
+  /// GlassMorphTrigger(
+  ///   builder: (context, anchor) => GlassButton(
+  ///     onTap: () => GlassModalSheet.show(
+  ///       context: context,
+  ///       morphFrom: anchor,
+  ///       builder: (context) => const MySheetBody(),
+  ///     ),
+  ///     child: const Icon(CupertinoIcons.add),
+  ///   ),
+  /// )
+  /// ```
+  ///
+  /// The wrapper is what makes the trigger *empty*: nothing in Flutter lets one
+  /// widget hide another it doesn't own, and a trigger still painting under the
+  /// droplet reads as a duplicated button rather than a morph.
+  ///
+  /// [morphFromRect] is the escape hatch for a trigger that can't be wrapped —
+  /// an explicit global [Rect]. The morph still runs, but since the trigger
+  /// stays painted the anchor blob is suppressed and the droplet blooms from
+  /// the rect's centre instead of stretching a teardrop out of it. Pass at most
+  /// one of [morphFrom] / [morphFromRect].
+  ///
+  /// Leave both null and the sheet presents exactly as it always has — the
+  /// slide transition is untouched. [morphSpeed] tunes the spring profile; the
+  /// default [MorphSpeed.normal] is the 375 ms native-parity profile.
+  ///
+  /// The morph needs the metaball blend that draws the teardrop neck, so it
+  /// falls back to the slide transition when that is unavailable: on Skia/web
+  /// (`ImageFilter.isShaderFilterSupported == false`), in
+  /// [GlassQuality.minimal], and under [platformViewBackdrop]. Reduce Motion is
+  /// honoured by the engine, which swaps in its instant spring so the sheet
+  /// resolves straight away instead of travelling.
+  ///
+  /// A dismissal that leaves the sheet at rest — barrier tap, back gesture,
+  /// [GlassModalSheetController] close — morphs back into the trigger. A
+  /// swipe-down dismissal keeps the sheet's own slide-away instead, so the
+  /// sheet follows the finger it was thrown with.
   static Future<T?> show<T>({
     required BuildContext context,
     required WidgetBuilder builder,
@@ -345,7 +399,14 @@ class GlassModalSheet extends StatefulWidget {
     double? peekWidth,
     double? peekTopBorderRadius,
     double? peekBottomRadius,
+    GlassMorphAnchor? morphFrom,
+    Rect? morphFromRect,
+    MorphSpeed morphSpeed = MorphSpeed.normal,
   }) {
+    assert(
+        morphFrom == null || morphFromRect == null,
+        'Pass either morphFrom (the GlassMorphAnchor from a GlassMorphTrigger) '
+        'or morphFromRect (an explicit global rect) — not both.');
     assert(
         detents.isNotEmpty,
         'GlassModalSheet.show() needs at least one detent — add medium '
@@ -376,14 +437,37 @@ class GlassModalSheet extends StatefulWidget {
     final effectiveController = controller ?? GlassModalSheetController();
     bool isClosing = false;
 
+    // Resolved once, before the route is pushed: the trigger's rect has to be
+    // read while the trigger is still laid out, and the render capabilities
+    // decide which transition the route is built with in the first place.
+    final morphTriggerRect = _resolveMorphTriggerRect(morphFrom, morphFromRect);
+    final morphing = morphTriggerRect != null &&
+        _supportsMorph(
+          context,
+          quality: quality,
+          platformViewBackdrop: platformViewBackdrop,
+        );
+
+    // The morph owns its own spring clock; the route duration only has to be
+    // long enough to keep the page mounted (and the barrier fading) for as long
+    // as the morph runs — most visibly on the way out, where the route reverse
+    // is the window the closing morph plays in.
+    final transitionDuration = morphing
+        ? _morphRouteDuration(morphSpeed)
+        : const Duration(milliseconds: 500);
+
     return showGeneralDialog<T>(
       context: context,
       barrierDismissible: isDismissible,
       barrierLabel: 'Dismiss',
       barrierColor: barrierColor,
       useRootNavigator: useRootNavigator,
-      transitionDuration: const Duration(milliseconds: 500),
+      transitionDuration: transitionDuration,
       transitionBuilder: (context, animation, secondaryAnimation, child) {
+        // Morphing: the droplet IS the transition. Mapping the engine onto this
+        // linear route animation would flatten the J-curve and the underdamped
+        // catch, so the page passes straight through.
+        if (morphing) return child;
         return SlideTransition(
           position: Tween<Offset>(begin: const Offset(0, 1), end: Offset.zero)
               .animate(
@@ -393,7 +477,7 @@ class GlassModalSheet extends StatefulWidget {
         );
       },
       pageBuilder: (context, animation, secondaryAnimation) {
-        return GlassModalSheetScaffold(
+        final scaffold = GlassModalSheetScaffold(
           controller: effectiveController,
           halfSize: halfSize,
           fullSize: fullSize,
@@ -451,8 +535,144 @@ class GlassModalSheet extends StatefulWidget {
           body: const SizedBox.shrink(),
           sheet: builder(context),
         );
+
+        if (!morphing) return scaffold;
+
+        return GlassSheetMorphPresenter(
+          routeAnimation: animation,
+          triggerRect: morphTriggerRect,
+          anchor: morphFrom,
+          speed: morphSpeed,
+          restingState: resolvedInitialState,
+          // Built from the same inputs as the sheet's own _buildGeometry, so
+          // the droplet aims at the detent the sheet will actually rest at.
+          geometry: SheetGeometry(
+            mode: mode,
+            halfSize: halfSize,
+            fullSize: fullSize,
+            peekSize: peekSize,
+            enablePeek: SheetGeometry.resolvePeek(
+              enablePeek: enablePeek,
+              detents: detents,
+              mode: mode,
+            ),
+            enableHalf: detents.contains(GlassSheetDetent.medium),
+            enableFull: detents.contains(GlassSheetDetent.large),
+            dismissible: dismissible,
+          ),
+          horizontalMargin: horizontalMargin,
+          bottomMargin: bottomMargin,
+          topBorderRadius: topBorderRadius,
+          fullTopBorderRadius: fullTopBorderRadius,
+          bottomBorderRadius: bottomBorderRadius,
+          fullBottomBorderRadius: fullBottomBorderRadius,
+          settings: settings,
+          peekSettings: peekSettings,
+          halfSettings: halfSettings,
+          fullSettings: fullSettings,
+          expandedColor: expandedColor,
+          quality: quality,
+          peekHorizontalMargin: peekHorizontalMargin,
+          peekBottomMargin: peekBottomMargin,
+          peekWidth: peekWidth,
+          peekTopBorderRadius: peekTopBorderRadius,
+          platformViewBackdrop: platformViewBackdrop,
+          child: scaffold,
+        );
       },
     );
+  }
+
+  /// Resolves the trigger's global rect from whichever of [morphFrom] /
+  /// [morphFromRect] the caller supplied, or null when neither was given.
+  ///
+  /// An anchor whose trigger isn't laid out is a caller mistake, so it asserts
+  /// in debug; in release it degrades to the slide transition rather than
+  /// morphing out of a rect that doesn't exist.
+  static Rect? _resolveMorphTriggerRect(
+    GlassMorphAnchor? morphFrom,
+    Rect? morphFromRect,
+  ) {
+    if (morphFromRect != null) return morphFromRect;
+    if (morphFrom == null) return null;
+
+    final rect = morphFrom._rect;
+    assert(
+        rect != null,
+        'GlassModalSheet.show(morphFrom:) needs a GlassMorphAnchor whose '
+        'GlassMorphTrigger is mounted and laid out. It was not on screen when '
+        'show() was called — pass morphFromRect if the trigger has no render '
+        'box of its own.');
+    return rect;
+  }
+
+  /// Whether the current render path can draw the morph.
+  ///
+  /// The teardrop neck is an Impeller-only SDF metaball blend, and a degraded
+  /// morph — two glass shapes with no bridge between them — reads worse than
+  /// the slide it replaces. So anything that suppresses blending falls back
+  /// wholesale: Skia/web, [GlassQuality.minimal], and the BackdropFilter path
+  /// forced by [platformViewBackdrop] (both of which skip the
+  /// [LiquidGlassBlendGroup] entirely — see #214).
+  static bool _supportsMorph(
+    BuildContext context, {
+    required GlassQuality? quality,
+    required bool platformViewBackdrop,
+  }) {
+    if (platformViewBackdrop) return false;
+    final resolved = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: quality,
+      fallback: GlassQuality.premium,
+    );
+    if (resolved == GlassQuality.minimal) return false;
+    return debugMorphSupportsBlending ?? ImageFilter.isShaderFilterSupported;
+  }
+
+  /// Test-only override for the Impeller probe in [_supportsMorph].
+  ///
+  /// A headless test run reports `ImageFilter.isShaderFilterSupported == false`
+  /// — correctly, since there is no Impeller — which makes the morph path
+  /// unreachable from a widget test and would leave the route wiring untested.
+  /// Set this to `true` to exercise it, and back to `null` in a `tearDown`.
+  ///
+  /// It stands in for the render-capability probe only; [platformViewBackdrop]
+  /// and [GlassQuality.minimal] still disable the morph, so those fallbacks
+  /// stay honest under the override.
+  @visibleForTesting
+  static bool? debugMorphSupportsBlending;
+
+  /// Route transition duration that covers a morph at [speed].
+  ///
+  /// Sized to the droplet's journey — the moment it is caught by the trigger —
+  /// and no longer. The route's modal barrier swallows every touch while it is
+  /// mounted, so holding it open for the spring's full settle would leave the
+  /// trigger visibly back but dead to the touch for a few hundred milliseconds.
+  /// `GlassMenu` drops its own barrier 30 % into the close for the same reason.
+  ///
+  /// The tail of the bounce is not lost: [GlassMorphTrigger] continues the
+  /// spring on its own ticker once the droplet is handed back, so it keeps
+  /// easing home after this route is gone.
+  ///
+  /// Measured against the profiles in [GlassMorphController], with headroom:
+  ///
+  /// | speed   | droplet caught | route |
+  /// |---------|----------------|-------|
+  /// | slow    | 408 ms         | 480   |
+  /// | normal  | 304 ms         | 380   |
+  /// | fast    | 240 ms         | 300   |
+  /// | instant | 160 ms         | 210   |
+  static Duration _morphRouteDuration(MorphSpeed speed) {
+    switch (speed) {
+      case MorphSpeed.slow:
+        return const Duration(milliseconds: 480);
+      case MorphSpeed.normal:
+        return const Duration(milliseconds: 380);
+      case MorphSpeed.fast:
+        return const Duration(milliseconds: 300);
+      case MorphSpeed.instant:
+        return const Duration(milliseconds: 210);
+    }
   }
 
   @override

--- a/lib/widgets/overlays/shared/glass_modal_sheet_morph.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_morph.dart
@@ -1,0 +1,1060 @@
+part of '../glass_modal_sheet.dart';
+
+// ===========================================================================
+// Liquid Morph presentation for GlassModalSheet
+// ===========================================================================
+//
+// The second consumer of the Liquid Morph Engine (docs/LIQUID_MORPH_ENGINE.md),
+// after GlassMenu. Where GlassMenu morphs a trigger button into a floating menu,
+// this morphs a trigger button into a presented modal sheet: the trigger empties,
+// a glass droplet detaches and inflates while travelling down the J-curve, and
+// lands exactly on the sheet's resting frame. Dismissal reverses it.
+//
+// ─── Why the sheet is not itself Blob B ──────────────────────────────────────
+//
+// The teardrop "neck" is drawn by the SDF metaball shader, which only bridges
+// shapes that share ONE glass layer's blend group. The real sheet owns its own
+// AdaptiveGlass layer (see _SheetLayout), so it structurally cannot merge with
+// the trigger ghost. The morph therefore renders its own two-blob droplet and
+// hands off to the real sheet at the settled instant — when both are motionless
+// and share the exact same frame, so the swap is invisible.
+//
+// That handoff is also why SheetMorphGeometry derives the destination from
+// SheetGeometry.positionForState — the same call the sheet's own metrics use —
+// instead of a parallel calculation that could drift out of agreement.
+
+/// The widget a [GlassModalSheet] morphs out of, and the channel that empties
+/// it while the morph is in flight.
+///
+/// An opaque token: it carries no members a caller can use. [GlassMorphTrigger]
+/// creates one, hands it to its builder, and disposes it; callers pass it
+/// straight to [GlassModalSheet.show] as `morphFrom` and never touch it
+/// otherwise. The constructor is private so one cannot be made by hand — an
+/// anchor with no trigger behind it has nothing to empty.
+///
+/// ## Why a token rather than a bare [GlobalKey]
+///
+/// A key can only *locate* the trigger. Reading its rect is enough to aim the
+/// morph, but not to make the trigger look like it empties — and a trigger that
+/// stays painted while a glass droplet inflates on top of it reads as a
+/// duplicated button, not a morph. Nothing in Flutter lets one widget hide
+/// another it does not own, so the trigger has to cooperate: [GlassMorphTrigger]
+/// owns the key *and* the opacity, and this token is how the presented sheet
+/// reaches back to it.
+///
+/// `GlassMenu` does the same thing internally with its own trigger; this is that
+/// arrangement made available to a trigger the sheet does not own.
+class GlassMorphAnchor {
+  GlassMorphAnchor._();
+
+  /// Identifies the trigger's subtree so its global rect can be resolved at
+  /// `show()` time.
+  final GlobalKey _key = GlobalKey();
+
+  /// Broadcasts state changes to the owning [GlassMorphTrigger].
+  ///
+  /// Held rather than inherited so this type stays a plain token: extending
+  /// [ChangeNotifier] would put `addListener` and `dispose` on the public
+  /// surface, and a caller disposing their own anchor would strand the morph.
+  final _AnchorNotifier _notifier = _AnchorNotifier();
+
+  bool _emptied = false;
+  _MorphHandback? _handback;
+  bool _disposed = false;
+
+  /// The trigger's rect in global coordinates, or null when it is not currently
+  /// laid out.
+  Rect? get _rect {
+    final renderObject = _key.currentContext?.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) return null;
+    return renderObject.localToGlobal(Offset.zero) & renderObject.size;
+  }
+
+  /// Hides the trigger so the morph's anchor blob can stand in for it.
+  void _empty() {
+    if (_disposed) return;
+    _handback = null;
+    if (_emptied) return;
+    _emptied = true;
+    _notify();
+  }
+
+  /// Hands the trigger back at the moment the droplet is caught, passing the
+  /// spring's live state so the trigger can carry the bounce the rest of the
+  /// way itself.
+  ///
+  /// The presented route is torn down as soon as the droplet lands — otherwise
+  /// its modal barrier would keep swallowing taps on a button that is visibly
+  /// back — so the tail of the bounce cannot be driven from there. [travel] is
+  /// the trigger-centre → sheet-centre vector the droplet came home along;
+  /// [value] and [velocity] are the closing spring's state at the catch, so the
+  /// trigger's own simulation continues it without a seam.
+  void _handBack({
+    required Offset travel,
+    required double value,
+    required double velocity,
+  }) {
+    if (_disposed || !_emptied) return;
+    _emptied = false;
+    _handback = _MorphHandback(travel, value, velocity);
+    _notify();
+  }
+
+  /// Restores the trigger with no bounce.
+  ///
+  /// The safety net for a route torn down without the closing morph ever
+  /// running — a Navigator reset, a hot restart. Leaving the trigger emptied
+  /// would erase a live button.
+  void _restore() {
+    if (_disposed || !_emptied) return;
+    _emptied = false;
+    _handback = null;
+    _notify();
+  }
+
+  void _dispose() {
+    _disposed = true;
+    _notifier.dispose();
+  }
+
+  /// Notifies the trigger without ever marking it dirty mid-build.
+  ///
+  /// The presenter drives this from its own lifecycle — `didChangeDependencies`
+  /// on the way in, `dispose` on the way out — both of which run while the tree
+  /// is being built or is locked, where `setState` on the listening trigger is
+  /// illegal. Deferring to the end of the frame in those phases costs the
+  /// trigger one frame, during which the droplet is still exactly on top of it,
+  /// so nothing shows.
+  void _notify() {
+    final binding = WidgetsBinding.instance;
+    final phase = binding.schedulerPhase;
+    if (phase == SchedulerPhase.persistentCallbacks ||
+        phase == SchedulerPhase.midFrameMicrotasks) {
+      binding.addPostFrameCallback((_) {
+        if (!_disposed) _notifier.notify();
+      });
+      return;
+    }
+    _notifier.notify();
+  }
+}
+
+/// Minimal [ChangeNotifier] subclass exposing [notifyListeners] as [notify], so
+/// [GlassMorphAnchor] can hold one instead of being one.
+///
+/// Mirrors `_ProgressNotifier` in `glass_modal_sheet_state.dart`.
+class _AnchorNotifier extends ChangeNotifier {
+  void notify() => notifyListeners();
+}
+
+/// The closing spring's state at the instant the trigger catches the droplet.
+class _MorphHandback {
+  const _MorphHandback(this.travel, this.value, this.velocity);
+
+  /// Trigger centre → sheet centre. The bounce is along this vector.
+  final Offset travel;
+
+  /// Spring position at the catch — near zero, heading into the undershoot.
+  final double value;
+
+  /// Spring velocity at the catch, so the trigger's simulation continues it.
+  final double velocity;
+}
+
+/// Wraps the widget a [GlassModalSheet] morphs out of, so the trigger can empty
+/// itself while the morph runs and take the hit when the droplet comes home.
+///
+/// The builder receives a [GlassMorphAnchor] to pass to
+/// [GlassModalSheet.show] as `morphFrom`:
+///
+/// ```dart
+/// GlassMorphTrigger(
+///   builder: (context, anchor) => GlassButton(
+///     onTap: () => GlassModalSheet.show(
+///       context: context,
+///       morphFrom: anchor,
+///       builder: (context) => const MySheetBody(),
+///     ),
+///     child: const Icon(CupertinoIcons.add),
+///   ),
+/// )
+/// ```
+///
+/// While the sheet is presented the child paints nothing — the morph's anchor
+/// blob stands in for it, so the two never appear at once. When the droplet
+/// lands, the child is restored and *this widget* runs the rest of the closing
+/// bounce on its own ticker, so it keeps easing home after the presented route
+/// is gone. The button is tappable throughout that tail, exactly as `GlassMenu`'s
+/// trigger is: grabbing it cancels the bounce and opens again.
+///
+/// Without this wrapper `GlassModalSheet.show` still morphs (pass
+/// `morphFromRect`), but it blooms from a point instead of stretching a
+/// teardrop, because the anchor blob would otherwise duplicate a trigger it
+/// cannot hide.
+class GlassMorphTrigger extends StatefulWidget {
+  /// Creates a new [GlassMorphTrigger].
+  const GlassMorphTrigger({super.key, required this.builder});
+
+  /// Builds the trigger, given the [GlassMorphAnchor] to present with.
+  final Widget Function(BuildContext context, GlassMorphAnchor anchor) builder;
+
+  @override
+  State<GlassMorphTrigger> createState() => _GlassMorphTriggerState();
+}
+
+class _GlassMorphTriggerState extends State<GlassMorphTrigger>
+    with SingleTickerProviderStateMixin {
+  final GlassMorphAnchor _anchor = GlassMorphAnchor._();
+
+  /// Drives the tail of the closing bounce, after the presented route — and the
+  /// controller that started the spring — has been torn down.
+  late final AnimationController _bounce =
+      AnimationController.unbounded(vsync: this);
+
+  /// Built once, not per build: [AnimatedBuilder] compares listenables by
+  /// identity, so merging inline would resubscribe on every rebuild.
+  late final Listenable _repaint =
+      Listenable.merge([_anchor._notifier, _bounce]);
+
+  /// Vector the current bounce swings along; zero when nothing is bouncing.
+  Offset _travel = Offset.zero;
+
+  @override
+  void initState() {
+    super.initState();
+    _anchor._notifier.addListener(_onAnchorChanged);
+  }
+
+  @override
+  void dispose() {
+    _anchor._notifier.removeListener(_onAnchorChanged);
+    _anchor._dispose();
+    _bounce.dispose();
+    super.dispose();
+  }
+
+  void _onAnchorChanged() {
+    if (!mounted) return;
+    final handback = _anchor._handback;
+    if (_anchor._emptied ||
+        handback == null ||
+        handback.travel == Offset.zero) {
+      // A fresh open cancels any bounce still running — including one the user
+      // interrupted by tapping the button mid-swing — and so does a plain
+      // restore, which carries no momentum to continue.
+      _bounce.stop();
+      if (_travel != Offset.zero) setState(() => _travel = Offset.zero);
+      return;
+    }
+
+    // Continue the closing spring from exactly where the presenter left it, so
+    // the catch has no seam. The tail always runs the native-parity profile;
+    // across the speed profiles this is a sub-pixel difference over a bounce
+    // this small, and it keeps the trigger from having to know the speed.
+    setState(() => _travel = handback.travel);
+    _bounce.animateWith(
+      SpringSimulation(
+        LiquidMorphPhysics.closeSpring,
+        handback.value,
+        0.0,
+        handback.velocity,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _repaint,
+      // The consumer's trigger is built here, not inside the builder below, so
+      // the bounce repaints it without rebuilding their subtree every frame.
+      child: KeyedSubtree(
+        key: _anchor._key,
+        child: widget.builder(context, _anchor),
+      ),
+      builder: (context, child) {
+        // Opacity is toggled between 0 and 1 outright, never animated: a glass
+        // surface's backdrop pass renders fully or not at all, so a partial
+        // fade pops. The morph's anchor blob covers the visual transition.
+        final emptied = _anchor._emptied;
+        return Transform.translate(
+          offset: _travel * _bounce.value,
+          child: Opacity(
+            opacity: emptied ? 0.0 : 1.0,
+            child: IgnorePointer(ignoring: emptied, child: child),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Pure geometry for presenting a [GlassModalSheet] with a liquid morph.
+///
+/// Stateless and free of `BuildContext`, so every value the morph renders can
+/// be unit-tested without a widget tree — the same contract
+/// [LiquidMorphPhysics] follows.
+///
+/// [LiquidMorphPhysics] answers *how far along* the morph is; this answers
+/// *where the sheet actually sits*, so the droplet can be aimed at it.
+class SheetMorphGeometry {
+  // Pure utility class — no instances.
+  const SheetMorphGeometry._();
+
+  /// The frame the sheet comes to rest in for [state], in global coordinates.
+  ///
+  /// Mirrors the resting output of the sheet's own per-frame metrics (see
+  /// `_calculateMetrics` in `glass_modal_sheet_state.dart`) for the case that
+  /// matters here: no drag in flight, no frozen pivot, no interaction pulse.
+  /// The vertical position comes from [SheetGeometry.positionForState] rather
+  /// than a re-derivation, so the droplet and the sheet cannot disagree about
+  /// where the sheet is.
+  ///
+  /// The sheet's top edge is always `(1 - pos) * screenSize.height`; only the
+  /// horizontal inset and the bottom overhang differ per detent:
+  ///
+  ///   • [GlassSheetState.full] — edge to edge, sunk past the bottom by
+  ///     [bottomInset] + [bottomRadius] so its lower corners leave the screen.
+  ///   • [GlassSheetState.half] — inset by [horizontalMargin] / [bottomMargin].
+  ///   • [GlassSheetState.peek] — inset by the `peek*` overrides, falling back
+  ///     to the base margins; [peekWidth] centres a fixed-width floor.
+  ///   • [GlassSheetState.hidden] — collapses to a zero-height line at the
+  ///     bottom edge; never a morph destination, but kept total for callers.
+  static Rect restingRect({
+    required GlassSheetState state,
+    required SheetGeometry geometry,
+    required Size screenSize,
+    required double horizontalMargin,
+    required double bottomMargin,
+    required double bottomInset,
+    required double bottomRadius,
+    double? peekHorizontalMargin,
+    double? peekBottomMargin,
+    double? peekWidth,
+  }) {
+    final screenHeight = screenSize.height;
+    final screenWidth = screenSize.width;
+    final pos = geometry.positionForState(state, screenHeight);
+
+    // Every detent parks its top edge at the same place: the visual height is
+    // measured down from the top, so `bottom`/`height` only redistribute the
+    // remainder below it.
+    final top = (1.0 - pos) * screenHeight;
+
+    late final double hPad;
+    late final double bottom;
+
+    switch (state) {
+      case GlassSheetState.full:
+        // Expanded: margins are gone and the sheet sinks by `extraHeight` so
+        // its bottom corners run off screen instead of floating.
+        hPad = 0.0;
+        bottom = -(bottomInset + bottomRadius);
+        break;
+      case GlassSheetState.peek:
+        hPad = _peekHorizontalPad(
+          screenWidth: screenWidth,
+          horizontalMargin: horizontalMargin,
+          peekHorizontalMargin: peekHorizontalMargin,
+          peekWidth: peekWidth,
+        );
+        bottom = peekBottomMargin ?? bottomMargin;
+        break;
+      case GlassSheetState.half:
+      case GlassSheetState.hidden:
+        hPad = horizontalMargin;
+        bottom = bottomMargin;
+        break;
+    }
+
+    // A sheet narrower than its own margins (tiny test surfaces, extreme
+    // margins) would invert the rect; clamp so the frame stays well-formed.
+    final safeHPad = hPad.clamp(0.0, screenWidth / 2.0);
+    return Rect.fromLTRB(
+      safeHPad,
+      top,
+      screenWidth - safeHPad,
+      math.max(top, screenHeight - bottom),
+    );
+  }
+
+  /// Horizontal inset of the peek floor.
+  ///
+  /// [peekWidth] wins when set — a fixed-width floor is centred rather than
+  /// inset — matching the sheet's own peek resolution.
+  static double _peekHorizontalPad({
+    required double screenWidth,
+    required double horizontalMargin,
+    double? peekHorizontalMargin,
+    double? peekWidth,
+  }) {
+    if (peekWidth != null) {
+      return ((screenWidth - peekWidth) / 2.0).clamp(0.0, screenWidth / 2.0);
+    }
+    return peekHorizontalMargin ?? horizontalMargin;
+  }
+
+  /// The frame of the travelling droplet (Blob B) for one morph frame.
+  ///
+  /// Size follows [LiquidMorphState.sizeT] and position follows
+  /// [LiquidMorphState.pathT]; keeping them on separate curves is what opens
+  /// the gap the metaball neck stretches across. Both are clamped to a
+  /// non-negative size because the closing undershoot drives `sizeT` slightly
+  /// below zero, which would otherwise trip a negative-constraint assert.
+  static Rect blobRect({
+    required Rect trigger,
+    required Rect destination,
+    required double pathT,
+    required double sizeT,
+  }) {
+    final width =
+        lerpDouble(trigger.width, destination.width, sizeT)!.clamp(0.0, 1e6);
+    final height =
+        lerpDouble(trigger.height, destination.height, sizeT)!.clamp(0.0, 1e6);
+
+    final centerX =
+        lerpDouble(trigger.center.dx, destination.center.dx, pathT)!;
+    final centerY =
+        lerpDouble(trigger.center.dy, destination.center.dy, pathT)!;
+
+    return Rect.fromLTWH(
+      centerX - width / 2.0,
+      centerY - height / 2.0,
+      width,
+      height,
+    );
+  }
+
+  /// Corner radius of the droplet as it inflates from [trigger] into the sheet.
+  ///
+  /// Starts fully rounded (a pill/circle the size of the trigger) and resolves
+  /// to [target] late — `easeInExpo` holds the droplet round through the travel
+  /// and only squares it off as it lands, which is what reads as *liquid*
+  /// rather than a rectangle growing. The same curve GlassMenu uses.
+  static double blobRadius({
+    required Size blobSize,
+    required double target,
+    required double sizeT,
+  }) {
+    final maxRadius = math.min(blobSize.width, blobSize.height) / 2.0;
+    final t = Curves.easeInExpo.transform(sizeT.clamp(0.0, 1.0));
+    return lerpDouble(maxRadius, math.min(target, maxRadius), t)!;
+  }
+
+  /// Opacity of the droplet's solid fill, ramping in over the last 30 % of the
+  /// size curve so the glass droplet has already arrived before it takes on the
+  /// sheet's opaque surface.
+  ///
+  /// Fading the *fill* is safe; fading the glass itself is not — a shader
+  /// backdrop pass renders fully or not at all, so an animated `Opacity` over
+  /// it pops. The droplet's glass therefore stays at full strength for the
+  /// whole morph and only this plain colour layer crossfades.
+  static double fillReveal(double sizeT) =>
+      ((sizeT - 0.7) / 0.3).clamp(0.0, 1.0);
+
+  /// Opacity the sheet's solid fill rests at in [state].
+  ///
+  /// Mirrors the fill branches of `_calculateMetrics` at rest so the droplet
+  /// lands wearing the surface the sheet is about to show: a glass half detent
+  /// hands off to glass, an opaque full detent hands off to opaque colour.
+  /// Returning the wrong value here would show as a one-frame flash at the
+  /// handoff, which is exactly what the unit tests pin down.
+  static double restingFillOpacity({
+    required GlassSheetState state,
+    required LiquidGlassSettings baseSettings,
+    required bool enablePeek,
+    LiquidGlassSettings? peekSettings,
+    LiquidGlassSettings? halfSettings,
+    LiquidGlassSettings? fullSettings,
+  }) {
+    final sPeek = peekSettings ?? baseSettings;
+    final sHalf = halfSettings ?? baseSettings;
+    final sFull = fullSettings ?? baseSettings;
+
+    switch (state) {
+      case GlassSheetState.full:
+        // t == 1: the crossfade is complete whichever route got us here, so
+        // only the explicit full-state settings can keep the surface glassy.
+        if (fullSettings == null) return 1.0;
+        return _fillFor(from: sHalf, to: sFull, t: 1.0);
+      case GlassSheetState.half:
+        // t == 0: the half→full crossfade hasn't started. Without explicit
+        // full settings the sheet is opaque only when its own surface has no
+        // blur to show through.
+        if (fullSettings == null) {
+          return (sHalf.blur == 0 || baseSettings.blur == 0) ? 1.0 : 0.0;
+        }
+        return _fillFor(from: sHalf, to: sFull, t: 0.0);
+      case GlassSheetState.peek:
+        if (!enablePeek) return sHalf.blur == 0 ? 1.0 : 0.0;
+        return _fillFor(from: sPeek, to: sHalf, t: 0.0);
+      case GlassSheetState.hidden:
+        return 0.0;
+    }
+  }
+
+  /// Resolves the fill opacity for a crossfade between two surfaces at [t].
+  ///
+  /// A surface with `blur == 0` is a solid colour, so the fill is whichever
+  /// side of the crossfade is currently solid.
+  static double _fillFor({
+    required LiquidGlassSettings from,
+    required LiquidGlassSettings to,
+    required double t,
+  }) {
+    if (from.blur > 0 && to.blur == 0) return t;
+    if (from.blur == 0 && to.blur > 0) return 1.0 - t;
+    if (from.blur == 0 && to.blur == 0) return 1.0;
+    return 0.0;
+  }
+
+  /// The glass settings the sheet rests on in [state], before the solid fill is
+  /// composited over them. Mirrors the settings interpolation in
+  /// `_calculateMetrics` at rest.
+  static LiquidGlassSettings restingSettings({
+    required GlassSheetState state,
+    required LiquidGlassSettings baseSettings,
+    required bool enablePeek,
+    LiquidGlassSettings? peekSettings,
+    LiquidGlassSettings? halfSettings,
+    LiquidGlassSettings? fullSettings,
+  }) {
+    switch (state) {
+      case GlassSheetState.full:
+        return fullSettings ?? baseSettings;
+      case GlassSheetState.peek:
+        if (!enablePeek) return halfSettings ?? baseSettings;
+        return peekSettings ?? baseSettings;
+      case GlassSheetState.half:
+      case GlassSheetState.hidden:
+        return halfSettings ?? baseSettings;
+    }
+  }
+}
+
+/// Drives the liquid morph that presents [child] (a [GlassModalSheetScaffold]).
+///
+/// Owns a [GlassMorphController] and renders the two-blob droplet while the
+/// morph is in flight, swapping to the real sheet at the settled instant.
+///
+/// The route's own animation is used only as a *signal* — its reverse status
+/// starts the closing morph — never as the morph's clock. Mapping the engine
+/// onto a linear route animation would discard the J-curve and the underdamped
+/// catch, which are the whole effect.
+///
+/// Inserted by [GlassModalSheet.show] when a trigger is supplied; it is not
+/// part of the package's public surface, but is left constructible so the morph
+/// can be driven directly in tests (headless test runs report no Impeller, so
+/// `show()` itself always takes the slide fallback there).
+class GlassSheetMorphPresenter extends StatefulWidget {
+  /// Creates a new [GlassSheetMorphPresenter].
+  const GlassSheetMorphPresenter({
+    super.key,
+    required this.routeAnimation,
+    required this.triggerRect,
+    required this.anchor,
+    required this.speed,
+    required this.restingState,
+    required this.geometry,
+    required this.horizontalMargin,
+    required this.bottomMargin,
+    required this.topBorderRadius,
+    required this.fullTopBorderRadius,
+    required this.bottomBorderRadius,
+    required this.fullBottomBorderRadius,
+    required this.settings,
+    required this.peekSettings,
+    required this.halfSettings,
+    required this.fullSettings,
+    required this.expandedColor,
+    required this.quality,
+    required this.peekHorizontalMargin,
+    required this.peekBottomMargin,
+    required this.peekWidth,
+    required this.peekTopBorderRadius,
+    required this.platformViewBackdrop,
+    required this.child,
+  });
+
+  /// The presenting route's animation. Watched for [AnimationStatus.reverse]
+  /// so the closing morph starts the moment the route begins popping.
+  final Animation<double> routeAnimation;
+
+  /// Global rect of the widget the sheet morphs out of.
+  final Rect triggerRect;
+
+  /// The trigger this morph can empty, when there is one.
+  ///
+  /// Present: the anchor blob stands in for the hidden trigger and the teardrop
+  /// neck stretches between them. Null: the trigger stays painted — so no
+  /// anchor blob is drawn (it would duplicate the button) and the droplet
+  /// blooms from [triggerRect]'s centre instead.
+  final GlassMorphAnchor? anchor;
+
+  /// Speed profile forwarded to the [GlassMorphController].
+  final MorphSpeed speed;
+
+  /// The detent the sheet comes to rest at — the morph's destination.
+  final GlassSheetState restingState;
+
+  /// Detent configuration, shared with the sheet so both resolve the same
+  /// resting position.
+  final SheetGeometry geometry;
+
+  /// Sheet margins and radii, forwarded so the droplet lands on the sheet's
+  /// exact frame.
+  final double horizontalMargin;
+
+  /// See [GlassModalSheet.bottomMargin].
+  final double bottomMargin;
+
+  /// See [GlassModalSheet.topBorderRadius].
+  final double? topBorderRadius;
+
+  /// See [GlassModalSheet.fullTopBorderRadius].
+  final double? fullTopBorderRadius;
+
+  /// See [GlassModalSheet.bottomBorderRadius].
+  final double? bottomBorderRadius;
+
+  /// See [GlassModalSheet.fullBottomBorderRadius].
+  final double? fullBottomBorderRadius;
+
+  /// See [GlassModalSheet.settings].
+  final LiquidGlassSettings? settings;
+
+  /// See [GlassModalSheet.peekSettings].
+  final LiquidGlassSettings? peekSettings;
+
+  /// See [GlassModalSheet.halfSettings].
+  final LiquidGlassSettings? halfSettings;
+
+  /// See [GlassModalSheet.fullSettings].
+  final LiquidGlassSettings? fullSettings;
+
+  /// See [GlassModalSheet.expandedColor].
+  final Color? expandedColor;
+
+  /// See [GlassModalSheet.quality].
+  final GlassQuality? quality;
+
+  /// See [GlassModalSheet.peekHorizontalMargin].
+  final double? peekHorizontalMargin;
+
+  /// See [GlassModalSheet.peekBottomMargin].
+  final double? peekBottomMargin;
+
+  /// See [GlassModalSheet.peekWidth].
+  final double? peekWidth;
+
+  /// See [GlassModalSheet.peekTopBorderRadius].
+  final double? peekTopBorderRadius;
+
+  /// See [GlassModalSheet.platformViewBackdrop]. Suppresses the metaball blend
+  /// group, exactly as it does in the sheet and in `GlassMenu`.
+  final bool platformViewBackdrop;
+
+  /// The real sheet. Mounted for the whole morph — never remounted at the
+  /// handoff — so its glass layers and springs are already seeded when it is
+  /// revealed.
+  final Widget child;
+
+  @override
+  State<GlassSheetMorphPresenter> createState() =>
+      _GlassSheetMorphPresenterState();
+}
+
+class _GlassSheetMorphPresenterState extends State<GlassSheetMorphPresenter>
+    with TickerProviderStateMixin {
+  late final GlassMorphController _morph;
+
+  /// Latches once the droplet has landed and the real sheet has taken over.
+  ///
+  /// Without the latch the underdamped spring dipping back below the settle
+  /// threshold would flip the sheet back to a droplet for a frame.
+  bool _handedOffToSheet = false;
+
+  /// True once the closing morph has started, so the reverse listener and the
+  /// settle latch don't fight over the same transition.
+  bool _isClosing = false;
+
+  /// Whether the pointer that is dismissing the sheet dragged it first.
+  ///
+  /// A drag-dismiss throws the sheet down with the finger's own momentum and
+  /// releases it anywhere between detents; morphing back from the sheet's
+  /// *resting* frame at that point would visibly jump. So a dragged dismissal
+  /// keeps the sheet's native slide-away and skips the morph, while a barrier
+  /// tap, a back gesture, or a controller close — all of which leave the sheet
+  /// sitting at rest — morph back into the trigger.
+  bool _draggedSincePointerDown = false;
+
+  /// Where the active pointer went down, for the slop comparison above.
+  Offset? _dragOrigin;
+
+  /// Whether the opening morph has been started. See [didChangeDependencies].
+  bool _opened = false;
+
+  /// Trigger-centre → destination-centre delta from the last build, handed to
+  /// the trigger at the catch as the vector its bounce swings along.
+  Offset _finalDelta = Offset.zero;
+
+  /// Latches when the trigger has taken the bounce over, so the handoff fires
+  /// exactly once per close.
+  bool _handedBackToTrigger = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _morph = GlassMorphController(vsync: this, speed: widget.speed);
+    _morph.addListener(_onMorphTick);
+    widget.routeAnimation.addStatusListener(_onRouteStatus);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Reduce Motion: swaps in the engine's instant spring. GlassMenu can set
+    // this in didChangeDependencies and open later on a tap; a presented sheet
+    // opens the moment it mounts, so the flag has to land BEFORE the spring
+    // starts — otherwise the first presentation of every session animates at
+    // full length with Reduce Motion on.
+    _morph.setDisableAnimations(MediaQuery.of(context).disableAnimations);
+    if (!_opened) {
+      _opened = true;
+      // Empty the trigger before the first morph frame paints, so the button
+      // and the anchor blob standing in for it are never both on screen.
+      widget.anchor?._empty();
+      _morph.open();
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.routeAnimation.removeStatusListener(_onRouteStatus);
+    _morph.removeListener(_onMorphTick);
+    _morph.dispose();
+    // The route can be torn down without the closing morph ever running (a
+    // Navigator reset, a hot restart). Leaving the trigger emptied would erase
+    // a live button, so restoring here is the safety net.
+    widget.anchor?._restore();
+    super.dispose();
+  }
+
+  void _onMorphTick() {
+    if (!mounted) return;
+    // Hand off to the real sheet only at the settled instant, when the droplet
+    // and the sheet occupy the identical frame and nothing is moving — the one
+    // moment a glass surface can be swapped without a glitch frame.
+    if (!_isClosing && !_handedOffToSheet && _morph.value >= 0.999) {
+      _handedOffToSheet = true;
+    }
+    _syncTrigger();
+    setState(() {});
+  }
+
+  /// Hands the trigger back at the moment the droplet is caught.
+  ///
+  /// [GlassMorphController.hasHandedOff] latches on the spring's first
+  /// zero-crossing during a close, which is exactly when the droplet has
+  /// arrived — so the real button reappears there rather than after the
+  /// underdamped bounce has finished. Same latch GlassMenu hands off on.
+  ///
+  /// Fires once, and passes the spring's live state rather than driving the
+  /// bounce frame by frame: this route is torn down moments later (its barrier
+  /// would otherwise keep swallowing taps on a button that is visibly back), so
+  /// the trigger continues the simulation itself from exactly here.
+  void _syncTrigger() {
+    final anchor = widget.anchor;
+    if (anchor == null || !_isClosing || _handedBackToTrigger) return;
+    if (!_morph.hasHandedOff) return;
+    _handedBackToTrigger = true;
+    anchor._handBack(
+      travel: _finalDelta,
+      value: _morph.value,
+      velocity: _morph.velocity,
+    );
+  }
+
+  void _onRouteStatus(AnimationStatus status) {
+    if (status != AnimationStatus.reverse || _isClosing) return;
+    if (_draggedSincePointerDown) return; // the sheet slides itself away
+    setState(() {
+      _isClosing = true;
+      _handedOffToSheet = false;
+      _handedBackToTrigger = false;
+    });
+    _morph.close();
+  }
+
+  void _onPointerDown(PointerDownEvent event) {
+    _dragOrigin = event.position;
+    _draggedSincePointerDown = false;
+  }
+
+  void _onPointerMove(PointerMoveEvent event) {
+    // Slop, not any movement at all: a tap on the dismiss barrier routinely
+    // wobbles a pixel or two, and mistaking that for a drag would cost the
+    // morph on the most common way of closing the sheet.
+    final origin = _dragOrigin;
+    if (origin == null || _draggedSincePointerDown) return;
+    if ((event.position - origin).distance > kTouchSlop) {
+      _draggedSincePointerDown = true;
+    }
+  }
+
+  void _onPointerRelease(PointerEvent event) {
+    _dragOrigin = null;
+    // Cleared after the frame, not during it: a drag that ends in a dismissal
+    // pops the route synchronously from this same pointer-up, and the flag has
+    // to still be set when [_onRouteStatus] reads it. By the next frame the
+    // gesture is over, so a later back gesture or controller close still
+    // morphs.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _draggedSincePointerDown = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.sizeOf(context);
+    final bottomInset = MediaQuery.paddingOf(context).bottom;
+
+    final adaptiveRadius = GlassThemeHelpers.resolveAdaptiveRadius(context);
+    final topRadiusBase = widget.topBorderRadius ?? adaptiveRadius;
+    final bottomRadiusBase = widget.bottomBorderRadius ?? adaptiveRadius;
+
+    final destination = SheetMorphGeometry.restingRect(
+      state: widget.restingState,
+      geometry: widget.geometry,
+      screenSize: screenSize,
+      horizontalMargin: widget.horizontalMargin,
+      bottomMargin: widget.bottomMargin,
+      bottomInset: bottomInset,
+      bottomRadius: bottomRadiusBase,
+      peekHorizontalMargin: widget.peekHorizontalMargin,
+      peekBottomMargin: widget.peekBottomMargin,
+      peekWidth: widget.peekWidth,
+    );
+
+    // The real sheet stays mounted underneath for the whole morph so its
+    // post-frame snap, glass layers and springs are already settled by the time
+    // it is revealed; only painting and hit-testing are gated.
+    final sheet = Visibility(
+      visible: _handedOffToSheet,
+      maintainState: true,
+      maintainAnimation: true,
+      maintainSize: true,
+      child: Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: _onPointerDown,
+        onPointerMove: _onPointerMove,
+        onPointerUp: _onPointerRelease,
+        onPointerCancel: _onPointerRelease,
+        child: widget.child,
+      ),
+    );
+
+    // The sheet is always slot 0 of the same Stack, whether the droplet is
+    // present or not. Returning `sheet` bare at the handoff would change its
+    // depth in the element tree, and Flutter answers a depth change by tearing
+    // the subtree down and rebuilding it — remounting every glass layer and
+    // re-seeding every spring inside the sheet, at the exact moment the morph
+    // is trying to look seamless.
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        sheet,
+        if (!_handedOffToSheet)
+          _buildDroplet(
+            context: context,
+            destination: destination,
+            topRadiusBase: topRadiusBase,
+            bottomRadiusBase: bottomRadiusBase,
+          ),
+      ],
+    );
+  }
+
+  Widget _buildDroplet({
+    required BuildContext context,
+    required Rect destination,
+    required double topRadiusBase,
+    required double bottomRadiusBase,
+  }) {
+    final trigger = widget.triggerRect;
+
+    // The anchor blob only earns its place when the real trigger is hidden.
+    // Drawn over a trigger that is still painted it reads as a duplicated
+    // button rather than a morph, so without an anchor the droplet blooms from
+    // the trigger's centre instead — no second button-sized shape at any point,
+    // at the cost of the teardrop neck, which needs two blobs to stretch
+    // between. Mirrors GlassMenu's `morphFromZero`.
+    final showAnchorBlob = widget.anchor != null;
+    final source = showAnchorBlob
+        ? trigger
+        : Rect.fromCenter(center: trigger.center, width: 0, height: 0);
+
+    // The engine works in displacement-from-trigger-centre terms; the sheet's
+    // destination is an absolute rect, so hand it the delta between centres.
+    _finalDelta = destination.center - trigger.center;
+    final state = _morph.computeState(
+      finalDx: _finalDelta.dx,
+      finalDy: _finalDelta.dy,
+    );
+
+    final blob = SheetMorphGeometry.blobRect(
+      trigger: source,
+      destination: destination,
+      pathT: state.pathT,
+      sizeT: state.sizeT,
+    );
+
+    final enablePeek = widget.geometry.enablePeek;
+    final baseSettings = GlassThemeHelpers.resolveSettings(
+      context,
+      explicit: widget.settings,
+      fallback: kDefaultSheetSettings,
+    );
+    final dropletSettings = SheetMorphGeometry.restingSettings(
+      state: widget.restingState,
+      baseSettings: baseSettings,
+      enablePeek: enablePeek,
+      peekSettings: widget.peekSettings,
+      halfSettings: widget.halfSettings,
+      fullSettings: widget.fullSettings,
+    );
+    final fillOpacity = SheetMorphGeometry.restingFillOpacity(
+          state: widget.restingState,
+          baseSettings: baseSettings,
+          enablePeek: enablePeek,
+          peekSettings: widget.peekSettings,
+          halfSettings: widget.halfSettings,
+          fullSettings: widget.fullSettings,
+        ) *
+        SheetMorphGeometry.fillReveal(state.sizeT);
+
+    final quality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.quality,
+      fallback: GlassQuality.premium,
+    );
+
+    final isDark = GlassTheme.brightnessOf(context) == Brightness.dark;
+    final fillColor = widget.expandedColor ??
+        (isDark ? const Color(0xFF1C1C1E) : CupertinoColors.white);
+
+    // Radii the droplet resolves to: the sheet's own resting corners.
+    final targetTopRadius = switch (widget.restingState) {
+      GlassSheetState.full => widget.fullTopBorderRadius ?? topRadiusBase,
+      GlassSheetState.peek => widget.peekTopBorderRadius ?? topRadiusBase,
+      _ => topRadiusBase,
+    };
+    final targetBottomRadius = widget.restingState == GlassSheetState.full
+        ? (widget.fullBottomBorderRadius ?? bottomRadiusBase)
+        : bottomRadiusBase;
+
+    final blobSize = blob.size;
+    final topRadius = SheetMorphGeometry.blobRadius(
+      blobSize: blobSize,
+      target: targetTopRadius,
+      sizeT: state.sizeT,
+    );
+    final bottomRadius = SheetMorphGeometry.blobRadius(
+      blobSize: blobSize,
+      target: targetBottomRadius,
+      sizeT: state.sizeT,
+    );
+
+    // Blob A — the trigger ghost. Shrinks to nothing over the first 40 % of the
+    // opening so the liquid bridge snaps, and grows back on close so the real
+    // button "catches" the returning droplet.
+    final anchorRadius = trigger.shortestSide / 2.0;
+    final Widget? blobA = !showAnchorBlob
+        ? null
+        : Positioned(
+            left: trigger.left + state.pushDx,
+            top: trigger.top + state.pushDy,
+            child: Transform.scale(
+              scale: state.anchorScale,
+              child: AdaptiveGlass(
+                shape: LiquidRoundedRectangle(borderRadius: anchorRadius),
+                settings: dropletSettings,
+                quality: quality,
+                platformViewBackdrop: widget.platformViewBackdrop,
+                useOwnLayer: false,
+                child: SizedBox(width: trigger.width, height: trigger.height),
+              ),
+            ),
+          );
+
+    // Blob B — the travelling body. Scaled by the engine's squeeze pulse so the
+    // closing undershoot reads as a physical compression rather than a slide.
+    final blobB = Positioned(
+      left: blob.left,
+      top: blob.top,
+      child: IgnorePointer(
+        child: Transform.scale(
+          scale: state.containerScale,
+          child: AdaptiveGlass(
+            shape: LiquidVerticalRoundedSuperellipse(
+              topRadius: topRadius,
+              bottomRadius: bottomRadius,
+            ),
+            settings: dropletSettings,
+            quality: quality,
+            useOwnLayer: false,
+            child: SizedBox(
+              width: blobSize.width,
+              height: blobSize.height,
+              child: fillOpacity <= 0.0
+                  ? null
+                  : ColoredBox(
+                      color: fillColor.withValues(alpha: fillOpacity),
+                    ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Widget blobs = Stack(
+      clipBehavior: Clip.none,
+      children: [if (blobA != null) blobA, blobB],
+    );
+
+    // LiquidGlassBlendGroup needs the InheritedGeometryRenderLink that only a
+    // full LiquidGlassLayer provides. AdaptiveLiquidGlassLayer skips that layer
+    // in minimal quality and in platformViewBackdrop mode, so the blend group
+    // has to be skipped in exactly those cases too (issue #214).
+    final useBlendGroup =
+        quality != GlassQuality.minimal && !widget.platformViewBackdrop;
+
+    // Once the droplet has been caught, the real trigger is back on screen and
+    // the droplet is standing in front of a button that is already there — two
+    // shapes where there should be one. GlassMenu hides its overlay at exactly
+    // this latch for the same reason; without it the last frames read as a
+    // duplicated button that vanishes when the route unmounts, rather than a
+    // droplet settling into the trigger.
+    //
+    // Toggled outright, never faded: a glass surface's backdrop pass renders
+    // fully or not at all.
+    final handedBack = _morph.isClosing && _morph.hasHandedOff;
+
+    return Positioned.fill(
+      child: IgnorePointer(
+        child: Opacity(
+          opacity: handedBack ? 0.0 : 1.0,
+          child: AdaptiveLiquidGlassLayer(
+            settings: dropletSettings,
+            quality: quality,
+            blendAmount: state.blend,
+            platformViewBackdrop: widget.platformViewBackdrop,
+            child: useBlendGroup
+                ? LiquidGlassBlendGroup(blend: state.blend, child: blobs)
+                : blobs,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/widgets/overlays/glass_modal_sheet_morph_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_morph_test.dart
@@ -1,0 +1,1421 @@
+// Coverage for the Liquid Morph presentation of GlassModalSheet:
+// SheetMorphGeometry (pure) and GlassSheetMorphPresenter (widget), plus the
+// capability fallback GlassModalSheet.show() applies before pushing the route.
+//
+// Both types live in the glass_modal_sheet library rather than the package's
+// public surface, so — like the mechanics tests — this imports the library file
+// directly.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart'
+    show GlassQuality, MorphSpeed;
+import 'package:liquid_glass_widgets/src/renderer/liquid_glass_renderer.dart';
+import 'package:liquid_glass_widgets/widgets/shared/adaptive_glass.dart';
+import 'package:liquid_glass_widgets/widgets/shared/adaptive_liquid_glass_layer.dart';
+import 'package:liquid_glass_widgets/widgets/overlays/glass_modal_sheet.dart';
+
+/// A 400 × 800 screen keeps every expected number below exact and readable.
+const _screen = Size(400, 800);
+
+/// Two detents, no peek floor — the default sheet configuration.
+const _defaultGeometry = SheetGeometry(
+  mode: GlassSheetMode.dismissible,
+  halfSize: 0.5,
+  peekSize: 100.0,
+  enablePeek: false,
+);
+
+const _peekGeometry = SheetGeometry(
+  mode: GlassSheetMode.persistent,
+  halfSize: 0.5,
+  peekSize: 100.0,
+  enablePeek: true,
+);
+
+/// Glass (blurred) and solid (blur-free) surfaces, for the fill branches.
+const _glassSettings = LiquidGlassSettings(blur: 10.0);
+const _solidSettings = LiquidGlassSettings(blur: 0.0);
+
+Widget _app(Widget child, {bool disableAnimations = false}) => MaterialApp(
+      home: MediaQuery(
+        data: MediaQueryData(
+          size: _screen,
+          disableAnimations: disableAnimations,
+        ),
+        child: Scaffold(backgroundColor: Colors.transparent, body: child),
+      ),
+    );
+
+void main() {
+  group('SheetMorphGeometry.restingRect', () {
+    test('half detent rests inset by the sheet margins', () {
+      final rect = SheetMorphGeometry.restingRect(
+        state: GlassSheetState.half,
+        geometry: _defaultGeometry,
+        screenSize: _screen,
+        horizontalMargin: 8.0,
+        bottomMargin: 6.0,
+        bottomInset: 34.0,
+        bottomRadius: 56.0,
+      );
+
+      // pos = 0.5 → the top edge sits halfway down the screen.
+      expect(rect.top, 400.0);
+      expect(rect.left, 8.0);
+      expect(rect.right, 392.0);
+      expect(rect.bottom, 794.0); // 800 - bottomMargin
+      expect(rect.height, 394.0);
+    });
+
+    test('full detent runs edge to edge and sinks past the bottom', () {
+      final rect = SheetMorphGeometry.restingRect(
+        state: GlassSheetState.full,
+        geometry: _defaultGeometry,
+        screenSize: _screen,
+        horizontalMargin: 8.0,
+        bottomMargin: 6.0,
+        bottomInset: 34.0,
+        bottomRadius: 46.0,
+      );
+
+      // Default full size is screenHeight - 90.
+      expect(rect.top, closeTo(90.0, 1e-9));
+      expect(rect.left, 0.0);
+      expect(rect.right, 400.0);
+      // Sunk by bottomInset + bottomRadius so the lower corners leave screen.
+      expect(rect.bottom, 880.0);
+    });
+
+    test('peek detent honours the peek-specific margins', () {
+      final rect = SheetMorphGeometry.restingRect(
+        state: GlassSheetState.peek,
+        geometry: _peekGeometry,
+        screenSize: _screen,
+        horizontalMargin: 8.0,
+        bottomMargin: 6.0,
+        bottomInset: 0.0,
+        bottomRadius: 56.0,
+        peekHorizontalMargin: 20.0,
+        peekBottomMargin: 12.0,
+      );
+
+      // peekSize 100 of an 800pt screen → pos 0.125 → top 700.
+      expect(rect.top, 700.0);
+      expect(rect.left, 20.0);
+      expect(rect.right, 380.0);
+      expect(rect.bottom, 788.0);
+    });
+
+    test('peekWidth centres a fixed-width floor instead of insetting it', () {
+      final rect = SheetMorphGeometry.restingRect(
+        state: GlassSheetState.peek,
+        geometry: _peekGeometry,
+        screenSize: _screen,
+        horizontalMargin: 8.0,
+        bottomMargin: 6.0,
+        bottomInset: 0.0,
+        bottomRadius: 56.0,
+        peekWidth: 200.0,
+      );
+
+      expect(rect.left, 100.0);
+      expect(rect.width, 200.0);
+    });
+
+    test('hidden collapses to the bottom edge without inverting', () {
+      final rect = SheetMorphGeometry.restingRect(
+        state: GlassSheetState.hidden,
+        geometry: _defaultGeometry,
+        screenSize: _screen,
+        horizontalMargin: 8.0,
+        bottomMargin: 6.0,
+        bottomInset: 0.0,
+        bottomRadius: 56.0,
+      );
+
+      expect(rect.top, 800.0);
+      expect(rect.height, 0.0);
+      expect(rect.isEmpty, isTrue);
+    });
+
+    test('margins wider than the screen clamp instead of inverting', () {
+      final rect = SheetMorphGeometry.restingRect(
+        state: GlassSheetState.half,
+        geometry: _defaultGeometry,
+        screenSize: _screen,
+        horizontalMargin: 900.0,
+        bottomMargin: 6.0,
+        bottomInset: 0.0,
+        bottomRadius: 56.0,
+      );
+
+      expect(rect.left, 200.0);
+      expect(rect.width, 0.0);
+    });
+  });
+
+  group('SheetMorphGeometry.blobRect', () {
+    const trigger = Rect.fromLTWH(100, 700, 56, 56);
+    const destination = Rect.fromLTWH(8, 400, 384, 394);
+
+    test('starts exactly on the trigger', () {
+      final rect = SheetMorphGeometry.blobRect(
+        trigger: trigger,
+        destination: destination,
+        pathT: 0.0,
+        sizeT: 0.0,
+      );
+      expect(rect.center, trigger.center);
+      expect(rect.size, trigger.size);
+    });
+
+    test('lands exactly on the destination', () {
+      final rect = SheetMorphGeometry.blobRect(
+        trigger: trigger,
+        destination: destination,
+        pathT: 1.0,
+        sizeT: 1.0,
+      );
+      // The handoff to the real sheet depends on this being exact.
+      expect(rect.center.dx, closeTo(destination.center.dx, 1e-9));
+      expect(rect.center.dy, closeTo(destination.center.dy, 1e-9));
+      expect(rect.width, closeTo(destination.width, 1e-9));
+      expect(rect.height, closeTo(destination.height, 1e-9));
+    });
+
+    test('position and size advance independently', () {
+      // The J-curve runs ahead of the size curve — that separation is what the
+      // metaball neck stretches across, so the blob must not couple them.
+      final rect = SheetMorphGeometry.blobRect(
+        trigger: trigger,
+        destination: destination,
+        pathT: 0.9,
+        sizeT: 0.3,
+      );
+      expect(rect.center.dy, lessThan(trigger.center.dy));
+      expect(rect.width, lessThan(destination.width));
+      expect(rect.width, greaterThan(trigger.width));
+    });
+
+    test('closing undershoot cannot produce a negative size', () {
+      // The underdamped close drives sizeT below zero; a negative width would
+      // trip a BoxConstraints assert.
+      final rect = SheetMorphGeometry.blobRect(
+        trigger: trigger,
+        destination: destination,
+        pathT: -0.2,
+        sizeT: -0.2,
+      );
+      expect(rect.width, greaterThanOrEqualTo(0.0));
+      expect(rect.height, greaterThanOrEqualTo(0.0));
+    });
+  });
+
+  group('SheetMorphGeometry.blobRadius', () {
+    test('starts fully rounded at the trigger', () {
+      final radius = SheetMorphGeometry.blobRadius(
+        blobSize: const Size(56, 56),
+        target: 56.0,
+        sizeT: 0.0,
+      );
+      expect(radius, 28.0);
+    });
+
+    test('resolves to the sheet radius on arrival', () {
+      final radius = SheetMorphGeometry.blobRadius(
+        blobSize: const Size(384, 394),
+        target: 56.0,
+        sizeT: 1.0,
+      );
+      expect(radius, 56.0);
+    });
+
+    test('never exceeds the half-extent of the blob', () {
+      // A 56pt target on a 40pt-tall droplet would render as a lozenge with
+      // overlapping corners.
+      final radius = SheetMorphGeometry.blobRadius(
+        blobSize: const Size(384, 40),
+        target: 56.0,
+        sizeT: 1.0,
+      );
+      expect(radius, 20.0);
+    });
+
+    test('stays round through the travel', () {
+      // easeInExpo holds the droplet round until it is nearly landed.
+      final radius = SheetMorphGeometry.blobRadius(
+        blobSize: const Size(200, 200),
+        target: 20.0,
+        sizeT: 0.5,
+      );
+      expect(radius, greaterThan(90.0));
+    });
+  });
+
+  group('SheetMorphGeometry.fillReveal', () {
+    test('holds at zero through the travel', () {
+      expect(SheetMorphGeometry.fillReveal(0.0), 0.0);
+      expect(SheetMorphGeometry.fillReveal(0.7), 0.0);
+    });
+
+    test('ramps to full over the last 30%', () {
+      expect(SheetMorphGeometry.fillReveal(0.85), closeTo(0.5, 1e-9));
+      expect(SheetMorphGeometry.fillReveal(1.0), 1.0);
+    });
+
+    test('clamps past the ends', () {
+      expect(SheetMorphGeometry.fillReveal(-0.2), 0.0);
+      expect(SheetMorphGeometry.fillReveal(1.4), 1.0);
+    });
+  });
+
+  group('SheetMorphGeometry.restingFillOpacity', () {
+    test('default sheet: glass at half, opaque at full', () {
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.half,
+          baseSettings: _glassSettings,
+          enablePeek: false,
+        ),
+        0.0,
+      );
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.full,
+          baseSettings: _glassSettings,
+          enablePeek: false,
+        ),
+        1.0,
+      );
+    });
+
+    test('a blur-free base surface is solid at every detent', () {
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.half,
+          baseSettings: _solidSettings,
+          enablePeek: false,
+        ),
+        1.0,
+      );
+    });
+
+    test('explicit full settings keep the full detent glassy', () {
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.full,
+          baseSettings: _glassSettings,
+          halfSettings: _glassSettings,
+          fullSettings: _glassSettings,
+          enablePeek: false,
+        ),
+        0.0,
+      );
+    });
+
+    test('explicit solid full settings fill on arrival', () {
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.full,
+          baseSettings: _glassSettings,
+          halfSettings: _glassSettings,
+          fullSettings: _solidSettings,
+          enablePeek: false,
+        ),
+        1.0,
+      );
+      // ...and the half detent it crossfades from stays glass.
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.half,
+          baseSettings: _glassSettings,
+          halfSettings: _glassSettings,
+          fullSettings: _solidSettings,
+          enablePeek: false,
+        ),
+        0.0,
+      );
+    });
+
+    test('a solid half crossfading to glass is solid at half', () {
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.half,
+          baseSettings: _glassSettings,
+          halfSettings: _solidSettings,
+          fullSettings: _glassSettings,
+          enablePeek: false,
+        ),
+        1.0,
+      );
+    });
+
+    test('two solid surfaces stay solid throughout', () {
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.full,
+          baseSettings: _glassSettings,
+          halfSettings: _solidSettings,
+          fullSettings: _solidSettings,
+          enablePeek: false,
+        ),
+        1.0,
+      );
+    });
+
+    test('peek follows the peek surface when the floor is enabled', () {
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.peek,
+          baseSettings: _glassSettings,
+          enablePeek: true,
+        ),
+        0.0,
+      );
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.peek,
+          baseSettings: _glassSettings,
+          peekSettings: _solidSettings,
+          enablePeek: true,
+        ),
+        1.0,
+      );
+    });
+
+    test('peek without a floor falls back to the half surface', () {
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.peek,
+          baseSettings: _glassSettings,
+          halfSettings: _solidSettings,
+          enablePeek: false,
+        ),
+        1.0,
+      );
+    });
+
+    test('hidden never fills', () {
+      expect(
+        SheetMorphGeometry.restingFillOpacity(
+          state: GlassSheetState.hidden,
+          baseSettings: _glassSettings,
+          enablePeek: false,
+        ),
+        0.0,
+      );
+    });
+  });
+
+  group('SheetMorphGeometry.restingSettings', () {
+    test('picks the surface the detent rests on', () {
+      expect(
+        SheetMorphGeometry.restingSettings(
+          state: GlassSheetState.full,
+          baseSettings: _glassSettings,
+          fullSettings: _solidSettings,
+          enablePeek: false,
+        ),
+        _solidSettings,
+      );
+      expect(
+        SheetMorphGeometry.restingSettings(
+          state: GlassSheetState.half,
+          baseSettings: _glassSettings,
+          halfSettings: _solidSettings,
+          enablePeek: false,
+        ),
+        _solidSettings,
+      );
+      expect(
+        SheetMorphGeometry.restingSettings(
+          state: GlassSheetState.peek,
+          baseSettings: _glassSettings,
+          peekSettings: _solidSettings,
+          enablePeek: true,
+        ),
+        _solidSettings,
+      );
+      expect(
+        SheetMorphGeometry.restingSettings(
+          state: GlassSheetState.hidden,
+          baseSettings: _glassSettings,
+          enablePeek: false,
+        ),
+        _glassSettings,
+      );
+    });
+
+    test('peek without a floor uses the half surface', () {
+      expect(
+        SheetMorphGeometry.restingSettings(
+          state: GlassSheetState.peek,
+          baseSettings: _glassSettings,
+          halfSettings: _solidSettings,
+          enablePeek: false,
+        ),
+        _solidSettings,
+      );
+    });
+
+    test('falls back to the base surface when nothing is overridden', () {
+      expect(
+        SheetMorphGeometry.restingSettings(
+          state: GlassSheetState.full,
+          baseSettings: _glassSettings,
+          enablePeek: false,
+        ),
+        _glassSettings,
+      );
+    });
+  });
+
+  group('GlassSheetMorphPresenter', () {
+    /// Builds a presenter with a caller-owned route animation, so the test can
+    /// drive the reverse that a real pop would.
+    Widget buildPresenter({
+      required AnimationController routeAnimation,
+      MorphSpeed speed = MorphSpeed.normal,
+      GlassSheetState restingState = GlassSheetState.half,
+      bool disableAnimations = false,
+      GlassMorphAnchor? anchor,
+    }) {
+      return _app(
+        disableAnimations: disableAnimations,
+        GlassSheetMorphPresenter(
+          routeAnimation: routeAnimation,
+          triggerRect: const Rect.fromLTWH(172, 700, 56, 56),
+          anchor: anchor,
+          speed: speed,
+          restingState: restingState,
+          geometry: _defaultGeometry,
+          horizontalMargin: 8.0,
+          bottomMargin: 6.0,
+          topBorderRadius: 56.0,
+          fullTopBorderRadius: 46.0,
+          bottomBorderRadius: null,
+          fullBottomBorderRadius: null,
+          settings: null,
+          peekSettings: null,
+          halfSettings: null,
+          fullSettings: null,
+          expandedColor: null,
+          quality: null,
+          peekHorizontalMargin: null,
+          peekBottomMargin: null,
+          peekWidth: null,
+          peekTopBorderRadius: null,
+          platformViewBackdrop: false,
+          child: GlassModalSheetScaffold(
+            body: SizedBox.shrink(),
+            sheet: Text('Sheet body'),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the droplet before it lands, then the real sheet',
+        (tester) async {
+      final route = AnimationController(
+        vsync: tester,
+        duration: const Duration(milliseconds: 500),
+      )..forward();
+      addTearDown(route.dispose);
+
+      await tester.pumpWidget(buildPresenter(routeAnimation: route));
+      await tester.pump(const Duration(milliseconds: 16));
+
+      // Mid-morph: the droplet's glass layer is in the tree and the sheet is
+      // mounted but not painted.
+      expect(find.byType(AdaptiveLiquidGlassLayer), findsWidgets);
+      expect(
+        tester.widget<Visibility>(find.byType(Visibility).first).visible,
+        isFalse,
+      );
+
+      await tester.pumpAndSettle();
+
+      // Settled: the sheet has taken over and the droplet is gone.
+      expect(find.text('Sheet body'), findsOneWidget);
+      expect(
+        tester.widget<Visibility>(find.byType(Visibility).first).visible,
+        isTrue,
+      );
+    });
+
+    testWidgets('the sheet is mounted for the whole morph, never remounted',
+        (tester) async {
+      // Remounting a glass widget mid-animation re-seeds its layers and springs
+      // and shows as a glitch frame, so the sheet element must survive the
+      // handoff rather than being inserted at the end.
+      final route = AnimationController(
+        vsync: tester,
+        duration: const Duration(milliseconds: 500),
+      )..forward();
+      addTearDown(route.dispose);
+
+      await tester.pumpWidget(buildPresenter(routeAnimation: route));
+      await tester.pump(const Duration(milliseconds: 16));
+
+      final elementDuringMorph =
+          tester.element(find.byType(GlassModalSheetScaffold));
+
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.element(find.byType(GlassModalSheetScaffold)),
+        same(elementDuringMorph),
+      );
+    });
+
+    testWidgets('a route reverse starts the closing morph', (tester) async {
+      final route = AnimationController(
+        vsync: tester,
+        duration: const Duration(milliseconds: 500),
+      )..forward();
+      addTearDown(route.dispose);
+
+      await tester.pumpWidget(buildPresenter(routeAnimation: route));
+      await tester.pumpAndSettle();
+      expect(
+        tester.widget<Visibility>(find.byType(Visibility).first).visible,
+        isTrue,
+      );
+
+      route.reverse();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      // The sheet hands back to the droplet for the return trip.
+      expect(
+        tester.widget<Visibility>(find.byType(Visibility).first).visible,
+        isFalse,
+      );
+
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('a dragged dismissal keeps the sheet, skipping the morph',
+        (tester) async {
+      // A swipe-down releases the sheet between detents; morphing back from the
+      // resting frame would visibly jump, so the sheet slides itself away.
+      final route = AnimationController(
+        vsync: tester,
+        duration: const Duration(milliseconds: 500),
+      )..forward();
+      addTearDown(route.dispose);
+
+      await tester.pumpWidget(buildPresenter(routeAnimation: route));
+      await tester.pumpAndSettle();
+
+      final gesture = await tester.startGesture(const Offset(200, 500));
+      await gesture.moveBy(const Offset(0, 120));
+      await tester.pump();
+
+      route.reverse();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(
+        tester.widget<Visibility>(find.byType(Visibility).first).visible,
+        isTrue,
+      );
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('a tap that wobbles within slop still morphs', (tester) async {
+      // Barrier taps routinely move a pixel or two; treating that as a drag
+      // would cost the morph on the most common way of closing the sheet.
+      final route = AnimationController(
+        vsync: tester,
+        duration: const Duration(milliseconds: 500),
+      )..forward();
+      addTearDown(route.dispose);
+
+      await tester.pumpWidget(buildPresenter(routeAnimation: route));
+      await tester.pumpAndSettle();
+
+      final gesture = await tester.startGesture(const Offset(200, 500));
+      await gesture.moveBy(const Offset(1, 2));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      route.reverse();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(
+        tester.widget<Visibility>(find.byType(Visibility).first).visible,
+        isFalse,
+      );
+
+      await tester.pumpAndSettle();
+    });
+
+    /// Runs an opening morph frame by frame and reports whether it had landed
+    /// within 200 ms — long enough for the engine's instant spring, well short
+    /// of the ~375 ms native-parity profile.
+    Future<bool> landedWithin200ms(
+      WidgetTester tester, {
+      required bool disableAnimations,
+    }) async {
+      final route = AnimationController(
+        vsync: tester,
+        duration: const Duration(milliseconds: 500),
+      )..forward();
+      addTearDown(route.dispose);
+
+      await tester.pumpWidget(
+        buildPresenter(
+          routeAnimation: route,
+          disableAnimations: disableAnimations,
+        ),
+      );
+
+      var landed = false;
+      for (var elapsed = 0; elapsed < 200 && !landed; elapsed += 16) {
+        await tester.pump(const Duration(milliseconds: 16));
+        landed =
+            tester.widget<Visibility>(find.byType(Visibility).first).visible;
+      }
+      await tester.pumpAndSettle();
+      return landed;
+    }
+
+    testWidgets('reduce motion resolves the morph immediately', (tester) async {
+      // The engine's own accessibility path — the same one GlassMenu takes.
+      // The flag has to reach the controller before the spring starts, which is
+      // why the presenter opens from didChangeDependencies and not initState;
+      // opening in initState left the very first presentation animating at full
+      // length with Reduce Motion on.
+      expect(await landedWithin200ms(tester, disableAnimations: true), isTrue);
+    });
+
+    testWidgets('a normal morph is still travelling at 200 ms', (tester) async {
+      // Guards the test above from passing for the wrong reason.
+      expect(
+          await landedWithin200ms(tester, disableAnimations: false), isFalse);
+    });
+
+    testWidgets('morphs into the full detent as well as the half detent',
+        (tester) async {
+      final route = AnimationController(
+        vsync: tester,
+        duration: const Duration(milliseconds: 500),
+      )..forward();
+      addTearDown(route.dispose);
+
+      await tester.pumpWidget(
+        buildPresenter(
+          routeAnimation: route,
+          restingState: GlassSheetState.full,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Sheet body'), findsOneWidget);
+    });
+
+    testWidgets('skips the blend group under platformViewBackdrop (#214)',
+        (tester) async {
+      // LiquidGlassBlendGroup needs a full LiquidGlassLayer, which
+      // AdaptiveLiquidGlassLayer does not create in this mode.
+      final route = AnimationController(
+        vsync: tester,
+        duration: const Duration(milliseconds: 500),
+      )..forward();
+      addTearDown(route.dispose);
+
+      await tester.pumpWidget(
+        _app(
+          GlassSheetMorphPresenter(
+            routeAnimation: route,
+            triggerRect: const Rect.fromLTWH(172, 700, 56, 56),
+            anchor: null,
+            speed: MorphSpeed.fast,
+            restingState: GlassSheetState.half,
+            geometry: _defaultGeometry,
+            horizontalMargin: 8.0,
+            bottomMargin: 6.0,
+            topBorderRadius: 56.0,
+            fullTopBorderRadius: 46.0,
+            bottomBorderRadius: null,
+            fullBottomBorderRadius: null,
+            settings: null,
+            peekSettings: null,
+            halfSettings: null,
+            fullSettings: null,
+            expandedColor: null,
+            quality: null,
+            peekHorizontalMargin: null,
+            peekBottomMargin: null,
+            peekWidth: null,
+            peekTopBorderRadius: null,
+            platformViewBackdrop: true,
+            child: GlassModalSheetScaffold(
+              body: SizedBox.shrink(),
+              sheet: Text('Sheet body'),
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(find.byType(LiquidGlassBlendGroup), findsNothing);
+      expect(tester.takeException(), isNull);
+
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('GlassMorphTrigger', () {
+    // GlassMorphAnchor is an opaque token — no public members to drive — so
+    // these exercise the trigger the way a consumer does: present a sheet and
+    // watch what the trigger renders.
+    setUp(() => GlassModalSheet.debugMorphSupportsBlending = true);
+    tearDown(() => GlassModalSheet.debugMorphSupportsBlending = null);
+
+    const triggerKey = Key('trigger-content');
+
+    Future<GlassMorphAnchor> pumpTrigger(WidgetTester tester) async {
+      late GlassMorphAnchor anchor;
+      await tester.pumpWidget(
+        _app(
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: GlassMorphTrigger(builder: (context, a) {
+              anchor = a;
+              return const SizedBox(key: triggerKey, width: 56, height: 56);
+            }),
+          ),
+        ),
+      );
+      await tester.pump();
+      return anchor;
+    }
+
+    double triggerOpacity(WidgetTester tester) => tester
+        .widget<Opacity>(
+          find
+              .ancestor(
+                of: find.byKey(triggerKey),
+                matching: find.byType(Opacity),
+              )
+              .first,
+        )
+        .opacity;
+
+    Future<void> present(WidgetTester tester, GlassMorphAnchor anchor) async {
+      GlassModalSheet.show<void>(
+        context: tester.element(find.byType(Align)),
+        builder: (_) => const Text('Sheet body'),
+        morphFrom: anchor,
+      );
+    }
+
+    testWidgets('hands the same anchor to its builder across rebuilds',
+        (tester) async {
+      final seen = <GlassMorphAnchor>[];
+      await tester.pumpWidget(
+        _app(GlassMorphTrigger(builder: (context, anchor) {
+          seen.add(anchor);
+          return const SizedBox(width: 56, height: 56);
+        })),
+      );
+      await tester.pump();
+
+      expect(seen, isNotEmpty);
+      expect(seen.every((a) => identical(a, seen.first)), isTrue);
+    });
+
+    testWidgets('paints nothing while presented, and is restored after',
+        (tester) async {
+      final anchor = await pumpTrigger(tester);
+      expect(triggerOpacity(tester), 1.0);
+
+      await present(tester, anchor);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+      // Toggled outright, never animated — a partial fade would pop the glass.
+      expect(triggerOpacity(tester), 0.0);
+
+      await tester.pumpAndSettle();
+      expect(triggerOpacity(tester), 0.0, reason: 'still presented');
+
+      await tester.tapAt(const Offset(200, 60));
+      await tester.pumpAndSettle();
+      expect(triggerOpacity(tester), 1.0);
+    });
+
+    testWidgets('keeps bouncing after the presented route is gone',
+        (tester) async {
+      // The whole point of the trigger owning a ticker: the route is torn down
+      // as soon as the droplet lands, so a bounce driven from there would be
+      // truncated mid-swing and the button would snap home.
+      final anchor = await pumpTrigger(tester);
+      final resting = tester.getTopLeft(find.byKey(triggerKey));
+
+      await present(tester, anchor);
+      await tester.pumpAndSettle();
+
+      await tester.tapAt(const Offset(200, 60));
+      await tester.pump();
+
+      var routeGone = false;
+      var maxOffsetAfterRouteGone = 0.0;
+      for (var elapsed = 0; elapsed < 1200; elapsed += 16) {
+        await tester.pump(const Duration(milliseconds: 16));
+        if (find.byType(GlassSheetMorphPresenter).evaluate().isEmpty) {
+          routeGone = true;
+          final dy =
+              (tester.getTopLeft(find.byKey(triggerKey)).dy - resting.dy).abs();
+          if (dy > maxOffsetAfterRouteGone) maxOffsetAfterRouteGone = dy;
+        }
+      }
+
+      expect(routeGone, isTrue, reason: 'route never popped');
+      expect(maxOffsetAfterRouteGone, greaterThan(0.5),
+          reason: 'trigger was not still bouncing once the route had gone');
+
+      // ...and it eases back to exactly where it started.
+      await tester.pumpAndSettle();
+      expect(
+        tester.getTopLeft(find.byKey(triggerKey)).dy,
+        moreOrLessEquals(resting.dy, epsilon: 0.5),
+      );
+    });
+
+    testWidgets('does not rebuild the consumer subtree during the bounce',
+        (tester) async {
+      // The bounce repaints the trigger every frame; building the consumer's
+      // widget inside the AnimatedBuilder callback would rebuild their whole
+      // subtree at 60fps along with it.
+      var builds = 0;
+      late GlassMorphAnchor anchor;
+      await tester.pumpWidget(
+        _app(
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: GlassMorphTrigger(builder: (context, a) {
+              anchor = a;
+              builds++;
+              return const SizedBox(key: triggerKey, width: 56, height: 56);
+            }),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await present(tester, anchor);
+      await tester.pumpAndSettle();
+      await tester.tapAt(const Offset(200, 60));
+      await tester.pump();
+
+      final before = builds;
+      var frames = 0;
+      for (var elapsed = 0; elapsed < 1200; elapsed += 16) {
+        await tester.pump(const Duration(milliseconds: 16));
+        frames++;
+      }
+      await tester.pumpAndSettle();
+
+      // One rebuild when the bounce is handed over is expected; per-frame is
+      // the regression.
+      expect(builds - before, lessThanOrEqualTo(3),
+          reason: 'consumer rebuilt ${builds - before} times over $frames '
+              'frames — the trigger should be repainted, not rebuilt');
+    });
+
+    testWidgets('a fresh open cancels a bounce still in flight',
+        (tester) async {
+      // Tapping the button mid-bounce must not leave it stranded off-centre.
+      final anchor = await pumpTrigger(tester);
+      final resting = tester.getTopLeft(find.byKey(triggerKey));
+
+      await present(tester, anchor);
+      await tester.pumpAndSettle();
+      await tester.tapAt(const Offset(200, 60));
+      await tester.pump();
+      // Far enough in that the route is gone and the bounce is running.
+      for (var elapsed = 0; elapsed < 450; elapsed += 16) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+
+      await present(tester, anchor);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(tester.getTopLeft(find.byKey(triggerKey)), resting);
+
+      await tester.tapAt(const Offset(200, 60));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('a swipe-down dismissal still hands the trigger back',
+        (tester) async {
+      // A dragged dismissal skips the closing morph, so nothing hands the
+      // trigger back mid-flight — the presenter restores it as it is disposed.
+      // Without that the button would stay invisible for good.
+      final anchor = await pumpTrigger(tester);
+      await present(tester, anchor);
+      await tester.pumpAndSettle();
+      expect(triggerOpacity(tester), 0.0);
+
+      // Throw the sheet down from its handle zone.
+      final drag = await tester.startGesture(const Offset(200, 420));
+      await drag.moveBy(const Offset(0, 260));
+      await tester.pump();
+      await drag.moveBy(const Offset(0, 160));
+      await tester.pump();
+      await drag.up();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(GlassSheetMorphPresenter), findsNothing);
+      expect(triggerOpacity(tester), 1.0);
+    });
+
+    testWidgets('survives its trigger being unmounted while presented',
+        (tester) async {
+      // The presenter restores the anchor from dispose as a safety net; that
+      // must not touch a trigger that has already gone away.
+      final anchor = await pumpTrigger(tester);
+      await present(tester, anchor);
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(_app(const SizedBox.shrink()));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('an anchor whose trigger has gone falls back to the slide',
+        (tester) async {
+      final anchor = await pumpTrigger(tester);
+      // Trigger unmounted — its rect can no longer be resolved.
+      await tester.pumpWidget(_app(const SizedBox.shrink()));
+      await tester.pump();
+
+      expect(
+        () => GlassModalSheet.show<void>(
+          context: tester.element(find.byType(SizedBox)),
+          builder: (_) => const Text('Sheet body'),
+          morphFrom: anchor,
+        ),
+        throwsAssertionError,
+      );
+    });
+  });
+
+  group('GlassModalSheet.show morph arguments', () {
+    testWidgets('rejects both an anchor and a rect', (tester) async {
+      late GlassMorphAnchor anchor;
+      await tester.pumpWidget(
+        _app(GlassMorphTrigger(builder: (context, a) {
+          anchor = a;
+          return const SizedBox(width: 56, height: 56);
+        })),
+      );
+      await tester.pump();
+      final context = tester.element(find.byType(GlassMorphTrigger));
+
+      expect(
+        () => GlassModalSheet.show<void>(
+          context: context,
+          builder: (_) => const Text('Sheet'),
+          morphFrom: anchor,
+          morphFromRect: const Rect.fromLTWH(0, 0, 10, 10),
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    testWidgets('without a trigger the slide transition is unchanged',
+        (tester) async {
+      await tester.pumpWidget(_app(const SizedBox.shrink()));
+      final context = tester.element(find.byType(SizedBox));
+
+      GlassModalSheet.show<void>(
+        context: context,
+        builder: (_) => const Text('Sheet body'),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.byType(SlideTransition), findsWidgets);
+
+      await tester.pumpAndSettle();
+      expect(find.text('Sheet body'), findsOneWidget);
+    });
+
+    testWidgets('falls back to the slide when blending is unavailable',
+        (tester) async {
+      // Headless test runs report ImageFilter.isShaderFilterSupported == false,
+      // which is exactly the Skia/web path: the metaball neck cannot be drawn,
+      // so the sheet must present with its ordinary slide rather than a
+      // degraded morph.
+      late GlassMorphAnchor anchor;
+      await tester.pumpWidget(
+        _app(GlassMorphTrigger(builder: (context, a) {
+          anchor = a;
+          return const SizedBox(width: 56, height: 56);
+        })),
+      );
+      final context = tester.element(find.byType(Scaffold));
+
+      GlassModalSheet.show<void>(
+        context: context,
+        builder: (_) => const Text('Sheet body'),
+        morphFrom: anchor,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.byType(SlideTransition), findsWidgets);
+      expect(find.byType(GlassSheetMorphPresenter), findsNothing);
+
+      await tester.pumpAndSettle();
+      expect(find.text('Sheet body'), findsOneWidget);
+    });
+
+    testWidgets('an explicit rect takes the same fallback path',
+        (tester) async {
+      await tester.pumpWidget(_app(const SizedBox.shrink()));
+      final context = tester.element(find.byType(SizedBox));
+
+      GlassModalSheet.show<void>(
+        context: context,
+        builder: (_) => const Text('Sheet body'),
+        morphFromRect: const Rect.fromLTWH(172, 700, 56, 56),
+        morphSpeed: MorphSpeed.fast,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Sheet body'), findsOneWidget);
+    });
+    testWidgets('minimal quality falls back even with blending forced',
+        (tester) async {
+      GlassModalSheet.debugMorphSupportsBlending = true;
+      addTearDown(() => GlassModalSheet.debugMorphSupportsBlending = null);
+
+      await tester.pumpWidget(_app(const SizedBox.shrink()));
+      final context = tester.element(find.byType(SizedBox));
+
+      GlassModalSheet.show<void>(
+        context: context,
+        quality: GlassQuality.minimal,
+        builder: (_) => const Text('Sheet body'),
+        morphFromRect: const Rect.fromLTWH(172, 700, 56, 56),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(GlassSheetMorphPresenter), findsNothing);
+      expect(find.byType(SlideTransition), findsWidgets);
+    });
+
+    testWidgets('platformViewBackdrop falls back even with blending forced',
+        (tester) async {
+      GlassModalSheet.debugMorphSupportsBlending = true;
+      addTearDown(() => GlassModalSheet.debugMorphSupportsBlending = null);
+
+      await tester.pumpWidget(_app(const SizedBox.shrink()));
+      final context = tester.element(find.byType(SizedBox));
+
+      GlassModalSheet.show<void>(
+        context: context,
+        platformViewBackdrop: true,
+        builder: (_) => const Text('Sheet body'),
+        morphFromRect: const Rect.fromLTWH(172, 700, 56, 56),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(GlassSheetMorphPresenter), findsNothing);
+    });
+  });
+
+  group('GlassModalSheet.show with the morph route', () {
+    setUp(() => GlassModalSheet.debugMorphSupportsBlending = true);
+    tearDown(() => GlassModalSheet.debugMorphSupportsBlending = null);
+
+    /// Pumps an app whose body is a 56pt trigger wrapped in a
+    /// [GlassMorphTrigger], and hands back its anchor.
+    Future<GlassMorphAnchor> pumpTrigger(WidgetTester tester) async {
+      late GlassMorphAnchor anchor;
+      await tester.pumpWidget(
+        _app(
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: GlassMorphTrigger(builder: (context, a) {
+              anchor = a;
+              return const SizedBox(
+                key: Key('trigger-content'),
+                width: 56,
+                height: 56,
+              );
+            }),
+          ),
+        ),
+      );
+      return anchor;
+    }
+
+    /// The context to present from — the trigger's own subtree is fine.
+    BuildContext contextOf(WidgetTester tester) =>
+        tester.element(find.byType(Align));
+
+    /// Whether the trigger is currently painting. The anchor is opaque, so the
+    /// rendered opacity is what a consumer would see.
+    bool triggerPainted(WidgetTester tester) =>
+        tester
+            .widget<Opacity>(
+              find
+                  .ancestor(
+                    of: find.byKey(const Key('trigger-content')),
+                    matching: find.byType(Opacity),
+                  )
+                  .first,
+            )
+            .opacity >
+        0.0;
+
+    testWidgets('presents through the morph instead of the slide',
+        (tester) async {
+      final anchor = await pumpTrigger(tester);
+      final context = contextOf(tester);
+
+      GlassModalSheet.show<void>(
+        context: context,
+        builder: (_) => const Text('Sheet body'),
+        morphFrom: anchor,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(find.byType(GlassSheetMorphPresenter), findsOneWidget);
+      // The slide is the thing being replaced, so the route must not have
+      // wrapped the page in one.
+      expect(
+        find.ancestor(
+          of: find.byType(GlassSheetMorphPresenter),
+          matching: find.byType(SlideTransition),
+        ),
+        findsNothing,
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('Sheet body'), findsOneWidget);
+    });
+
+    testWidgets('empties the trigger for the whole morph, then hands it back',
+        (tester) async {
+      final anchor = await pumpTrigger(tester);
+      final context = contextOf(tester);
+
+      GlassModalSheet.show<void>(
+        context: context,
+        builder: (_) => const Text('Sheet body'),
+        morphFrom: anchor,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      // Emptied before the first morph frame paints, so the real button and
+      // the anchor blob standing in for it are never both on screen.
+      expect(triggerPainted(tester), isFalse);
+
+      await tester.pumpAndSettle();
+      expect(triggerPainted(tester), isFalse, reason: 'still presented');
+
+      await tester.tapAt(const Offset(200, 60));
+      await tester.pumpAndSettle();
+
+      // Handed back once the droplet has been caught.
+      expect(triggerPainted(tester), isTrue);
+    });
+
+    testWidgets('an explicit rect blooms instead of duplicating the trigger',
+        (tester) async {
+      // With no anchor the trigger stays painted, so drawing the anchor blob
+      // over it would read as two buttons. It is suppressed and the droplet
+      // blooms from the rect's centre instead.
+      await tester.pumpWidget(_app(const SizedBox.shrink()));
+      final context = tester.element(find.byType(SizedBox));
+
+      GlassModalSheet.show<void>(
+        context: context,
+        builder: (_) => const Text('Sheet body'),
+        morphFromRect: const Rect.fromLTWH(172, 700, 56, 56),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      final presenter = tester.widget<GlassSheetMorphPresenter>(
+        find.byType(GlassSheetMorphPresenter),
+      );
+      expect(presenter.anchor, isNull);
+      // One blob, not two: the anchor blob is the one that would duplicate.
+      // Scoped to the droplet's blend group so the sheet's own glass — mounted
+      // underneath for the whole morph — isn't counted.
+      expect(
+        find.descendant(
+          of: find.byType(LiquidGlassBlendGroup),
+          matching: find.byType(AdaptiveGlass),
+        ),
+        findsOneWidget,
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('Sheet body'), findsOneWidget);
+    });
+
+    testWidgets('an anchored morph draws both blobs so the neck can form',
+        (tester) async {
+      final anchor = await pumpTrigger(tester);
+      final context = contextOf(tester);
+
+      GlassModalSheet.show<void>(
+        context: context,
+        builder: (_) => const Text('Sheet body'),
+        morphFrom: anchor,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      // Anchor blob + travelling droplet — the metaball bridges exactly these.
+      expect(
+        find.descendant(
+          of: find.byType(LiquidGlassBlendGroup),
+          matching: find.byType(AdaptiveGlass),
+        ),
+        findsNWidgets(2),
+      );
+
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('hides the droplet once the trigger has caught it',
+        (tester) async {
+      // The droplet and the restored trigger must never be on screen together
+      // — that is the duplicated-button artifact the anchor exists to avoid,
+      // and it reappears at the tail of the close if the overlay isn't hidden
+      // at the handoff latch. GlassMenu gates its overlay at the same point.
+      final anchor = await pumpTrigger(tester);
+      final context = contextOf(tester);
+
+      GlassModalSheet.show<void>(
+        context: context,
+        builder: (_) => const Text('Sheet body'),
+        morphFrom: anchor,
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tapAt(const Offset(200, 60));
+      await tester.pump();
+
+      // Step through the close and assert the invariant on every frame.
+      var sawBothHidden = false;
+      for (var elapsed = 0; elapsed < 380; elapsed += 16) {
+        await tester.pump(const Duration(milliseconds: 16));
+        if (find.byType(GlassSheetMorphPresenter).evaluate().isEmpty) break;
+
+        final dropletOpacity = tester
+            .widgetList<Opacity>(
+              find.ancestor(
+                of: find.byType(AdaptiveLiquidGlassLayer),
+                matching: find.byType(Opacity),
+              ),
+            )
+            .first
+            .opacity;
+
+        if (triggerPainted(tester)) {
+          // Trigger is back — the droplet must be gone.
+          expect(dropletOpacity, 0.0,
+              reason: 'droplet still painted after the trigger returned');
+          sawBothHidden = true;
+        }
+      }
+
+      expect(sawBothHidden, isTrue, reason: 'never observed the handoff');
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('a barrier tap morphs back and then pops the route',
+        (tester) async {
+      final anchor = await pumpTrigger(tester);
+      final context = contextOf(tester);
+
+      GlassModalSheet.show<void>(
+        context: context,
+        builder: (_) => const Text('Sheet body'),
+        morphFrom: anchor,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Sheet body'), findsOneWidget);
+
+      // Tap well above the half detent — that is the dismiss barrier.
+      await tester.tapAt(const Offset(200, 60));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      // Still mounted: the route stays up for the whole closing morph.
+      expect(find.byType(GlassSheetMorphPresenter), findsOneWidget);
+      expect(
+        tester.widget<Visibility>(find.byType(Visibility).first).visible,
+        isFalse,
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byType(GlassSheetMorphPresenter), findsNothing);
+      expect(find.text('Sheet body'), findsNothing);
+    });
+
+    testWidgets('every speed profile keeps the page up for its morph',
+        (tester) async {
+      // Each must outlast its spring's full settle (968 / 696 / 544 / 352 ms),
+      // not just the moment the droplet is caught — the trigger's closing
+      // bounce is driven by this route and snaps if it unmounts mid-swing.
+      // Sized to the droplet's trip home (408 / 304 / 240 / 160 ms), not the
+      // spring's full settle — the barrier must not outlive the morph and
+      // leave the restored trigger dead to the touch. The bounce's tail runs
+      // on GlassMorphTrigger's own ticker afterwards.
+      const expected = <MorphSpeed, int>{
+        MorphSpeed.slow: 480,
+        MorphSpeed.normal: 380,
+        MorphSpeed.fast: 300,
+        MorphSpeed.instant: 210,
+      };
+
+      for (final entry in expected.entries) {
+        final anchor = await pumpTrigger(tester);
+        final context = contextOf(tester);
+
+        GlassModalSheet.show<void>(
+          context: context,
+          builder: (_) => const Text('Sheet body'),
+          morphFrom: anchor,
+          morphSpeed: entry.key,
+        );
+        await tester.pump();
+
+        final route = ModalRoute.of(
+          tester.element(find.byType(GlassSheetMorphPresenter)),
+        )!;
+        expect(
+          route.transitionDuration,
+          Duration(milliseconds: entry.value),
+          reason: 'for ${entry.key}',
+        );
+
+        await tester.pumpAndSettle();
+        Navigator.of(
+          tester.element(find.byType(GlassSheetMorphPresenter)),
+        ).pop();
+        await tester.pumpAndSettle();
+      }
+    });
+  });
+}


### PR DESCRIPTION
Fixes #216 - the second consumer of the Liquid Morph Engine, which
`LIQUID_MORPH_ENGINE.md` anticipated when it noted the engine is decoupled so future widgets can use it.

## What changed

`GlassModalSheet.show()` takes a trigger and presents by morphing out of it
instead of sliding up from the edge: the trigger empties, a glass droplet
detaches and inflates along the J-curve, and lands as the sheet. Dismissing
pours it back.

https://github.com/user-attachments/assets/dfeb2f7c-104e-41a0-81b2-2a8c90978ffb

```dart
GlassMorphTrigger(
  builder: (context, anchor) => GlassButton(
    onTap: () => GlassModalSheet.show(
      context: context,
      morphFrom: anchor,
      builder: (context) => const MySheetBody(),
    ),
    child: const Icon(CupertinoIcons.add),
  ),
)
```

| parameter | type | effect |
|---|---|---|
| `morphFrom` | `GlassMorphAnchor?` | full morph — the trigger empties and the teardrop neck stretches |
| `morphFromRect` | `Rect?` | escape hatch for a trigger that can't be wrapped; blooms from a point |
| `morphSpeed` | `MorphSpeed` | reuses the engine's existing vocabulary, default `normal` |

Everything after the morph is untouched — detents, drag, snap, the controller.
Only the presentation changes.

## Why the trigger needs a wrapper rather than a GlobalKey

My first cut took a `GlobalKey`, which is enough to *locate* the trigger and aim
the droplet. It looked wrong on device, and the reason is structural: nothing in
Flutter lets one widget hide another it doesn't own, so the trigger kept painting
underneath while a glass droplet inflated on top of it. That reads as a
duplicated button, not a morph — worst in `standard`, where the rims are crisper.

`GlassMenu` doesn't hit this because it owns its trigger and can set it to
`Opacity(0)` for the duration. `GlassMorphTrigger` makes that same arrangement
available to a trigger the sheet doesn't own: it owns the key *and* the opacity,
and `GlassMorphAnchor` is the channel back from the presented route.

`morphFromRect` stays for triggers that genuinely can't be wrapped. Since the
trigger keeps painting there, the anchor blob is suppressed and the droplet
blooms from the rect's centre — no second button-sized shape at any point, at
the cost of the teardrop neck, which needs two blobs to stretch between. Same
trade-off as `GlassMenu.morphFromZero`.

## Why the droplet isn't the sheet itself

The teardrop neck is drawn by the SDF metaball shader, which only bridges shapes
inside one glass layer's blend group — and the real sheet owns its own
`AdaptiveGlass` layer, so it structurally cannot merge with the trigger ghost.
The morph therefore renders its own two-blob droplet and hands off to the sheet
at the settled instant, when both are motionless on the identical frame.

The sheet stays mounted underneath for the whole morph and is *revealed*, never
inserted — it keeps its slot in the same `Stack` throughout, because remounting a
glass widget mid-animation re-seeds its layers and springs and shows as a glitch
frame. That was worth being careful about; an earlier version returned the sheet
bare once settled, which changed its depth and tore the subtree down at exactly
the moment the handoff is meant to be invisible.

Aiming is not a parallel calculation: `SheetMorphGeometry.restingRect` derives
the destination from `SheetGeometry.positionForState`, the same call the sheet's
own `_calculateMetrics` uses, so the droplet and the sheet cannot drift apart.
It also mirrors the resting surface per detent, so a glass `medium` hands off to
glass and an opaque `large` hands off to colour.

## Why the route duration is sized the way it is

The route reverse is the window the closing morph plays in, and I got this wrong
twice before measuring it. For `MorphSpeed.normal` the droplet is caught at
**304 ms** but the spring doesn't fully settle until **696 ms**.

Sizing the route to the full settle keeps the modal barrier up for that whole
time, and the barrier swallows every touch — so the trigger sits there visibly
back but dead for ~400 ms. `GlassMenu` drops its own barrier 30 % into the close
precisely so that doesn't happen, and you can grab its trigger mid-animation.

So the route is sized to the droplet's journey and no further (380 ms at
`normal`), and `GlassMorphTrigger` continues the spring on its own ticker from
the value and velocity it's handed at the catch. The bounce finishes after the
route is gone, and the button is tappable throughout — grabbing it cancels the
bounce and reopens.

One deviation worth naming: that tail always runs the native-parity spring rather
than the per-speed one, because `GlassMorphController`'s spring mapping is
private. Over a bounce this small it's sub-pixel, and it saves the trigger from
having to know the speed — but say the word and I'll expose the mapping instead.

## Back-compat

Purely additive. Leave `morphFrom` and `morphFromRect` null and the existing
`SlideTransition` presentation is unchanged — same duration, same curve, same
route. No removals; existing call sites compile untouched.

The morph is skipped wholesale wherever the metaball blend is unavailable, and
the sheet presents with the ordinary slide instead: Skia/web
(`ImageFilter.isShaderFilterSupported == false`), `GlassQuality.minimal`, and
`platformViewBackdrop` — the same cases that skip `LiquidGlassBlendGroup` per
#214. A morph without the neck is two glass shapes and no bridge, which reads
worse than the slide it would replace, so degrading seemed wrong.

Reduce Motion is honoured by the engine's instant spring. The presenter opens
from `didChangeDependencies` rather than `initState` for that reason — the flag
has to reach the controller before the spring starts, or the first presentation
of every session animates at full length with Reduce Motion on.

## Tests & coverage

Effective project coverage **91.99%** (gate is 90%). Patch coverage **99.7%**
(305/306 added executable lines).

59 new tests: the pure geometry (resting frames per detent, blob interpolation,
radius, fill opacity), `GlassMorphTrigger` (empties and restores, runs its bounce
and returns to exactly the resting position, a fresh open cancels an in-flight
bounce), the presenter (handoff latch, the sheet element surviving the handoff,
reduce motion, the closing gate), the route wiring, and every fallback.

**One added line is uncovered** — `SheetMorphGeometry._()`, the private
constructor of a pure utility class, which is never invoked. `LiquidMorphPhysics`
has exactly the same uncovered line for the same reason.

## Verification

On the iOS 27 simulator (iPhone 17, Impeller, `isShaderFilterSupported == true`)
via `example/integration_test/morph_demo_test.dart`, which drives the real demo
and asserts the morph route is taken rather than the fallback — through the open,
the landing, and the barrier-tap close.

Not tested on a physical device, on Android, or on desktop. The Skia fallback is
covered by widget tests rather than a browser run.

`flutter analyze --fatal-warnings` clean; `dart format` clean.

## Two things to say no to if you'd rather

- **`example/integration_test/morph_demo_test.dart`** adds an `integration_test`
  dev-dependency to the example, and needs a platform folder generated to run,
  which the repo doesn't ship. It exists because a headless run reports no
  Impeller, so `show()` always takes the slide fallback there and the morph path
  is otherwise unverifiable. Happy to drop it.
- **`GlassModalSheet.debugMorphSupportsBlending`** is a `@visibleForTesting`
  override standing in for that same probe, so the route wiring is still tested
  headlessly. `platformViewBackdrop` and `minimal` continue to disable the morph
  under it, so those fallbacks stay honest. Also happy to drop it, at the cost of
  that coverage.

## Notes

- `CHANGELOG.md` is under `# Unreleased` — move it under whatever version you're
  cutting next.
- Docs updated: README feature bullet, a consumers table and a section on what
  differs when the destination is a route in `LIQUID_MORPH_ENGINE.md`, and the
  three new parameters plus a "Morphing from a Trigger" section in
  `GLASS_MODAL_SHEETS_GUIDE.md`.
- `SheetMorphGeometry` and `GlassSheetMorphPresenter` are public within the
  library but deliberately not exported from `liquid_glass_widgets.dart`, the way
  `SheetGeometry` and `GestureArena` already are — reachable from the tests that
  import the library file directly, without widening the package's public
  surface. Only `GlassMorphTrigger` and `GlassMorphAnchor` are exported.
