### PR TITLE
feat(GlassTabBar): .minimizable - tabBarMinimizeBehavior without the search, and GlassSearchBarConfig.showPill

### DIFF
--- a/example/lib/demos/minimizable_bar_demo.dart
+++ b/example/lib/demos/minimizable_bar_demo.dart
@@ -1,0 +1,237 @@
+/// GlassTabBar.minimizable — SwiftUI's tabBarMinimizeBehavior without the search
+///
+/// Demonstrates the minimizable placement: the tab pill minimizes to the
+/// selected tab's circle on scroll (mirroring
+/// `.tabBarMinimizeBehavior(.onScrollDown)`), with the trailing slot in each
+/// of its modes:
+///
+///   - none    — no trailing pill in either state
+///   - always  — present in both states (Tab(role: .search) behavior)
+///
+/// Run standalone:
+///   flutter run -t lib/demos/minimizable_bar_demo.dart
+///
+library;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollDirection;
+
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await LiquidGlassWidgets.initialize();
+  runApp(LiquidGlassWidgets.wrap(child: const _DemoApp()));
+}
+
+class _DemoApp extends StatelessWidget {
+  const _DemoApp();
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      title: 'GlassTabBar.minimizable',
+      debugShowCheckedModeBanner: false,
+      theme: const CupertinoThemeData(brightness: Brightness.dark),
+      builder: (context, child) => Theme(
+        data: ThemeData.dark(useMaterial3: true).copyWith(
+          scaffoldBackgroundColor: const Color(0xFF0A0A0F),
+        ),
+        child: child!,
+      ),
+      home: const _DemoHome(),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Trailing-slot modes
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum _TrailingMode {
+  none('None'),
+  always('Always');
+
+  const _TrailingMode(this.label);
+  final String label;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Home
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _DemoHome extends StatefulWidget {
+  const _DemoHome();
+
+  @override
+  State<_DemoHome> createState() => _DemoHomeState();
+}
+
+class _DemoHomeState extends State<_DemoHome> {
+  int _selectedIndex = 0;
+  bool _minimized = false;
+  _TrailingMode _trailingMode = _TrailingMode.always;
+  int _composerTaps = 0;
+
+  static const _tabs = [
+    GlassTab(label: 'Home', icon: Icon(CupertinoIcons.house)),
+    GlassTab(label: 'Alerts', icon: Icon(CupertinoIcons.bell)),
+    GlassTab(label: 'Favorites', icon: Icon(CupertinoIcons.heart)),
+  ];
+
+  /// Mirrors `.tabBarMinimizeBehavior(.onScrollDown)`: scrolling down starts
+  /// the minimize, scrolling back up expands again. The bar itself animates
+  /// the morph — this just decides *when*.
+  bool _onScroll(UserScrollNotification n) {
+    if (n.direction == ScrollDirection.reverse && !_minimized) {
+      setState(() => _minimized = true);
+    } else if (n.direction == ScrollDirection.forward && _minimized) {
+      setState(() => _minimized = false);
+    }
+    return false;
+  }
+
+  GlassTabBarTrailingButton? get _trailingButton {
+    final button = GlassTabBarTrailingButton(
+      icon: const Icon(CupertinoIcons.square_pencil),
+      onTap: () => setState(() => _composerTaps++),
+    );
+    return switch (_trailingMode) {
+      _TrailingMode.none => null,
+      _TrailingMode.always => button,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      extendBody: true,
+      body: NotificationListener<UserScrollNotification>(
+        onNotification: _onScroll,
+        child: CustomScrollView(
+          slivers: [
+            SliverSafeArea(
+              sliver: SliverToBoxAdapter(child: _buildControls()),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 140),
+              sliver: SliverList.separated(
+                itemCount: 40,
+                separatorBuilder: (_, __) => const SizedBox(height: 12),
+                itemBuilder: (context, i) => _ContentCard(index: i),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: GlassTabBar.minimizable(
+        tabs: _tabs,
+        selectedIndex: _selectedIndex,
+        onTabSelected: (i) => setState(() => _selectedIndex = i),
+        minimized: _minimized,
+        onMinimizedTabTap: () => setState(() => _minimized = false),
+        trailingButton: _trailingButton,
+      ),
+    );
+  }
+
+  Widget _buildControls() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'GlassTabBar.minimizable',
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Scroll down to minimize, up to expand — '
+            '.tabBarMinimizeBehavior(.onScrollDown). '
+            'Tap the minimized circle to bring the tabs back.',
+            style: TextStyle(
+              fontSize: 13,
+              color: Colors.white.withValues(alpha: 0.6),
+            ),
+          ),
+          const SizedBox(height: 14),
+          Text(
+            'TRAILING BUTTON',
+            style: TextStyle(
+              fontSize: 11,
+              letterSpacing: 1.1,
+              color: Colors.white.withValues(alpha: 0.45),
+            ),
+          ),
+          const SizedBox(height: 6),
+          CupertinoSlidingSegmentedControl<_TrailingMode>(
+            groupValue: _trailingMode,
+            onValueChanged: (m) =>
+                setState(() => _trailingMode = m ?? _TrailingMode.always),
+            children: {
+              for (final m in _TrailingMode.values)
+                m: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  child: Text(m.label, style: const TextStyle(fontSize: 13)),
+                ),
+            },
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'minimized: $_minimized   ·   composer taps: $_composerTaps',
+            style: TextStyle(
+              fontSize: 12,
+              fontFeatures: const [FontFeature.tabularFigures()],
+              color: Colors.white.withValues(alpha: 0.5),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filler content
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _ContentCard extends StatelessWidget {
+  const _ContentCard({required this.index});
+
+  final int index;
+
+  static const _hues = [
+    Color(0xFF3D5AFE),
+    Color(0xFF00BFA5),
+    Color(0xFFFF6D00),
+    Color(0xFFD500F9),
+    Color(0xFFFFD600),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final hue = _hues[index % _hues.length];
+    return Container(
+      height: 96,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(18),
+        gradient: LinearGradient(
+          colors: [
+            hue.withValues(alpha: 0.55),
+            hue.withValues(alpha: 0.18),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+      ),
+      alignment: Alignment.centerLeft,
+      padding: const EdgeInsets.symmetric(horizontal: 18),
+      child: Text(
+        'Item number $index',
+        style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
@@ -216,6 +216,15 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
   late AnimationController _whitenBoostCtrl;
   double _whitenTarget = 0.0;
 
+  // Appear/disappear scale for the search pill — 1 present, 0 gone. Only
+  // moves when [GlassSearchBarConfig.showPill] changes: the pill grows and
+  // shrinks IN PLACE at its slot, on the same spring as the pill morphs,
+  // rather than width-morphing in from the trailing edge.
+  late AnimationController _pillScaleCtrl;
+
+  /// Whether the search pill exists — see [GlassSearchBarConfig.showPill].
+  bool get _pillShown => widget.searchConfig.showPill;
+
   // D1: hoisted — avoids allocating a new _MergedListenable on every LayoutBuilder call.
   late Listenable _searchPillListenable;
 
@@ -256,8 +265,17 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
     );
     _whitenBoostCtrl = AnimationController(vsync: this)
       ..addListener(_onWhitenTick);
+    // Starts settled — a pill that should be absent right now was never on
+    // screen to animate away.
+    _pillScaleCtrl = AnimationController(
+      vsync: this,
+      lowerBound: double.negativeInfinity,
+      upperBound: double.infinity,
+      value: _pillShown ? 1.0 : 0.0,
+    );
     // D1: create once — the controllers never change after initState.
-    _searchPillListenable = Listenable.merge([_searchLeftCtrl, _searchWCtrl]);
+    _searchPillListenable =
+        Listenable.merge([_searchLeftCtrl, _searchWCtrl, _pillScaleCtrl]);
     widget.scrollController?.addListener(_onScrollMaybeWhiten);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _onScrollMaybeWhiten();
@@ -291,6 +309,16 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
       wasActive: old.isSearchActive,
       isActive: widget.isSearchActive,
     );
+    // Spring the pill's appear/disappear scale when its presence changes.
+    if (old.searchConfig.showPill != _pillShown) {
+      _pillScaleCtrl.animateWith(
+        SearchableBottomBarController.makeSpring(
+          spring: widget.springDescription ?? TabBarSearchableLayout._kSpring,
+          from: _pillScaleCtrl.value,
+          to: _pillShown ? 1.0 : 0.0,
+        ),
+      );
+    }
   }
 
   @override
@@ -298,6 +326,7 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
     _tabWCtrl.dispose();
     _searchLeftCtrl.dispose();
     _searchWCtrl.dispose();
+    _pillScaleCtrl.dispose();
     widget.scrollController?.removeListener(_onScrollMaybeWhiten);
     _whitenBoostCtrl.dispose();
     _controller.removeListener(_onControllerChanged);
@@ -426,6 +455,7 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                   keyboardH: keyboardH,
                   tabCount: widget.tabs.length,
                   perTabWidth: widget.tabWidth,
+                  showPill: widget.searchConfig.showPill,
                 );
 
                 final targetTabW = layout.targetTabW;
@@ -443,9 +473,11 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                 final targetDismissReserve = layout.dismissReserve;
                 final centeredTab =
                     widget.tabPillAnchor == GlassTabPillAnchor.center;
+                // Mirrors computeLayout — an absent pill reserves nothing.
                 final maxTabW = totalW -
-                    targetH -
-                    widget.spacing -
+                    (widget.searchConfig.showPill
+                        ? targetH + widget.spacing
+                        : 0.0) -
                     (extraFullW > 0 &&
                             extraPos == GlassExtraButtonPosition.beforeSearch
                         ? extraFullW + widget.spacing
@@ -521,10 +553,26 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                   child: Stack(
                     clipBehavior: Clip.none,
                     children: [
-                      // 1. Search pill — D1: rebuilt only when position/width tick.
+                      // 1. Search pill — D1: rebuilt only when position/width
+                      //    (or the appear/disappear scale) tick.
+                      //
+                      // A pill with `showPill: false` that has finished
+                      // disappearing (or never appeared) is UNMOUNTED rather
+                      // than shrunk or faded: a glass shape left anywhere in
+                      // the blend layer fuses with the tab pill's trailing
+                      // edge even at zero width, and opacity cannot hide a
+                      // grouped surface (the layer paints it, not the child).
+                      // Appearing, the pill spring-scales in place at its
+                      // slot; overlapping the still-morphing tab pill on the
+                      // shared layer is what produces the liquid pinch-off.
                       ListenableBuilder(
                         listenable: _searchPillListenable,
                         builder: (context, _) {
+                          final pillScale =
+                              _pillScaleCtrl.value.clamp(0.0, 1.25).toDouble();
+                          if (pillScale < 0.02) {
+                            return const SizedBox.shrink();
+                          }
                           final curSearchLeft = (_controller.pillsInitialized
                                   ? _searchLeftCtrl.value
                                   : targetSearchLeft)
@@ -538,36 +586,43 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                             bottom: floatY,
                             width: math.max(0.01, curSearchW),
                             height: animH,
-                            child: SearchPill(
-                              config: widget.searchConfig,
-                              isActive: searching,
-                              barBorderRadius: widget.barBorderRadius,
-                              quality: effectiveQuality,
-                              platformViewBackdrop: widget.platformViewBackdrop,
-                              enableBackgroundAnimation:
-                                  widget.interactionBehavior.hasScale,
-                              backgroundPressScale: widget.pressScale,
-                              iconColor: resolvedUnselectedIconColor,
-                              interactionGlowColor:
-                                  widget.interactionBehavior.hasGlow
-                                      ? effectiveInteractionGlowColor
-                                      : const Color(0x00000000),
-                              interactionGlowRadius:
-                                  widget.interactionGlowRadius,
-                              interactionGlowBlurRadius:
-                                  effectiveGlowBlurRadius,
-                              interactionGlowSpreadRadius:
-                                  effectiveGlowSpreadRadius,
-                              interactionGlowOpacity: effectiveGlowOpacity,
-                              onFocusChanged: (focused) {
-                                if (focused) {
-                                  _controller.onFocusChanged(true);
-                                } else {
-                                  _onFocusLost();
-                                }
-                                widget.searchConfig.onSearchFocusChanged
-                                    ?.call(focused);
-                              },
+                            child: IgnorePointer(
+                              ignoring: !_pillShown,
+                              child: Transform.scale(
+                                scale: pillScale,
+                                child: SearchPill(
+                                  config: widget.searchConfig,
+                                  isActive: searching,
+                                  barBorderRadius: widget.barBorderRadius,
+                                  quality: effectiveQuality,
+                                  platformViewBackdrop:
+                                      widget.platformViewBackdrop,
+                                  enableBackgroundAnimation:
+                                      widget.interactionBehavior.hasScale,
+                                  backgroundPressScale: widget.pressScale,
+                                  iconColor: resolvedUnselectedIconColor,
+                                  interactionGlowColor:
+                                      widget.interactionBehavior.hasGlow
+                                          ? effectiveInteractionGlowColor
+                                          : const Color(0x00000000),
+                                  interactionGlowRadius:
+                                      widget.interactionGlowRadius,
+                                  interactionGlowBlurRadius:
+                                      effectiveGlowBlurRadius,
+                                  interactionGlowSpreadRadius:
+                                      effectiveGlowSpreadRadius,
+                                  interactionGlowOpacity: effectiveGlowOpacity,
+                                  onFocusChanged: (focused) {
+                                    if (focused) {
+                                      _controller.onFocusChanged(true);
+                                    } else {
+                                      _onFocusLost();
+                                    }
+                                    widget.searchConfig.onSearchFocusChanged
+                                        ?.call(focused);
+                                  },
+                                ),
+                              ),
                             ),
                           );
                         },

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -44,6 +44,7 @@ import 'shared/tab_bar_accessory_placement.dart';
 /// |---|---|---|
 /// | [GlassTabBar.bottom] | `UITabBar` | App-level bottom navigation |
 /// | [GlassTabBar.searchable] | `UITabBar` + search | Bottom nav + morphing search bar |
+/// | [GlassTabBar.minimizable] | `tabBarMinimizeBehavior` + `Tab(role: .search)` | Bottom nav that minimizes to the selected tab, with an optional trailing action button |
 /// | [GlassTabBar.inline] | Glass-backed `UISegmentedControl` / inline `UITabBar` | In-page content switcher with glass track |
 ///
 /// ## Usage
@@ -75,6 +76,24 @@ import 'shared/tab_bar_accessory_placement.dart';
 /// )
 /// ```
 ///
+/// ### Minimizing on scroll, no search
+/// ```dart
+/// GlassTabBar.minimizable(
+///   tabs: [
+///     GlassTab(icon: Icon(Icons.home),   label: 'Home'),
+///     GlassTab(icon: Icon(Icons.person), label: 'Profile'),
+///   ],
+///   selectedIndex: _selectedIndex,
+///   onTabSelected: (i) => setState(() => _selectedIndex = i),
+///   minimized: _scrolledDown,
+///   onMinimizedTabTap: () => setState(() => _scrolledDown = false),
+///   trailingButton: GlassTabBarTrailingButton(
+///     icon: const Icon(CupertinoIcons.plus),
+///     onTap: _openComposer,
+///   ),
+/// )
+/// ```
+///
 /// ### Inline / in-page tab switching
 /// ```dart
 /// // ✅ Glass-backed track with jelly indicator — Apple Music style
@@ -100,7 +119,7 @@ import 'shared/tab_bar_accessory_placement.dart';
 // ---------------------------------------------------------------------------
 // Placement discriminant — private, drives constructor dispatch
 // ---------------------------------------------------------------------------
-enum _GlassTabBarPlacement { bottom, searchable, inline }
+enum _GlassTabBarPlacement { bottom, searchable, minimizable, inline }
 
 /// The iOS 26 structural bottom navigation bar.
 ///
@@ -112,6 +131,14 @@ enum _GlassTabBarPlacement { bottom, searchable, inline }
 ///
 /// - **[GlassTabBar.searchable]** — bottom pill that morphs into a search bar.
 ///   Replaces the deprecated [GlassSearchableBottomBar].
+///
+/// - **[GlassTabBar.minimizable]** — the searchable placement's morph
+///   without the search: the tab pill minimizes to the selected tab's
+///   circle (typically on scroll), mirroring SwiftUI's
+///   `tabBarMinimizeBehavior`, with an optional plain
+///   [GlassTabBarTrailingButton] in the slot the search pill occupies —
+///   the generalized `Tab(role: .search)` trailing circle, for bars whose
+///   trailing affordance is an action rather than a search field.
 ///
 /// For in-page / inline tab switching, use [GlassSegmentedControl] instead.
 ///
@@ -544,6 +571,170 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
           brightnessOverride: brightnessOverride,
         );
 
+  // ─── Minimizable constructor ───────────────────────────────────────────────
+
+  /// Creates a bottom bar that minimizes to the selected tab's circle —
+  /// SwiftUI's `tabBarMinimizeBehavior`, i.e. the [GlassTabBar.searchable]
+  /// morph without the search.
+  ///
+  /// Drives the same layout engine as the searchable placement, so the
+  /// minimize is the identical spring morph, but the API speaks navigation
+  /// rather than search: [minimized] replaces `isSearchActive` (the caller
+  /// decides when — typically from scroll direction, matching
+  /// `.tabBarMinimizeBehavior(.onScrollDown)`), tapping the minimized tab
+  /// circle fires [onMinimizedTabTap] (the "bring my tabs back" control),
+  /// and the slot the search pill occupies is an optional plain action
+  /// button — [trailingButton] — or nothing at all. Both pills render at
+  /// [minimizedBarHeight] while minimized, mirroring how the native
+  /// minimized bar sits slightly smaller than the expanded one.
+  ///
+  /// The trailing slot maps onto the native components:
+  ///
+  /// - `trailingButton: null` — a plain minimizing tab bar; the tabs get the
+  ///   full bar width, and the minimized state is the selected tab's circle
+  ///   alone.
+  /// - With a [trailingButton], the button is present in both states —
+  ///   exactly how a `Tab(role: .search)` trailing circle keeps its
+  ///   priority visibility through the minimize.
+  ///
+  /// [trailingButton] may change between builds and the bar animates the
+  /// difference: the button spring-scales in and out in place at its slot.
+  /// An app that wants a button only while minimized simply passes it only
+  /// while [minimized] is true — the appearing button grows in at the
+  /// trailing edge as the tab pill shrinks to its circle.
+  const GlassTabBar.minimizable({
+    required List<GlassTab> tabs,
+    required int selectedIndex,
+    required ValueChanged<int> onTabSelected,
+    Key? key,
+    bool minimized = false,
+    VoidCallback? onMinimizedTabTap,
+    GlassTabBarTrailingButton? trailingButton,
+    Widget? bottomAccessory,
+    GlassTabBarAccessoryPlacement? bottomAccessoryPlacement,
+    bool bottomAccessoryEnabled = true,
+    double bottomAccessorySpacing = 6.0,
+    double? bottomAccessoryHeight,
+    double spacing = 8,
+    double horizontalPadding = 20,
+    double verticalPadding = 20,
+    double barHeight = 64,
+    double minimizedBarHeight = 50,
+    double barBorderRadius = _kDefaultBottomBorderRadius,
+    EdgeInsetsGeometry tabPadding = const EdgeInsets.symmetric(horizontal: 4),
+    double iconLabelSpacing = 4,
+    bool enableBlend = true,
+    double blendAmount = 10,
+    LiquidGlassSettings? settings,
+    bool showIndicator = true,
+    Color? indicatorColor,
+    LiquidGlassSettings? indicatorSettings,
+    double indicatorPinchStrength = 0.4,
+    Color? selectedIconColor,
+    Color? unselectedIconColor,
+    Color? selectedLabelColor,
+    Color? unselectedLabelColor,
+    TextStyle? selectedLabelStyle,
+    TextStyle? unselectedLabelStyle,
+    double iconSize = 24,
+    double labelFontSize = 11,
+    TextStyle? textStyle,
+    Duration glowDuration = const Duration(milliseconds: 300),
+    double glowBlurRadius = 32,
+    double glowSpreadRadius = 8,
+    double glowOpacity = 0.6,
+    GlassInteractionBehavior interactionBehavior =
+        GlassInteractionBehavior.full,
+    double pressScale = 1.04,
+    Color? interactionGlowColor,
+    double interactionGlowRadius = 1.5,
+    GlassQuality? quality,
+    double magnification = 1.15,
+    double innerBlur = 0.0,
+    bool platformViewBackdrop = false,
+    MaskingQuality maskingQuality = MaskingQuality.high,
+    GlobalKey? backgroundKey,
+    SpringDescription? springDescription,
+    GlassTabPillAnchor tabPillAnchor = GlassTabPillAnchor.start,
+    double? tabWidth,
+    double? indicatorBorderRadius,
+    EdgeInsetsGeometry indicatorExpansion =
+        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    VoidCallback? onBarTap,
+    bool whitenAtBottom = true,
+    double whitenBottomThreshold = 45.0,
+    double whitenAtBottomTarget = 1.0,
+    ScrollController? scrollController,
+    bool adaptiveBrightness = false,
+    ValueChanged<Brightness>? onBrightnessChanged,
+    ValueListenable<Brightness>? brightnessOverride,
+  }) : this._(
+          key: key,
+          placement: _GlassTabBarPlacement.minimizable,
+          tabs: tabs,
+          selectedIndex: selectedIndex,
+          onTabSelected: onTabSelected,
+          isSearchActive: minimized,
+          onMinimizedTabTap: onMinimizedTabTap,
+          trailingButton: trailingButton,
+          bottomAccessoryPlacement: bottomAccessoryPlacement,
+          bottomAccessory: bottomAccessory,
+          bottomAccessoryEnabled: bottomAccessoryEnabled,
+          bottomAccessorySpacing: bottomAccessorySpacing,
+          bottomAccessoryHeight: bottomAccessoryHeight,
+          spacing: spacing,
+          horizontalPadding: horizontalPadding,
+          verticalPadding: verticalPadding,
+          barHeight: barHeight,
+          searchBarHeight: minimizedBarHeight,
+          barBorderRadius: barBorderRadius,
+          tabPadding: tabPadding,
+          iconLabelSpacing: iconLabelSpacing,
+          enableBlend: enableBlend,
+          blendAmount: blendAmount,
+          settings: settings,
+          showIndicator: showIndicator,
+          indicatorColor: indicatorColor,
+          indicatorSettings: indicatorSettings,
+          indicatorPinchStrength: indicatorPinchStrength,
+          selectedIconColor: selectedIconColor,
+          unselectedIconColor: unselectedIconColor,
+          selectedLabelColor: selectedLabelColor,
+          unselectedLabelColor: unselectedLabelColor,
+          selectedLabelStyle: selectedLabelStyle,
+          unselectedLabelStyle: unselectedLabelStyle,
+          iconSize: iconSize,
+          labelFontSize: labelFontSize,
+          textStyle: textStyle,
+          glowDuration: glowDuration,
+          glowBlurRadius: glowBlurRadius,
+          glowSpreadRadius: glowSpreadRadius,
+          glowOpacity: glowOpacity,
+          interactionBehavior: interactionBehavior,
+          pressScale: pressScale,
+          interactionGlowColor: interactionGlowColor,
+          interactionGlowRadius: interactionGlowRadius,
+          quality: quality,
+          magnification: magnification,
+          innerBlur: innerBlur,
+          platformViewBackdrop: platformViewBackdrop,
+          maskingQuality: maskingQuality,
+          backgroundKey: backgroundKey,
+          springDescription: springDescription,
+          tabPillAnchor: tabPillAnchor,
+          tabWidth: tabWidth,
+          indicatorBorderRadius: indicatorBorderRadius,
+          indicatorExpansion: indicatorExpansion,
+          onBarTap: onBarTap,
+          whitenAtBottom: whitenAtBottom,
+          whitenBottomThreshold: whitenBottomThreshold,
+          whitenAtBottomTarget: whitenAtBottomTarget,
+          scrollController: scrollController,
+          adaptiveBrightness: adaptiveBrightness,
+          onBrightnessChanged: onBrightnessChanged,
+          brightnessOverride: brightnessOverride,
+        );
+
   // ─── Private unified constructor (delegate target) ─────────────────────────
 
   const GlassTabBar._(
@@ -610,6 +801,9 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
       this.controller,
       this.isSearchActive = false,
       this.searchBarHeight = 50,
+      // Minimizable-only
+      this.onMinimizedTabTap,
+      this.trailingButton,
       this.springDescription,
       this.tabPillAnchor = GlassTabPillAnchor.start,
       this.onBarTap,
@@ -877,11 +1071,21 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
   /// Optional external controller for the search state machine.
   final SearchableBottomBarController? controller;
 
-  /// Whether the search bar is currently expanded (searchable only).
+  /// Whether the search bar is currently expanded (searchable only). For
+  /// [GlassTabBar.minimizable] this carries `minimized`, which drives the
+  /// identical morph.
   final bool isSearchActive;
 
   /// Height of the pills while search is active. Defaults to 50.
   final double searchBarHeight;
+
+  /// Tapping the minimized tab circle (minimizable only) — the "bring my
+  /// tabs back" control.
+  final VoidCallback? onMinimizedTabTap;
+
+  /// The optional plain action button in the trailing slot (minimizable
+  /// only). Null means no trailing pill at all, in either state.
+  final GlassTabBarTrailingButton? trailingButton;
 
   /// Custom spring for the pill morph animation. Null = iOS 26 default.
   final SpringDescription? springDescription;
@@ -910,10 +1114,11 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
     // (expanded) and searchBarHeight (inline/mini) — use whichever is active.
     // Both branches multiply verticalPadding by 2 (top + bottom) to match
     // the symmetric Padding applied inside AdaptiveLiquidGlassLayer.
-    final effectivePillH =
-        (_placement == _GlassTabBarPlacement.searchable && isSearchActive)
-            ? searchBarHeight + verticalPadding * 2
-            : barHeight + verticalPadding * 2;
+    final effectivePillH = ((_placement == _GlassTabBarPlacement.searchable ||
+                _placement == _GlassTabBarPlacement.minimizable) &&
+            isSearchActive)
+        ? searchBarHeight + verticalPadding * 2
+        : barHeight + verticalPadding * 2;
 
     double total = effectivePillH;
 
@@ -930,10 +1135,11 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
       // Guard: gapAdjustment only makes sense in the searchable placement when
       // both heights differ. For .bottom placement isSearchActive is always false
       // so effectivePillH == barHeight + vertPad*2 and gapAdjustment == 0.
-      final gapAdjustment =
-          (_placement == _GlassTabBarPlacement.searchable && isSearchActive)
-              ? barHeight - searchBarHeight
-              : 0.0;
+      final gapAdjustment = ((_placement == _GlassTabBarPlacement.searchable ||
+                  _placement == _GlassTabBarPlacement.minimizable) &&
+              isSearchActive)
+          ? barHeight - searchBarHeight
+          : 0.0;
       total = effectivePillH -
           gapAdjustment +
           bottomAccessorySpacing +
@@ -947,6 +1153,13 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
 }
 
 class _GlassTabBarState extends State<GlassTabBar> {
+  /// The most recent non-null [GlassTabBar.trailingButton] (minimizable
+  /// only). A button removed between builds must keep rendering ITSELF while
+  /// the pill scales away — deriving the icon from the now-null button would
+  /// swap the outgoing pill to the config's default search glyph for its
+  /// last few frames.
+  GlassTabBarTrailingButton? _lastTrailingButton;
+
   @override
   void didUpdateWidget(GlassTabBar oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -960,6 +1173,8 @@ class _GlassTabBarState extends State<GlassTabBar> {
         return _buildBottom(context);
       case _GlassTabBarPlacement.searchable:
         return _buildSearchable(context);
+      case _GlassTabBarPlacement.minimizable:
+        return _buildMinimizable(context);
       case _GlassTabBarPlacement.inline:
         return _buildInline(context);
     }
@@ -1083,12 +1298,50 @@ class _GlassTabBarState extends State<GlassTabBar> {
   }
 
   /// Dispatches to [TabBarSearchableLayout] — the iOS 26-style searchable placement engine.
-  Widget _buildSearchable(BuildContext context) {
+  Widget _buildSearchable(BuildContext context) =>
+      _buildSearchableEngine(context, widget.searchConfig!);
+
+  /// Dispatches to the same engine as [_buildSearchable], with a
+  /// [GlassSearchBarConfig] assembled from the minimizable placement's
+  /// navigation vocabulary: nothing search-shaped remains (the field never
+  /// expands, there is no cancel pill, no keyboard involvement), and the
+  /// search pill's slot carries the plain [GlassTabBarTrailingButton] — or,
+  /// with no button, nothing at all.
+  Widget _buildMinimizable(BuildContext context) {
+    final trailing = widget.trailingButton;
+    if (trailing != null) _lastTrailingButton = trailing;
+    // The ICON comes from the last known button, so a button removed this
+    // build still renders itself while the pill scales away. Existence and
+    // the tap stay on the live value — a removed button must not fire (and
+    // the disappearing pill is already IgnorePointered by the engine).
+    final rendered = trailing ?? _lastTrailingButton;
+    return _buildSearchableEngine(
+      context,
+      GlassSearchBarConfig(
+        // The engine's single callback carries both taps: `true` is the
+        // trailing pill, `false` is the minimized tab circle.
+        onSearchToggle: (activate) {
+          if (activate) {
+            widget.trailingButton?.onTap();
+          } else {
+            widget.onMinimizedTabTap?.call();
+          }
+        },
+        expandWhenActive: false,
+        showsCancelButton: false,
+        searchIcon: rendered?.icon,
+        showPill: trailing != null,
+      ),
+    );
+  }
+
+  Widget _buildSearchableEngine(
+      BuildContext context, GlassSearchBarConfig config) {
     return TabBarSearchableLayout(
       tabs: widget.tabs,
       selectedIndex: widget.selectedIndex,
       onTabSelected: widget.onTabSelected,
-      searchConfig: widget.searchConfig!,
+      searchConfig: config,
       controller: widget.controller,
       isSearchActive: widget.isSearchActive,
       extraButton: widget.extraButton,
@@ -1150,6 +1403,36 @@ class _GlassTabBarState extends State<GlassTabBar> {
       brightnessOverride: widget.brightnessOverride,
     );
   }
+}
+
+// =============================================================================
+// GlassTabBarTrailingButton — the minimizable placement's action button
+// =============================================================================
+
+/// The plain action button in [GlassTabBar.minimizable]'s trailing slot —
+/// the circular glass pill the searchable placement uses for search, carrying
+/// an ordinary tap action instead. The generalized form of SwiftUI's
+/// `Tab(role: .search)` trailing circle.
+///
+/// Not to be confused with [GlassTabBarExtraButton], which is an *additional*
+/// button rendered beside the pills. This one *is* the trailing pill: it
+/// shares the bar's glass blend layer, morphs with the same springs, and
+/// shrinks to [GlassTabBar.minimizable]'s `minimizedBarHeight` alongside the
+/// minimized tab circle. Like its native counterpart it is present in both
+/// states; pass it conditionally (see [GlassTabBar.minimizable]) for
+/// app-defined policies such as a button that exists only while minimized.
+class GlassTabBarTrailingButton {
+  /// Creates the trailing button.
+  const GlassTabBarTrailingButton({
+    required this.icon,
+    required this.onTap,
+  });
+
+  /// The glyph centered on the pill.
+  final Widget icon;
+
+  /// Called when the pill is tapped.
+  final VoidCallback onTap;
 }
 
 // =============================================================================

--- a/lib/widgets/surfaces/shared/glass_search_bar_config.dart
+++ b/lib/widgets/surfaces/shared/glass_search_bar_config.dart
@@ -46,6 +46,7 @@ class GlassSearchBarConfig {
     this.onTapOutside,
     this.autoFocusOnExpand = false,
     this.expandWhenActive = true,
+    this.showPill = true,
     this.showsCancelButton = true,
     this.cancelButtonColor,
     this.cancelIcon,
@@ -248,6 +249,21 @@ class GlassSearchBarConfig {
   /// search pill to remain a compact circular button on the right side when
   /// active, creating an empty gap in the center of the bar.
   final bool expandWhenActive;
+
+  /// Whether the compact search pill exists on the bar.
+  ///
+  /// Defaults to `true` — the pill is present in both states, the original
+  /// layout. `false` removes it entirely: the tab pill takes over the
+  /// reclaimed width, and the pill is genuinely absent rather than
+  /// invisible — it contributes no glass shape to the blend layer, so
+  /// nothing fuses with the tab pill's trailing edge.
+  ///
+  /// The value may change at runtime: the pill spring-scales in and out in
+  /// place at its slot, on the same spring the pill morphs use. That is the
+  /// building block for app-driven policies — a bar that wants the pill
+  /// only while search is active simply flips this together with
+  /// `isSearchActive`.
+  final bool showPill;
 
   /// Whether to show a cancel/dismiss button when the search bar is focused.
   ///

--- a/lib/widgets/surfaces/shared/tab_bar_searchable_controller.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_searchable_controller.dart
@@ -308,6 +308,12 @@ class SearchableBottomBarController extends ChangeNotifier {
   ///                           null means the tab pill fills all available space.
   /// [tabCount]             — number of tabs; used with [perTabWidth] to compute
   ///                           natural pill width.
+  /// [showPill]             — whether the search pill exists. An absent pill
+  ///                           stops reserving tab-pill width; its own
+  ///                           position/size targets stay unchanged either
+  ///                           way, because hiding is the layout's job (the
+  ///                           pill is unmounted and scaled in place), never
+  ///                           a zero-width morph.
   SearchablePillLayout computeLayout({
     required double totalW,
     required bool searching,
@@ -326,6 +332,7 @@ class SearchableBottomBarController extends ChangeNotifier {
     required double keyboardH,
     required int tabCount,
     required double? perTabWidth,
+    bool showPill = true,
   }) {
     final targetH = searching ? searchBarHeight : barHeight;
 
@@ -361,8 +368,9 @@ class SearchableBottomBarController extends ChangeNotifier {
 
     // maxTabW: maximum space the tab pill can ever occupy (when fully expanded).
     // Uses FULL (non-collapsed) extra widths for stability across states.
-    final maxTabW =
-        totalW - targetCompactW - spacing - extraFullWLeft - extraFullWRight;
+    // An absent pill reserves nothing — the tab pill takes the whole bar.
+    final pillReserve = showPill ? targetCompactW + spacing : 0.0;
+    final maxTabW = totalW - pillReserve - extraFullWLeft - extraFullWRight;
 
     // naturalTabW: intrinsic width when perTabWidth is specified.
     // Delegates to the shared resolveTabPillWidth function, which is also

--- a/test/widgets/surfaces/glass_searchable_bottom_bar_test.dart
+++ b/test/widgets/surfaces/glass_searchable_bottom_bar_test.dart
@@ -34,6 +34,7 @@ Widget _buildBar({
   ValueChanged<String>? onChanged,
   GlassTabBarExtraButton? extraButton,
   GlassQuality? quality,
+  bool showPill = true,
 }) {
   return createTestApp(
     child: GlassSearchableBottomBar(
@@ -50,6 +51,7 @@ Widget _buildBar({
         controller: controller,
         focusNode: focusNode,
         onChanged: onChanged,
+        showPill: showPill,
       ),
     ),
   );
@@ -1175,6 +1177,61 @@ void main() {
       await tester.pump();
       // The custom star icon must appear in the tree.
       expect(find.byIcon(CupertinoIcons.star_fill), findsOneWidget);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GlassSearchBarConfig.showPill
+  // ─────────────────────────────────────────────────────────────────────────
+
+  group('GlassSearchBarConfig.showPill', () {
+    test('defaults to true', () {
+      final config = GlassSearchBarConfig(onSearchToggle: (_) {});
+      expect(config.showPill, isTrue);
+    });
+
+    testWidgets('true renders the search pill', (tester) async {
+      await tester.pumpWidget(_buildBar());
+      await tester.pump();
+      expect(find.byIcon(CupertinoIcons.search), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('false renders no search pill in either state', (tester) async {
+      await tester.pumpWidget(_buildBar(showPill: false));
+      await tester.pump();
+      expect(find.byIcon(CupertinoIcons.search), findsNothing);
+
+      await tester.pumpWidget(
+        _buildBar(isSearchActive: true, showPill: false),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byIcon(CupertinoIcons.search), findsNothing);
+    });
+
+    testWidgets('flipping true springs the pill in', (tester) async {
+      await tester.pumpWidget(_buildBar(showPill: false));
+      await tester.pump();
+      expect(find.byIcon(CupertinoIcons.search), findsNothing);
+
+      await tester.pumpWidget(_buildBar());
+      // The appear scale is spring-driven; a couple of frames in, the pill
+      // is mounted and visible.
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.byIcon(CupertinoIcons.search), findsAtLeastNWidgets(1));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(CupertinoIcons.search), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('flipping false unmounts the pill', (tester) async {
+      await tester.pumpWidget(_buildBar());
+      await tester.pump();
+      expect(find.byIcon(CupertinoIcons.search), findsAtLeastNWidgets(1));
+
+      await tester.pumpWidget(_buildBar(showPill: false));
+      await tester.pumpAndSettle();
+      // Fully disappeared pills leave the tree entirely — a zero-scale glass
+      // shape would still fuse with the tab pill on the blend layer.
+      expect(find.byIcon(CupertinoIcons.search), findsNothing);
     });
   });
 }

--- a/test/widgets/surfaces/glass_tab_bar_minimizable_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_minimizable_test.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+import '../../shared/test_helpers.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _testTabs = [
+  GlassTab(label: 'For You', icon: Icon(CupertinoIcons.news)),
+  GlassTab(label: 'Following', icon: Icon(CupertinoIcons.person_2)),
+  GlassTab(label: 'Saved', icon: Icon(CupertinoIcons.bookmark)),
+];
+
+Widget _buildBar({
+  bool minimized = false,
+  int selectedIndex = 0,
+  ValueChanged<int>? onTabSelected,
+  VoidCallback? onMinimizedTabTap,
+  GlassTabBarTrailingButton? trailingButton,
+}) {
+  return createTestApp(
+    child: GlassTabBar.minimizable(
+      tabs: _testTabs,
+      selectedIndex: selectedIndex,
+      onTabSelected: onTabSelected ?? (_) {},
+      minimized: minimized,
+      onMinimizedTabTap: onMinimizedTabTap,
+      trailingButton: trailingButton,
+      maskingQuality: MaskingQuality.off, // no dual-layer in tests
+    ),
+  );
+}
+
+GlassTabBarTrailingButton _trailingButton({VoidCallback? onTap}) {
+  return GlassTabBarTrailingButton(
+    icon: const Icon(CupertinoIcons.square_pencil),
+    onTap: onTap ?? () {},
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('GlassTabBar.minimizable', () {
+    // ── Instantiation ─────────────────────────────────────────────────────────
+
+    testWidgets('can be instantiated with required parameters', (tester) async {
+      await tester.pumpWidget(_buildBar());
+      expect(find.byType(GlassTabBar), findsOneWidget);
+    });
+
+    testWidgets('displays tab labels while expanded', (tester) async {
+      await tester.pumpWidget(_buildBar());
+      await tester.pump();
+
+      expect(find.text('For You'), findsWidgets);
+      expect(find.text('Following'), findsWidgets);
+      expect(find.text('Saved'), findsWidgets);
+    });
+
+    testWidgets('minimized shows the selected tab\'s icon in the circle',
+        (tester) async {
+      await tester.pumpWidget(_buildBar(minimized: true, selectedIndex: 2));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(CupertinoIcons.bookmark), findsAtLeastNWidgets(1));
+    });
+
+    // ── Trailing button: none (plain minimizing bar) ──────────────────────────
+
+    testWidgets('renders no trailing pill in either state without a button',
+        (tester) async {
+      await tester.pumpWidget(_buildBar());
+      await tester.pump();
+      expect(find.byIcon(CupertinoIcons.search), findsNothing);
+      expect(find.byIcon(CupertinoIcons.square_pencil), findsNothing);
+
+      await tester.pumpWidget(_buildBar(minimized: true));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(CupertinoIcons.search), findsNothing);
+      expect(find.byIcon(CupertinoIcons.square_pencil), findsNothing);
+    });
+
+    // ── Trailing button: present (Tab(role: .search) behavior) ────────────────
+
+    testWidgets('trailing button is present in both states', (tester) async {
+      await tester.pumpWidget(_buildBar(trailingButton: _trailingButton()));
+      await tester.pump();
+      expect(
+          find.byIcon(CupertinoIcons.square_pencil), findsAtLeastNWidgets(1));
+
+      await tester.pumpWidget(
+        _buildBar(minimized: true, trailingButton: _trailingButton()),
+      );
+      await tester.pumpAndSettle();
+      expect(
+          find.byIcon(CupertinoIcons.square_pencil), findsAtLeastNWidgets(1));
+    });
+
+    // ── Trailing button: app-driven minimized-only pattern ────────────────────
+    //
+    // The package models only the native behaviors; an app that wants a
+    // button ONLY while minimized composes it by passing [trailingButton]
+    // conditionally, in the same rebuild that flips [minimized]. The bar
+    // animates the difference: the button spring-scales in at its slot as
+    // the tab pill shrinks, and unmounts once it has scaled away.
+
+    testWidgets('a conditionally passed button springs in with the minimize',
+        (tester) async {
+      await tester.pumpWidget(_buildBar());
+      await tester.pump();
+      expect(find.byIcon(CupertinoIcons.square_pencil), findsNothing);
+
+      await tester.pumpWidget(
+        _buildBar(minimized: true, trailingButton: _trailingButton()),
+      );
+      // The appear scale is spring-driven; a couple of frames in, the pill
+      // is mounted and visible.
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(
+          find.byIcon(CupertinoIcons.square_pencil), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('a conditionally removed button unmounts with the expand',
+        (tester) async {
+      await tester.pumpWidget(
+        _buildBar(minimized: true, trailingButton: _trailingButton()),
+      );
+      await tester.pump();
+      expect(
+          find.byIcon(CupertinoIcons.square_pencil), findsAtLeastNWidgets(1));
+
+      await tester.pumpWidget(_buildBar());
+      await tester.pumpAndSettle();
+      expect(find.byIcon(CupertinoIcons.square_pencil), findsNothing);
+    });
+
+    testWidgets('a removed button keeps its own icon while disappearing',
+        (tester) async {
+      await tester.pumpWidget(_buildBar(trailingButton: _trailingButton()));
+      await tester.pump();
+
+      await tester.pumpWidget(_buildBar(trailingButton: null));
+      // Mid-disappear the pill is still mounted and scaling away. It must
+      // render the button it WAS — deriving content from the now-null button
+      // would drop the icon and swap the collapsed slot to the config's
+      // default search glyph for its last few frames. (The pill's hidden
+      // expanded row always contains a search icon at zero opacity, so the
+      // meaningful assertion is the button's own icon surviving, not the
+      // search icon's absence.)
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(
+          find.byIcon(CupertinoIcons.square_pencil), findsAtLeastNWidgets(1));
+
+      await tester.pumpAndSettle();
+      expect(find.byIcon(CupertinoIcons.square_pencil), findsNothing);
+    });
+
+    // ── Taps ──────────────────────────────────────────────────────────────────
+
+    testWidgets('tapping the trailing button calls onTap', (tester) async {
+      var taps = 0;
+
+      await tester.pumpWidget(
+        _buildBar(
+          minimized: true,
+          trailingButton: _trailingButton(onTap: () => taps++),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(CupertinoIcons.square_pencil).first);
+      await tester.pumpAndSettle();
+
+      expect(taps, 1);
+    });
+
+    testWidgets('tapping the minimized tab circle calls onMinimizedTabTap',
+        (tester) async {
+      var taps = 0;
+
+      await tester.pumpWidget(
+        _buildBar(minimized: true, onMinimizedTabTap: () => taps++),
+      );
+      await tester.pumpAndSettle();
+
+      // The minimized circle carries the selected tab's icon.
+      await tester.tap(find.byIcon(CupertinoIcons.news).first);
+      await tester.pumpAndSettle();
+
+      expect(taps, 1);
+    });
+
+    // ── preferredSize ─────────────────────────────────────────────────────────
+
+    test('preferredSize follows minimizedBarHeight while minimized', () {
+      final expanded = GlassTabBar.minimizable(
+        tabs: _testTabs,
+        selectedIndex: 0,
+        onTabSelected: _noopInt,
+        minimizedBarHeight: 44,
+      );
+      final minimized = GlassTabBar.minimizable(
+        tabs: _testTabs,
+        selectedIndex: 0,
+        onTabSelected: _noopInt,
+        minimized: true,
+        minimizedBarHeight: 44,
+      );
+
+      // barHeight 64 + verticalPadding 20 * 2 / minimizedBarHeight 44 + 40.
+      expect(expanded.preferredSize.height, 104);
+      expect(minimized.preferredSize.height, 84);
+    });
+  });
+}
+
+void _noopInt(int _) {}

--- a/test/widgets/surfaces/searchable_bottom_bar_controller_test.dart
+++ b/test/widgets/surfaces/searchable_bottom_bar_controller_test.dart
@@ -626,4 +626,69 @@ void main() {
       expect(l.targetTabW, searchH); // 50
     });
   });
+
+  // ── computeLayout — showPill ───────────────────────────────────────────────
+
+  group('computeLayout — showPill', () {
+    const totalW = 400.0;
+    const barH = 64.0;
+    const searchH = 50.0;
+    const spacing = 8.0;
+
+    SearchablePillLayout compute({
+      required bool searching,
+      bool showPill = true,
+    }) =>
+        ctrl.computeLayout(
+          totalW: totalW,
+          searching: searching,
+          expandWhenActive: false,
+          barHeight: barH,
+          searchBarHeight: searchH,
+          spacing: spacing,
+          hasDismiss: false,
+          dismissVisible: false,
+          collapsedTabWidth: null,
+          tabPillAnchor: GlassTabPillAnchor.start,
+          extraFullW: 0,
+          extraPos: GlassExtraButtonPosition.beforeSearch,
+          extraCollapsesOnSearch: true,
+          isKeyboardActive: false,
+          keyboardH: 0,
+          tabCount: 3,
+          perTabWidth: null,
+          showPill: showPill,
+        );
+
+    test('defaults to shown — the pill slot stays reserved', () {
+      final l = compute(searching: false);
+      // maxTabW = totalW - barH - spacing = 400 - 64 - 8 = 328
+      expect(l.targetTabW, closeTo(328, 0.01));
+    });
+
+    test('an absent pill gives the tab pill the full bar', () {
+      final l = compute(searching: false, showPill: false);
+      expect(l.targetTabW, totalW);
+    });
+
+    test('an absent pill leaves the searching tab circle untouched', () {
+      final l = compute(searching: true, showPill: false);
+      expect(l.targetTabW, searchH); // collapsed circle
+    });
+
+    test('search pill targets are identical shown or absent', () {
+      // Hiding is the layout widget's job (the pill is unmounted and scaled
+      // in place at its slot) — the pill's own position/size targets must
+      // never morph with showPill, or (re)appearing would slide it in from
+      // wherever the hidden targets parked it.
+      for (final searching in [false, true]) {
+        final shown = compute(searching: searching);
+        final absent = compute(searching: searching, showPill: false);
+        expect(absent.targetSearchLeft, shown.targetSearchLeft,
+            reason: 'searching=$searching');
+        expect(absent.targetSearchW, shown.targetSearchW,
+            reason: 'searching=$searching');
+      }
+    });
+  });
 }


### PR DESCRIPTION
Fixes #218.

## Description

`GlassTabBar.searchable`'s tab-pill → circle morph is exactly iOS 26's tab bar
minimize — SwiftUI's `tabBarMinimizeBehavior(.onScrollDown)` — but the only way
to reach it today is through a search-shaped API: `isSearchActive` for the
minimize state, a `GlassSearchBarConfig` for a bar with no search in it, and a
trailing pill that is always a search affordance and always reserves its width.
A bar whose trailing slot is a plain action button — or nothing, like a native
tab bar without a `Tab(role: .search)` — has no honest way in.

https://github.com/user-attachments/assets/55f6e52d-176f-43a9-b40b-0b7680c3cce2

### 1. `GlassSearchBarConfig.showPill` (default `true` — no behavior change)

Whether the compact search pill exists. `false` removes it entirely: the tab
pill takes over the reclaimed width. The value may change at runtime, which is
the building block for app-driven policies (a pill that exists only while
search is active is `showPill` flipped together with `isSearchActive`).

Two implementation notes worth recording:

- **The pill's position/size targets in `computeLayout` are untouched either
  way** — only the tab pill's width reserve knows about `showPill`. Hiding is
  done by *unmounting* the pill and spring-scaling it in place at its slot
  (same `SpringDescription` as the pill morphs), never by a zero-width morph.
  A first attempt that parked the pill at zero width left a visible glass
  remnant fused to the tab pill's trailing edge: a grouped surface is painted
  by the blend layer, so neither zero width nor `Opacity` can hide it — only
  absence can. (Possibly worth a general docs note: `Opacity` around a grouped
  glass child does not hide the glass.)
- The appear/disappear comes out liquid for free: the pill overlaps the
  still-morphing tab pill on the shared blend layer, so the blending renders
  the circle pinching off the bar, and being absorbed on the way back.

### 2. `GlassTabBar.minimizable`

A placement that speaks navigation: `minimized` replaces `isSearchActive` (the
caller decides when — typically from scroll direction, matching
`.tabBarMinimizeBehavior(.onScrollDown)`), `onMinimizedTabTap` for the
minimized circle's "bring my tabs back" tap, `minimizedBarHeight` (default 50 —
both pills render smaller while minimized, as the native bar does), and an
optional `GlassTabBarTrailingButton` in the slot the search pill occupies.

The trailing slot models only what the native components express:

| Mode | Native equivalent |
|---|---|
| `trailingButton: null` | A plain minimizing tab bar — the tabs get the full width, and the minimized state is the selected tab's circle alone |
| With a `trailingButton` | [`Tab(role: .search)`](https://developer.apple.com/documentation/swiftui/tabrole/search) — the trailing circle keeps its priority visibility through the minimize |

Deliberately **not** modeled: a button that exists only while minimized has no
SwiftUI equivalent (no public API exposes minimize state), so it is left to
apps — pass `trailingButton` conditionally, in the same rebuild that flips
`minimized`, and the bar animates the difference. A test documents the pattern.

Internally the placement is a thin dispatch — `_buildSearchable` and
`_buildMinimizable` share one engine call, with the minimizable branch
assembling its `GlassSearchBarConfig` at build time (field never expands, no
cancel pill, the single toggle callback routed to the two taps, `showPill` from
the button's presence). The searchable placement is untouched apart from
gaining the config field.

### Tests

- 4 new `computeLayout` unit tests: the reserve math, and a guard that the
  pill's own targets never morph with `showPill` — the contract that keeps the
  transition an in-place scale.
- 5 new widget tests on the searchable placement: presence, both flip
  directions (spring-in, and unmount-on-disappear).
- 11 new widget tests on `GlassTabBar.minimizable`
  (`glass_tab_bar_minimizable_test.dart`): both trailing modes in both states,
  the conditional-button pattern in both directions, a removed button keeping
  its own icon while the pill scales away (caught on the first manual pass —
  the outgoing pill fell back to the default search glyph), both tap targets,
  and `preferredSize` under `minimizedBarHeight`.

`flutter test` is green apart from 11 golden tests that also fail byte-identically
on `origin/main` here — machine-dependent goldens, untouched by this change.

### Verification

Running in production in our app (iOS 26/27, Impeller): the bar collapses on
scroll with a conditionally-passed trailing action button, and the
appear/disappear reads as the pill pinching off / being absorbed by the bar.
The PR includes a standalone example (`example/lib/demos/minimizable_bar_demo.dart`,
in the demos/ convention) — a scrollable feed driving `minimized` from scroll
direction, with a live switch between the trailing modes. The screen recording
at the top of this description is that demo.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Platforms Tested

- [x] iOS (Impeller)

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (shaders, painting logic)
- [ ] I have made corresponding changes to the documentation / CHANGELOG.md — API docs are included; CHANGELOG left to the release commit per repo convention (happy to add an entry if you'd rather have it in the PR)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/golden tests pass locally (`flutter test`)

