### PR TITLE
feat(GlassTabBar): scroll-to-minimize via GlassTabBarMinimizeController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,53 @@
+# Unreleased
+
+## Features
+
+- **Scroll-to-minimize for `GlassTabBar.minimizable`:** A new
+  `GlassTabBarMinimizeController` drives the minimize from scrolling — the
+  Flutter equivalent of SwiftUI's `.tabBarMinimizeBehavior(_:)`. Pass it as
+  `minimizeController` alongside the scroll view's `scrollController` and the
+  bar minimizes and expands on its own; `minimized` remains available as a
+  plain controlled prop for callers that drive it themselves.
+  `GlassBarMinimizeBehavior` mirrors Apple's enum case for case — `automatic`,
+  `never`, `onScrollDown`, `onScrollUp`. Apple documents `automatic` only as
+  "the system default" without saying what it resolves to; as of iOS 26 it is
+  observed to mean no minimization on iPhone, so this package resolves it to
+  `never` and callers opt in explicitly.
+
+  The bar also re-expands on reaching the resting edge of the content and on
+  tapping the minimized circle, stays inert when the content cannot scroll, and
+  ignores rubber-band overscroll, `jumpTo`, keyboard viewport insets and layout
+  corrections. Minimizing is an iPhone-only behaviour on iOS; this package
+  documents that rather than gating on platform, so the behaviour never
+  silently switches itself off.
+
+  **The trigger is distance accumulated since the last direction reversal, not
+  a per-frame delta.** A per-frame gate is really a test on velocity ÷ refresh
+  rate, so its activation velocity doubles between 60 Hz and 120 Hz ProMotion —
+  and ProMotion switches rate adaptively, so it is not stable even on one
+  device. That frame-rate coupling is why the tab bar's previous
+  collapse-to-extra-button pattern was removed in 1.0.0 as "unreliable on
+  120 Hz ProMotion displays". Accumulated distance has no such coupling, and a
+  parameterised 60/120 Hz test locks the invariance in.
+
+## Bug Fixes
+
+- **Spring reversals no longer stall:** `SearchableBottomBarController.makeSpring`
+  discarded the in-flight velocity when a morph was retargeted mid-animation,
+  so reversing read as a stall followed by a restart. It now carries the
+  velocity through (new optional `velocity` parameter, defaulting to the
+  previous behaviour), and the launch sites read the controller's value and
+  velocity inside the post-frame callback rather than a frame earlier during
+  build. Rare when the morph was only ever toggled by a tap; routine once
+  scrolling drives it. Also benefits `GlassTabBar.searchable`.
+- **Whiten-at-bottom crash with a shared `ScrollController`:** the searchable
+  and minimizable placements read `ScrollController.position` guarded only by
+  `hasClients`, which asserts when two scroll views share one controller —
+  the few hundred milliseconds of an `AnimatedSwitcher` cross-fade or a
+  `Navigator` transition. Those frames are now skipped instead.
+
+---
+
 # 1.0.0
 
 ## Major Milestone: General Availability

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Without a controller, `minimized` stays a plain controlled prop and you decide
 when to flip it.
 
 > See `example/lib/demos/minimizable_bar_demo.dart` for all four behaviours,
-> per-tab scroll views, a non-scrollable tab, and the inline accessory.
+> per-tab scroll views, a non-scrollable tab, and `extendBody: false`.
 
 ### Content-Aware Brightness
 
@@ -906,7 +906,7 @@ Focused, self-contained demos — one widget, one file, runnable standalone:
 |---|---|
 | `glass_menu_demo.dart` — all 9 menu alignments | `cd example && flutter run -t lib/demos/glass_menu_demo.dart` |
 | `glass_tab_bar_scrollable_demo.dart` — scrollable tab bar | `cd example && flutter run -t lib/demos/glass_tab_bar_scrollable_demo.dart` |
-| `minimizable_bar_demo.dart` — scroll-to-minimize, all four behaviours, inline accessory | `cd example && flutter run -t lib/demos/minimizable_bar_demo.dart` |
+| `minimizable_bar_demo.dart` — scroll-to-minimize, all four behaviours | `cd example && flutter run -t lib/demos/minimizable_bar_demo.dart` |
 | `glass_modal_sheet_demo.dart` — peek / half / full states + liquid morph trigger | `cd example && flutter run -t lib/demos/glass_modal_sheet_demo.dart` |
 | `glass_tab_bar_bottom_demo.dart` — magic-lens masking | `cd example && flutter run -t lib/demos/glass_tab_bar_bottom_demo.dart` |
 | `bottom_bar_tab_width_demo.dart` — tabWidth showcase | `cd example && flutter run -t lib/demos/bottom_bar_tab_width_demo.dart` |

--- a/README.md
+++ b/README.md
@@ -411,6 +411,67 @@ GlassScaffold(
 
 > See `example/lib/demos/nav_bar_patterns_demo.dart` for complete `GlassScaffold` usage patterns.
 
+### Scroll-to-Minimize
+
+`GlassTabBar.minimizable` shrinks to the selected tab's circle as you scroll —
+SwiftUI's `.tabBarMinimizeBehavior(_:)`. Hand it a `GlassTabBarMinimizeController`
+and the scroll view it floats over, and it drives itself:
+
+```dart
+final _scroll = ScrollController();
+final _minimize = GlassTabBarMinimizeController(
+  behavior: GlassBarMinimizeBehavior.onScrollDown,
+);
+
+@override
+void dispose() {
+  _minimize.dispose();
+  _scroll.dispose();
+  super.dispose();
+}
+
+@override
+Widget build(BuildContext context) => GlassScaffold(
+      body: ListView.builder(controller: _scroll, ...),
+      bottomBar: GlassTabBar.minimizable(
+        tabs: _tabs,
+        selectedIndex: _index,
+        onTabSelected: (i) => setState(() => _index = i),
+        minimizeController: _minimize,
+        scrollController: _scroll,
+        onMinimizedTabTap: _minimize.expand,
+      ),
+    );
+```
+
+| SwiftUI | This package |
+|---|---|
+| `.tabBarMinimizeBehavior(.automatic)` | `GlassBarMinimizeBehavior.automatic` |
+| `.tabBarMinimizeBehavior(.never)` | `GlassBarMinimizeBehavior.never` |
+| `.tabBarMinimizeBehavior(.onScrollDown)` | `GlassBarMinimizeBehavior.onScrollDown` |
+| `.tabBarMinimizeBehavior(.onScrollUp)` | `GlassBarMinimizeBehavior.onScrollUp` |
+| `@Environment(\.tabViewBottomAccessoryPlacement)` | `GlassTabBarAccessoryPlacementScope.of(context)` |
+
+The bar also expands when you scroll back to the resting edge of the content
+and when you tap the minimized circle, and stays put when the content is too
+short to scroll. Each tab owns its own scroll view on iOS — pass the current
+tab's controller and call `expand()` from `onTabSelected` to match.
+
+A `bottomAccessory` does not follow the bar on its own — pass
+`GlassTabBarAccessoryPlacement.inline` in the same rebuild the minimize lands
+in, and it animates down into the bar. Note that the bar positions your
+accessory but paints no surface behind it, so give it its own glass.
+
+Minimizing is an iPhone-only behaviour on iOS — the iPad tab bar is a top bar
+and never minimizes. This package does not gate on platform or screen size, so
+if you want that parity, choose a different surface for the regular size class.
+
+Without a controller, `minimized` stays a plain controlled prop and you decide
+when to flip it.
+
+> See `example/lib/demos/minimizable_bar_demo.dart` for all four behaviours,
+> per-tab scroll views, a non-scrollable tab, and the inline accessory.
+
 ### Content-Aware Brightness
 
 Glass bars automatically adapt their icon and label colors to match the content
@@ -845,7 +906,7 @@ Focused, self-contained demos — one widget, one file, runnable standalone:
 |---|---|
 | `glass_menu_demo.dart` — all 9 menu alignments | `cd example && flutter run -t lib/demos/glass_menu_demo.dart` |
 | `glass_tab_bar_scrollable_demo.dart` — scrollable tab bar | `cd example && flutter run -t lib/demos/glass_tab_bar_scrollable_demo.dart` |
-| `minimizable_bar_demo.dart` — scroll-minimize + trailing button | `cd example && flutter run -t lib/demos/minimizable_bar_demo.dart` |
+| `minimizable_bar_demo.dart` — scroll-to-minimize, all four behaviours, inline accessory | `cd example && flutter run -t lib/demos/minimizable_bar_demo.dart` |
 | `glass_modal_sheet_demo.dart` — peek / half / full states + liquid morph trigger | `cd example && flutter run -t lib/demos/glass_modal_sheet_demo.dart` |
 | `glass_tab_bar_bottom_demo.dart` — magic-lens masking | `cd example && flutter run -t lib/demos/glass_tab_bar_bottom_demo.dart` |
 | `bottom_bar_tab_width_demo.dart` — tabWidth showcase | `cd example && flutter run -t lib/demos/bottom_bar_tab_width_demo.dart` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -513,9 +513,10 @@ Ideas for consideration after stable. None of these are committed.
   `CupertinoPageRoute` push/pop transitions.
 
 ### Enhancements
-- [ ] **Scroll-to-minimize** (`GlassBarMinimizeBehavior.onScrollDown`) — tab bar
+- [x] **Scroll-to-minimize** (`GlassBarMinimizeBehavior.onScrollDown`) — tab bar
   shrinks on scroll-down, re-expands on scroll-up. Matches iOS 26
-  `tabBarMinimizeBehavior`. High priority post-1.0.
+  `tabBarMinimizeBehavior`. Shipped in 1.1.0 as
+  `GlassTabBarMinimizeController`, with all four behaviour cases.
 - [x] **Tab bar bottom accessory** — persistent widget (mini player) above
   the tab bar that animates with minimize. Matches iOS 26 `tabViewBottomAccessory`.
   Currently achieved via `GlassScaffold.bodyOverlays` manually.

--- a/example/lib/demos/minimizable_bar_demo.dart
+++ b/example/lib/demos/minimizable_bar_demo.dart
@@ -76,7 +76,25 @@ class MinimizableBarDemo extends StatelessWidget {
   const MinimizableBarDemo({super.key});
 
   @override
-  Widget build(BuildContext context) => const _DemoHome();
+  Widget build(BuildContext context) {
+    // Reached from the showcase, which has its own light/dark toggle, this
+    // route would otherwise take its default text colour from the ambient
+    // theme while the scaffold below paints a fixed dark background — black
+    // on black in light mode.
+    //
+    // CupertinoTheme alone does not fix it: the app installs DefaultTextStyle
+    // once at the top from ITS theme, and nesting a CupertinoTheme lower down
+    // does not re-install one. So set both, and pin the same brightness
+    // `_DemoApp` gives the standalone entrypoint.
+    const theme = CupertinoThemeData(brightness: Brightness.dark);
+    return CupertinoTheme(
+      data: theme,
+      child: DefaultTextStyle(
+        style: theme.textTheme.textStyle,
+        child: const _DemoHome(),
+      ),
+    );
+  }
 }
 
 class _DemoHome extends StatefulWidget {
@@ -149,6 +167,10 @@ class _DemoHomeState extends State<_DemoHome> {
     return GlassScaffold(
       extendBody: _extendBody,
       backgroundColor: const Color(0xFF0A0A0F),
+      // The background is fixed dark, so the status bar has to be too —
+      // reached from the showcase in light mode it would otherwise be black
+      // on black.
+      statusBarStyle: GlassStatusBarStyle.light,
       body: _buildBody(),
       bottomBar: GlassTabBar.minimizable(
         tabs: _tabs,
@@ -201,7 +223,8 @@ class _DemoHomeState extends State<_DemoHome> {
         children: [
           const Text(
             'GlassTabBar.minimizable',
-            style: TextStyle(fontSize: 22, fontWeight: FontWeight.w700),
+            style: TextStyle(
+                fontSize: 22, fontWeight: FontWeight.w700, color: Colors.white),
           ),
           const SizedBox(height: 4),
           Text(
@@ -225,7 +248,9 @@ class _DemoHomeState extends State<_DemoHome> {
               for (final b in GlassBarMinimizeBehavior.values)
                 b: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 6),
-                  child: Text(b.label, style: const TextStyle(fontSize: 13)),
+                  child: Text(b.label,
+                      style:
+                          const TextStyle(fontSize: 13, color: Colors.white)),
                 ),
             },
           ),
@@ -240,7 +265,9 @@ class _DemoHomeState extends State<_DemoHome> {
               for (final m in _TrailingMode.values)
                 m: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 6),
-                  child: Text(m.label, style: const TextStyle(fontSize: 13)),
+                  child: Text(m.label,
+                      style:
+                          const TextStyle(fontSize: 13, color: Colors.white)),
                 ),
             },
           ),
@@ -281,7 +308,8 @@ class _DemoHomeState extends State<_DemoHome> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(title, style: const TextStyle(fontSize: 14)),
+                Text(title,
+                    style: const TextStyle(fontSize: 14, color: Colors.white)),
                 Text(
                   subtitle,
                   style: TextStyle(
@@ -345,7 +373,8 @@ class _ContentCard extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 18),
       child: Text(
         'Item number $index',
-        style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+        style: const TextStyle(
+            fontSize: 15, fontWeight: FontWeight.w600, color: Colors.white),
       ),
     );
   }

--- a/example/lib/demos/minimizable_bar_demo.dart
+++ b/example/lib/demos/minimizable_bar_demo.dart
@@ -8,7 +8,6 @@
 ///   - per-tab scroll views, re-targeted on tab change the way UIKit
 ///     re-resolves `contentScrollView(for: .bottom)`
 ///   - a tab whose content is shorter than the viewport, which never minimizes
-///   - a bottom accessory that moves inline as the bar shrinks
 ///   - `extendBody: false`, where the body inset tracks the bar's height
 ///
 /// Run standalone:
@@ -91,7 +90,6 @@ class _DemoHomeState extends State<_DemoHome> {
   int _selectedIndex = 0;
   _TrailingMode _trailingMode = _TrailingMode.always;
   int _composerTaps = 0;
-  bool _showAccessory = false;
   bool _extendBody = true;
 
   /// One scroll view per tab, as on iOS — the minimize follows whichever one
@@ -162,13 +160,6 @@ class _DemoHomeState extends State<_DemoHome> {
         scrollController: _scrollControllers[_selectedIndex],
         onMinimizedTabTap: _minimize.expand,
         trailingButton: _trailingButton,
-        bottomAccessory: _showAccessory ? const _MiniPlayer() : null,
-        bottomAccessoryHeight: _showAccessory ? 56 : null,
-        // The bar does not infer this — flip it in the same rebuild that the
-        // minimize lands, and the accessory animates down into the bar.
-        bottomAccessoryPlacement: _minimize.minimized
-            ? GlassTabBarAccessoryPlacement.inline
-            : GlassTabBarAccessoryPlacement.expanded,
       ),
     );
   }
@@ -255,12 +246,6 @@ class _DemoHomeState extends State<_DemoHome> {
           ),
           const SizedBox(height: 8),
           _toggle(
-            value: _showAccessory,
-            onChanged: (v) => setState(() => _showAccessory = v),
-            title: 'Bottom accessory (mini player)',
-            subtitle: 'Moves inline as the bar minimizes',
-          ),
-          _toggle(
             value: _extendBody,
             onChanged: (v) => setState(() => _extendBody = v),
             title: 'extendBody',
@@ -321,48 +306,6 @@ class _DemoHomeState extends State<_DemoHome> {
           color: Colors.white.withValues(alpha: 0.45),
         ),
       );
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Bottom accessory — reads the placement the bar publishes
-// ─────────────────────────────────────────────────────────────────────────────
-
-class _MiniPlayer extends StatelessWidget {
-  const _MiniPlayer();
-
-  @override
-  Widget build(BuildContext context) {
-    // The Flutter equivalent of @Environment(\.tabViewBottomAccessoryPlacement).
-    final placement = GlassTabBarAccessoryPlacementScope.of(context);
-    final inline = placement == GlassTabBarAccessoryPlacement.inline;
-
-    // The bar positions the accessory but does not paint a surface behind it —
-    // the accessory is the app's widget, so it brings its own glass.
-    return GlassContainer(
-      useOwnLayer: true,
-      shape: LiquidRoundedSuperellipse(borderRadius: inline ? 22 : 20),
-      padding: EdgeInsets.symmetric(horizontal: inline ? 12 : 16),
-      child: Row(
-        children: [
-          const Icon(CupertinoIcons.music_note_2, size: 18),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Text(
-              inline ? 'Now playing' : 'Liquid Glass — Side A',
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
-            ),
-          ),
-          if (!inline) ...[
-            const Icon(CupertinoIcons.backward_fill, size: 18),
-            const SizedBox(width: 14),
-          ],
-          const Icon(CupertinoIcons.play_fill, size: 18),
-        ],
-      ),
-    );
-  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/example/lib/demos/minimizable_bar_demo.dart
+++ b/example/lib/demos/minimizable_bar_demo.dart
@@ -1,12 +1,15 @@
 /// GlassTabBar.minimizable — SwiftUI's tabBarMinimizeBehavior without the search
 ///
-/// Demonstrates the minimizable placement: the tab pill minimizes to the
-/// selected tab's circle on scroll (mirroring
-/// `.tabBarMinimizeBehavior(.onScrollDown)`), with the trailing slot in each
-/// of its modes:
+/// Demonstrates the minimizable placement driven by a
+/// [GlassTabBarMinimizeController], the equivalent of
+/// `.tabBarMinimizeBehavior(_:)`:
 ///
-///   - none    — no trailing pill in either state
-///   - always  — present in both states (Tab(role: .search) behavior)
+///   - all four [GlassBarMinimizeBehavior] cases, switchable at runtime
+///   - per-tab scroll views, re-targeted on tab change the way UIKit
+///     re-resolves `contentScrollView(for: .bottom)`
+///   - a tab whose content is shorter than the viewport, which never minimizes
+///   - a bottom accessory that moves inline as the bar shrinks
+///   - `extendBody: false`, where the body inset tracks the bar's height
 ///
 /// Run standalone:
 ///   flutter run -t lib/demos/minimizable_bar_demo.dart
@@ -15,7 +18,6 @@ library;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart' show ScrollDirection;
 
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
 
@@ -57,6 +59,15 @@ enum _TrailingMode {
   final String label;
 }
 
+extension on GlassBarMinimizeBehavior {
+  String get label => switch (this) {
+        GlassBarMinimizeBehavior.automatic => 'Auto',
+        GlassBarMinimizeBehavior.never => 'Never',
+        GlassBarMinimizeBehavior.onScrollDown => 'Down',
+        GlassBarMinimizeBehavior.onScrollUp => 'Up',
+      };
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Home
 // ─────────────────────────────────────────────────────────────────────────────
@@ -78,26 +89,50 @@ class _DemoHome extends StatefulWidget {
 
 class _DemoHomeState extends State<_DemoHome> {
   int _selectedIndex = 0;
-  bool _minimized = false;
   _TrailingMode _trailingMode = _TrailingMode.always;
   int _composerTaps = 0;
+  bool _showAccessory = false;
+  bool _extendBody = true;
+
+  /// One scroll view per tab, as on iOS — the minimize follows whichever one
+  /// is currently under the bar.
+  late final List<ScrollController> _scrollControllers =
+      List.generate(_tabs.length, (_) => ScrollController());
+
+  final _minimize = GlassTabBarMinimizeController(
+    behavior: GlassBarMinimizeBehavior.onScrollDown,
+  );
 
   static const _tabs = [
     GlassTab(label: 'Home', icon: Icon(CupertinoIcons.house)),
-    GlassTab(label: 'Alerts', icon: Icon(CupertinoIcons.bell)),
-    GlassTab(label: 'Favorites', icon: Icon(CupertinoIcons.heart)),
+    GlassTab(label: 'Chat', icon: Icon(CupertinoIcons.chat_bubble_2)),
+    GlassTab(label: 'Short', icon: Icon(CupertinoIcons.square_list)),
   ];
 
-  /// Mirrors `.tabBarMinimizeBehavior(.onScrollDown)`: scrolling down starts
-  /// the minimize, scrolling back up expands again. The bar itself animates
-  /// the morph — this just decides *when*.
-  bool _onScroll(UserScrollNotification n) {
-    if (n.direction == ScrollDirection.reverse && !_minimized) {
-      setState(() => _minimized = true);
-    } else if (n.direction == ScrollDirection.forward && _minimized) {
-      setState(() => _minimized = false);
+  @override
+  void initState() {
+    super.initState();
+    // Repaint the readout as the bar minimizes. The bar and the scaffold
+    // subscribe on their own — this listener is only for the debug text.
+    _minimize.addListener(_onMinimizeChanged);
+  }
+
+  @override
+  void dispose() {
+    _minimize.removeListener(_onMinimizeChanged);
+    _minimize.dispose();
+    for (final c in _scrollControllers) {
+      c.dispose();
     }
-    return false;
+    super.dispose();
+  }
+
+  void _onMinimizeChanged() => setState(() {});
+
+  void _onTabSelected(int i) {
+    setState(() => _selectedIndex = i);
+    // The new tab starts with its tabs showing — you just tapped one.
+    _minimize.expand();
   }
 
   GlassTabBarTrailingButton? get _trailingButton {
@@ -113,34 +148,57 @@ class _DemoHomeState extends State<_DemoHome> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      extendBody: true,
-      body: NotificationListener<UserScrollNotification>(
-        onNotification: _onScroll,
-        child: CustomScrollView(
-          slivers: [
-            SliverSafeArea(
-              sliver: SliverToBoxAdapter(child: _buildControls()),
-            ),
-            SliverPadding(
-              padding: const EdgeInsets.fromLTRB(16, 8, 16, 140),
-              sliver: SliverList.separated(
-                itemCount: 40,
-                separatorBuilder: (_, __) => const SizedBox(height: 12),
-                itemBuilder: (context, i) => _ContentCard(index: i),
-              ),
-            ),
-          ],
-        ),
-      ),
-      bottomNavigationBar: GlassTabBar.minimizable(
+    return GlassScaffold(
+      extendBody: _extendBody,
+      backgroundColor: const Color(0xFF0A0A0F),
+      body: _buildBody(),
+      bottomBar: GlassTabBar.minimizable(
         tabs: _tabs,
         selectedIndex: _selectedIndex,
-        onTabSelected: (i) => setState(() => _selectedIndex = i),
-        minimized: _minimized,
-        onMinimizedTabTap: () => setState(() => _minimized = false),
+        onTabSelected: _onTabSelected,
+        // The controller owns `minimized` — no `minimized:` prop, no
+        // NotificationListener, no scroll bookkeeping in this file.
+        minimizeController: _minimize,
+        scrollController: _scrollControllers[_selectedIndex],
+        onMinimizedTabTap: _minimize.expand,
         trailingButton: _trailingButton,
+        bottomAccessory: _showAccessory ? const _MiniPlayer() : null,
+        bottomAccessoryHeight: _showAccessory ? 56 : null,
+        // The bar does not infer this — flip it in the same rebuild that the
+        // minimize lands, and the accessory animates down into the bar.
+        bottomAccessoryPlacement: _minimize.minimized
+            ? GlassTabBarAccessoryPlacement.inline
+            : GlassTabBarAccessoryPlacement.expanded,
       ),
+    );
+  }
+
+  Widget _buildBody() {
+    final controller = _scrollControllers[_selectedIndex];
+    // `Chat` is bottom-aligned, which is the case onScrollUp exists for.
+    final reverse = _selectedIndex == 1;
+    final itemCount = switch (_selectedIndex) {
+      2 => 2, // deliberately shorter than the viewport
+      _ => 40,
+    };
+
+    return CustomScrollView(
+      controller: controller,
+      reverse: reverse,
+      slivers: [
+        if (!reverse)
+          SliverSafeArea(
+            sliver: SliverToBoxAdapter(child: _buildControls()),
+          ),
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 160),
+          sliver: SliverList.separated(
+            itemCount: itemCount,
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemBuilder: (context, i) => _ContentCard(index: i),
+          ),
+        ),
+      ],
     );
   }
 
@@ -156,23 +214,32 @@ class _DemoHomeState extends State<_DemoHome> {
           ),
           const SizedBox(height: 4),
           Text(
-            'Scroll down to minimize, up to expand — '
-            '.tabBarMinimizeBehavior(.onScrollDown). '
-            'Tap the minimized circle to bring the tabs back.',
+            'Scroll to minimize — .tabBarMinimizeBehavior(_:). Tap the '
+            'minimized circle to bring the tabs back. "Chat" is bottom-'
+            'aligned (try Up); "Short" cannot scroll, so it never minimizes.',
             style: TextStyle(
               fontSize: 13,
               color: Colors.white.withValues(alpha: 0.6),
             ),
           ),
           const SizedBox(height: 14),
-          Text(
-            'TRAILING BUTTON',
-            style: TextStyle(
-              fontSize: 11,
-              letterSpacing: 1.1,
-              color: Colors.white.withValues(alpha: 0.45),
+          _label('BEHAVIOR'),
+          const SizedBox(height: 6),
+          CupertinoSlidingSegmentedControl<GlassBarMinimizeBehavior>(
+            groupValue: _minimize.behavior,
+            onValueChanged: (b) => setState(
+              () => _minimize.behavior = b ?? GlassBarMinimizeBehavior.never,
             ),
+            children: {
+              for (final b in GlassBarMinimizeBehavior.values)
+                b: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  child: Text(b.label, style: const TextStyle(fontSize: 13)),
+                ),
+            },
           ),
+          const SizedBox(height: 12),
+          _label('TRAILING BUTTON'),
           const SizedBox(height: 6),
           CupertinoSlidingSegmentedControl<_TrailingMode>(
             groupValue: _trailingMode,
@@ -187,14 +254,111 @@ class _DemoHomeState extends State<_DemoHome> {
             },
           ),
           const SizedBox(height: 8),
+          _toggle(
+            value: _showAccessory,
+            onChanged: (v) => setState(() => _showAccessory = v),
+            title: 'Bottom accessory (mini player)',
+            subtitle: 'Moves inline as the bar minimizes',
+          ),
+          _toggle(
+            value: _extendBody,
+            onChanged: (v) => setState(() => _extendBody = v),
+            title: 'extendBody',
+            subtitle: 'Off: the body inset follows the bar as it shrinks',
+          ),
+          const SizedBox(height: 4),
           Text(
-            'minimized: $_minimized   ·   composer taps: $_composerTaps',
+            'minimized: ${_minimize.minimized}   ·   '
+            'resolved: ${_minimize.resolvedBehavior.name}   ·   '
+            'composer taps: $_composerTaps',
             style: TextStyle(
               fontSize: 12,
               fontFeatures: const [FontFeature.tabularFigures()],
               color: Colors.white.withValues(alpha: 0.5),
             ),
           ),
+        ],
+      ),
+    );
+  }
+
+  Widget _toggle({
+    required bool value,
+    required ValueChanged<bool> onChanged,
+    required String title,
+    required String subtitle,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: const TextStyle(fontSize: 14)),
+                Text(
+                  subtitle,
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: Colors.white.withValues(alpha: 0.5),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          CupertinoSwitch(value: value, onChanged: onChanged),
+        ],
+      ),
+    );
+  }
+
+  Widget _label(String text) => Text(
+        text,
+        style: TextStyle(
+          fontSize: 11,
+          letterSpacing: 1.1,
+          color: Colors.white.withValues(alpha: 0.45),
+        ),
+      );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bottom accessory — reads the placement the bar publishes
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _MiniPlayer extends StatelessWidget {
+  const _MiniPlayer();
+
+  @override
+  Widget build(BuildContext context) {
+    // The Flutter equivalent of @Environment(\.tabViewBottomAccessoryPlacement).
+    final placement = GlassTabBarAccessoryPlacementScope.of(context);
+    final inline = placement == GlassTabBarAccessoryPlacement.inline;
+
+    // The bar positions the accessory but does not paint a surface behind it —
+    // the accessory is the app's widget, so it brings its own glass.
+    return GlassContainer(
+      useOwnLayer: true,
+      shape: LiquidRoundedSuperellipse(borderRadius: inline ? 22 : 20),
+      padding: EdgeInsets.symmetric(horizontal: inline ? 12 : 16),
+      child: Row(
+        children: [
+          const Icon(CupertinoIcons.music_note_2, size: 18),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              inline ? 'Now playing' : 'Liquid Glass — Side A',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+            ),
+          ),
+          if (!inline) ...[
+            const Icon(CupertinoIcons.backward_fill, size: 18),
+            const SizedBox(width: 14),
+          ],
+          const Icon(CupertinoIcons.play_fill, size: 18),
         ],
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -810,7 +810,7 @@ class _ExamplesTab extends StatelessWidget {
                   _LargeDemoCard(
                     title: 'Minimizable Bar',
                     subtitle:
-                        'Scroll-collapse navigation with trailing action button',
+                        'tabBarMinimizeBehavior — minimizes as you scroll',
                     icon: CupertinoIcons.arrow_down_to_line_alt,
                     gradient: const [
                       Color(0xFF0A2342),

--- a/lib/src/widgets/surfaces/dynamic_preferred_size.dart
+++ b/lib/src/widgets/surfaces/dynamic_preferred_size.dart
@@ -1,0 +1,27 @@
+// ignore_for_file: public_member_api_docs
+// A PreferredSizeWidget whose preferred size can change without the widget
+// instance being replaced.
+//
+// Do NOT import this file directly — it is an internal contract between
+// [GlassScaffold] and the bars it hosts.
+
+import 'package:flutter/widgets.dart';
+
+/// A [PreferredSizeWidget] whose [PreferredSizeWidget.preferredSize] can change
+/// while the widget instance stays the same.
+///
+/// [GlassScaffold] reads its bars' `preferredSize` during its own `build` to
+/// derive the body inset and the edge-fade extents. A bar that changes height
+/// from internal state — a tab bar minimizing on scroll, say — would otherwise
+/// leave those values stale, because nothing marks the scaffold as needing a
+/// rebuild.
+///
+/// A bar that implements this returns the [Listenable] it changes size in
+/// response to; the scaffold subscribes and re-reads the size when it fires.
+/// Returning `null` means the size is fixed for the lifetime of the widget,
+/// and the scaffold does no extra work.
+abstract mixin class GlassDynamicPreferredSize implements PreferredSizeWidget {
+  /// Fires whenever [PreferredSizeWidget.preferredSize] may have changed, or
+  /// `null` when the size cannot change on its own.
+  Listenable? get preferredSizeListenable;
+}

--- a/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
@@ -33,6 +33,7 @@ import '../../../widgets/surfaces/shared/tab_bar_searchable_controller.dart';
 import 'tab_bar_searchable_internal.dart'
     show DismissPill, SearchPill, SearchableTabIndicator;
 import '../../../widgets/surfaces/shared/tab_bar_accessory_placement.dart';
+import '../../../widgets/surfaces/shared/tab_bar_minimize_controller.dart';
 
 /// Internal [StatefulWidget] that owns the searchable-placement rendering engine.
 ///
@@ -47,6 +48,7 @@ class TabBarSearchableLayout extends StatefulWidget {
     super.key,
     this.controller,
     this.isSearchActive = false,
+    this.minimizeController,
     this.extraButton,
     this.bottomAccessoryPlacement,
     this.bottomAccessory,
@@ -119,6 +121,11 @@ class TabBarSearchableLayout extends StatefulWidget {
   final GlassSearchBarConfig searchConfig;
   final SearchableBottomBarController? controller;
   final bool isSearchActive;
+
+  /// Drives the minimize from scrolling. This engine only attaches it to
+  /// [scrollController] — the resulting state arrives through
+  /// [isSearchActive], which [GlassTabBar] resolves.
+  final GlassTabBarMinimizeController? minimizeController;
   final GlassTabBarExtraButton? extraButton;
   final GlassTabBarAccessoryPlacement? bottomAccessoryPlacement;
   final Widget? bottomAccessory;
@@ -271,6 +278,7 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
     _searchPillListenable =
         Listenable.merge([_searchLeftCtrl, _searchWCtrl, _pillScaleCtrl]);
     widget.scrollController?.addListener(_onScrollMaybeWhiten);
+    widget.minimizeController?.attach(widget.scrollController);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _onScrollMaybeWhiten();
     });
@@ -295,6 +303,15 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
       old.scrollController?.removeListener(_onScrollMaybeWhiten);
       widget.scrollController?.addListener(_onScrollMaybeWhiten);
       _onScrollMaybeWhiten();
+    }
+    // Both controllers can change independently. Handle the minimize
+    // controller swap first so a re-attach uses the CURRENT scroll controller;
+    // attach() itself is idempotent on identity and re-baselines either way.
+    if (widget.minimizeController != old.minimizeController) {
+      old.minimizeController?.detach();
+      widget.minimizeController?.attach(widget.scrollController);
+    } else if (widget.scrollController != old.scrollController) {
+      widget.minimizeController?.attach(widget.scrollController);
     }
     if (widget.whitenAtBottom != old.whitenAtBottom) {
       _onScrollMaybeWhiten();
@@ -322,6 +339,8 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
     _searchWCtrl.dispose();
     _pillScaleCtrl.dispose();
     widget.scrollController?.removeListener(_onScrollMaybeWhiten);
+    // Detach, never dispose — the minimize controller belongs to the app.
+    widget.minimizeController?.detach();
     _whitenBoostCtrl.dispose();
     _controller.removeListener(_onControllerChanged);
     if (_ownsController) _controller.dispose();
@@ -332,12 +351,18 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
 
   void _onScrollMaybeWhiten() {
     final c = widget.scrollController;
+    // hasClients alone is not enough: ScrollController.position asserts when
+    // more than one scroll view is attached, which happens for a few hundred
+    // milliseconds whenever two of them share a controller across an
+    // AnimatedSwitcher cross-fade or a Navigator transition. Skip those frames
+    // rather than crashing — GlassScaffold guards its header fade the same way.
+    final p = (c != null && c.hasClients && c.positions.length == 1)
+        ? c.positions.single
+        : null;
     final atBottom = widget.whitenAtBottom &&
-        c != null &&
-        c.hasClients &&
-        c.position.maxScrollExtent > 0 &&
-        (c.position.maxScrollExtent - c.position.pixels) <=
-            widget.whitenBottomThreshold;
+        p != null &&
+        p.maxScrollExtent > 0 &&
+        (p.maxScrollExtent - p.pixels) <= widget.whitenBottomThreshold;
     final target = atBottom ? 1.0 : 0.0;
     if (_whitenTarget != target) {
       _whitenTarget = target;
@@ -498,9 +523,6 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                 } else if (_controller.pillsInitialized) {
                   final retarget = _controller.checkRetarget(layout);
                   if (retarget.any) {
-                    final fromTabW = _tabWCtrl.value;
-                    final fromLeft = _searchLeftCtrl.value;
-                    final fromSearchW = _searchWCtrl.value;
                     final toTabW = targetTabW;
                     final toLeft = targetSearchLeft;
                     final toSearchW = targetSearchW;
@@ -509,22 +531,34 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                       if (!mounted) return;
                       final spring = widget.springDescription ??
                           TabBarSearchableLayout._kSpring;
+                      // Read `from` and the in-flight velocity HERE, not during
+                      // build: any still-running simulation ticks once more
+                      // between the two, so a value captured in build would
+                      // start the new spring a frame behind — visible when a
+                      // morph reverses at peak speed.
                       if (retarget.tabW) {
                         _tabWCtrl.animateWith(
                             SearchableBottomBarController.makeSpring(
-                                spring: spring, from: fromTabW, to: toTabW));
+                                spring: spring,
+                                from: _tabWCtrl.value,
+                                to: toTabW,
+                                velocity: _tabWCtrl.velocity));
                       }
                       if (retarget.searchLeft) {
                         _searchLeftCtrl.animateWith(
                             SearchableBottomBarController.makeSpring(
-                                spring: spring, from: fromLeft, to: toLeft));
+                                spring: spring,
+                                from: _searchLeftCtrl.value,
+                                to: toLeft,
+                                velocity: _searchLeftCtrl.velocity));
                       }
                       if (retarget.searchW) {
                         _searchWCtrl.animateWith(
                             SearchableBottomBarController.makeSpring(
                                 spring: spring,
-                                from: fromSearchW,
-                                to: toSearchW));
+                                from: _searchWCtrl.value,
+                                to: toSearchW,
+                                velocity: _searchWCtrl.velocity));
                       }
                     });
                   }

--- a/lib/widgets/surfaces/glass_scaffold.dart
+++ b/lib/widgets/surfaces/glass_scaffold.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/services.dart';
 
 import '../../src/renderer/liquid_glass_renderer.dart';
+import '../../src/widgets/surfaces/dynamic_preferred_size.dart';
 import '../../types/glass_quality.dart';
 import '../../theme/glass_theme_data.dart';
 import '../shared/glass_content_aware_scope.dart';
@@ -362,6 +363,26 @@ class GlassScaffold extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Some bars change height from their own internal state — a tab bar
+    // minimizing on scroll — without the widget instance being replaced.
+    // Their preferredSize is read below, so the scaffold has to know when it
+    // has changed; nothing else would mark this build dirty.
+    //
+    // Only build() re-runs. `body` is the same Widget instance every time, so
+    // the element for the app's content is re-parented rather than rebuilt.
+    final bar = bottomBar;
+    final barResize =
+        bar is GlassDynamicPreferredSize ? bar.preferredSizeListenable : null;
+    if (barResize != null) {
+      return ListenableBuilder(
+        listenable: barResize,
+        builder: _buildContent,
+      );
+    }
+    return _buildContent(context, null);
+  }
+
+  Widget _buildContent(BuildContext context, Widget? _) {
     final mediaQuery = MediaQuery.of(context);
     final topPad = mediaQuery.padding.top;
     final botPad = mediaQuery.padding.bottom;

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -10,13 +10,17 @@ import '../shared/inherited_liquid_glass.dart';
 import 'shared/glass_search_bar_config.dart';
 import 'shared/tab_bar_accessory_placement.dart';
 import 'shared/tab_bar_extra_button.dart';
+import 'shared/tab_bar_minimize_controller.dart';
 import 'shared/tab_bar_searchable_controller.dart';
 import 'shared/tab_bar_types.dart';
+import '../../src/widgets/surfaces/dynamic_preferred_size.dart';
 import '../../src/widgets/surfaces/tab_bar_bottom_layout.dart';
 import '../../src/widgets/surfaces/tab_bar_searchable_layout.dart';
 
+export 'shared/glass_bar_minimize_behavior.dart';
 export 'shared/glass_search_bar_config.dart';
 export 'shared/tab_bar_accessory_placement.dart';
+export 'shared/tab_bar_minimize_controller.dart';
 export 'shared/tab_bar_extra_button.dart'
     show
         GlassTabBarExtraButton,
@@ -152,7 +156,7 @@ enum _GlassTabBarPlacement { bottom, searchable, minimizable, inline }
 /// GlassTabBar.bottom(tabs: [...], ...)
 /// GlassTabBar.searchable(tabs: [...], searchConfig: ..., ...)
 /// ```
-class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
+class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
   // ─── Bottom constructor ────────────────────────────────────────────────────
 
   /// Creates a floating bottom tab bar — the iOS 26 `UITabBarController` equivalent.
@@ -597,12 +601,39 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
   /// An app that wants a button only while minimized simply passes it only
   /// while [minimized] is true — the appearing button grows in at the
   /// trailing edge as the tab pill shrinks to its circle.
+  ///
+  /// ### Minimizing on scroll
+  ///
+  /// Pass a [GlassTabBarMinimizeController] as [minimizeController] and the
+  /// bar minimizes itself from the scroll view given to [scrollController] —
+  /// the equivalent of `.tabBarMinimizeBehavior(.onScrollDown)`. The
+  /// controller then owns the state and [minimized] is ignored:
+  ///
+  /// ```dart
+  /// GlassTabBar.minimizable(
+  ///   tabs: tabs,
+  ///   selectedIndex: index,
+  ///   onTabSelected: onTabSelected,
+  ///   minimizeController: _minimize,
+  ///   scrollController: _scroll,
+  ///   onMinimizedTabTap: _minimize.expand,
+  /// )
+  /// ```
+  ///
+  /// Without one, [minimized] stays a plain controlled prop and the caller
+  /// decides when to flip it.
+  ///
+  /// A [bottomAccessory] follows the bar: with no explicit
+  /// [bottomAccessoryPlacement] it moves inline as the bar minimizes, the way
+  /// iOS 26 animates a `tabViewBottomAccessory` down into the minimized bar.
+  /// Pass [GlassTabBarAccessoryPlacement.expanded] to pin it.
   const GlassTabBar.minimizable({
     required List<GlassTab> tabs,
     required int selectedIndex,
     required ValueChanged<int> onTabSelected,
     Key? key,
     bool minimized = false,
+    GlassTabBarMinimizeController? minimizeController,
     VoidCallback? onMinimizedTabTap,
     GlassTabBarTrailingButton? trailingButton,
     Widget? bottomAccessory,
@@ -672,6 +703,7 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
           isSearchActive: minimized,
           onMinimizedTabTap: onMinimizedTabTap,
           trailingButton: trailingButton,
+          minimizeController: minimizeController,
           bottomAccessoryPlacement: bottomAccessoryPlacement,
           bottomAccessory: bottomAccessory,
           bottomAccessoryEnabled: bottomAccessoryEnabled,
@@ -798,6 +830,7 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
       // Minimizable-only
       this.onMinimizedTabTap,
       this.trailingButton,
+      this.minimizeController,
       this.springDescription,
       this.tabPillAnchor = GlassTabPillAnchor.start,
       this.onBarTap,
@@ -810,6 +843,12 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
         assert(
           selectedIndex >= 0 && selectedIndex < tabs.length,
           'selectedIndex must be within bounds of tabs list',
+        ),
+        assert(
+          minimizeController == null || !isSearchActive,
+          'Pass either minimizeController or minimized: true, not both — the '
+          'controller owns the minimize state when supplied, so a hardcoded '
+          'minimized: true would be silently ignored.',
         ),
         assert(
           bottomAccessory == null || bottomAccessoryHeight != null,
@@ -1091,15 +1130,36 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
   /// Scroll controller wired for searchable whitening and bottom-bar collapse.
   final ScrollController? scrollController;
 
+  /// Drives [minimized] from scrolling on the minimizable placement — the
+  /// equivalent of SwiftUI's `.tabBarMinimizeBehavior(_:)`.
+  ///
+  /// When supplied it owns the minimize state and [minimized] is ignored;
+  /// pass the same [ScrollController] to [scrollController] and to the scroll
+  /// view the bar floats over. See [GlassTabBarMinimizeController].
+  final GlassTabBarMinimizeController? minimizeController;
+
+  /// Whether the bar is minimized right now, from whichever source owns it.
+  bool get _effectiveMinimized =>
+      minimizeController?.minimized ?? isSearchActive;
+
+  /// The bar only changes height on its own when a minimize controller drives
+  /// it — otherwise the size follows the widget's own props and the scaffold
+  /// re-reads it on the rebuild that changed them.
+  @override
+  Listenable? get preferredSizeListenable => minimizeController;
+
   @override
   Size get preferredSize {
+    final minimized = _effectiveMinimized;
+    final isMinimizable = _placement == _GlassTabBarPlacement.minimizable;
+    final isMorphing =
+        _placement == _GlassTabBarPlacement.searchable || isMinimizable;
+
     // Base pill height. The searchable variant alternates between barHeight
     // (expanded) and searchBarHeight (inline/mini) — use whichever is active.
     // Both branches multiply verticalPadding by 2 (top + bottom) to match
     // the symmetric Padding applied inside AdaptiveLiquidGlassLayer.
-    final effectivePillH = ((_placement == _GlassTabBarPlacement.searchable ||
-                _placement == _GlassTabBarPlacement.minimizable) &&
-            isSearchActive)
+    final effectivePillH = (isMorphing && minimized)
         ? searchBarHeight + verticalPadding * 2
         : barHeight + verticalPadding * 2;
 
@@ -1118,11 +1178,8 @@ class GlassTabBar extends StatefulWidget implements PreferredSizeWidget {
       // Guard: gapAdjustment only makes sense in the searchable placement when
       // both heights differ. For .bottom placement isSearchActive is always false
       // so effectivePillH == barHeight + vertPad*2 and gapAdjustment == 0.
-      final gapAdjustment = ((_placement == _GlassTabBarPlacement.searchable ||
-                  _placement == _GlassTabBarPlacement.minimizable) &&
-              isSearchActive)
-          ? barHeight - searchBarHeight
-          : 0.0;
+      final gapAdjustment =
+          (isMorphing && minimized) ? barHeight - searchBarHeight : 0.0;
       total = effectivePillH -
           gapAdjustment +
           bottomAccessorySpacing +
@@ -1144,8 +1201,32 @@ class _GlassTabBarState extends State<GlassTabBar> {
   GlassTabBarTrailingButton? _lastTrailingButton;
 
   @override
+  void initState() {
+    super.initState();
+    widget.minimizeController?.addListener(_onMinimizeChanged);
+  }
+
+  @override
   void didUpdateWidget(GlassTabBar oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (widget.minimizeController != oldWidget.minimizeController) {
+      oldWidget.minimizeController?.removeListener(_onMinimizeChanged);
+      widget.minimizeController?.addListener(_onMinimizeChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.minimizeController?.removeListener(_onMinimizeChanged);
+    super.dispose();
+  }
+
+  /// The bar has to subscribe on its own account, even though [GlassScaffold]
+  /// also listens: the scaffold re-parents the SAME [GlassTabBar] instance on
+  /// its rebuild, and the framework skips an update when the widget is
+  /// identical — so without this the bar would never re-render.
+  void _onMinimizeChanged() {
+    if (mounted) setState(() {});
   }
 
   @override
@@ -1325,7 +1406,8 @@ class _GlassTabBarState extends State<GlassTabBar> {
       onTabSelected: widget.onTabSelected,
       searchConfig: config,
       controller: widget.controller,
-      isSearchActive: widget.isSearchActive,
+      isSearchActive: widget._effectiveMinimized,
+      minimizeController: widget.minimizeController,
       extraButton: widget.extraButton,
       bottomAccessoryPlacement: widget.bottomAccessoryPlacement,
       bottomAccessory: widget.bottomAccessory,

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -623,10 +623,9 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
   /// Without one, [minimized] stays a plain controlled prop and the caller
   /// decides when to flip it.
   ///
-  /// A [bottomAccessory] follows the bar: with no explicit
-  /// [bottomAccessoryPlacement] it moves inline as the bar minimizes, the way
-  /// iOS 26 animates a `tabViewBottomAccessory` down into the minimized bar.
-  /// Pass [GlassTabBarAccessoryPlacement.expanded] to pin it.
+  /// A [bottomAccessory] does not follow the bar on its own — pass
+  /// [GlassTabBarAccessoryPlacement.inline] in the same rebuild the minimize
+  /// lands in and it animates down into the bar.
   const GlassTabBar.minimizable({
     required List<GlassTab> tabs,
     required int selectedIndex,

--- a/lib/widgets/surfaces/shared/glass_bar_minimize_behavior.dart
+++ b/lib/widgets/surfaces/shared/glass_bar_minimize_behavior.dart
@@ -1,0 +1,50 @@
+/// How a bar minimizes in response to scrolling.
+///
+/// Mirrors SwiftUI's `TabBarMinimizeBehavior` and UIKit's
+/// `UITabBarController.MinimizeBehavior`, one case for one case.
+///
+/// Pass to a [GlassTabBarMinimizeController] and drive
+/// [GlassTabBar.minimizable] from it:
+///
+/// ```dart
+/// final _minimize = GlassTabBarMinimizeController(
+///   behavior: GlassBarMinimizeBehavior.onScrollDown,
+/// );
+/// ```
+///
+/// On iOS, minimizing is an **iPhone-only** behaviour — the iPad tab bar is a
+/// top bar and never minimizes. This package does not gate on platform or
+/// screen size: [GlassTabBar.minimizable] is a bottom bar by construction, and
+/// a behaviour that silently switches itself off on a large screen is far
+/// harder to debug than one that always does what it says. If you want iPad
+/// parity, choose a different surface for the regular size class rather than
+/// relying on the minimize disabling itself.
+enum GlassBarMinimizeBehavior {
+  /// Resolves to the system default minimize behaviour.
+  ///
+  /// Apple documents `.automatic` only as "the system default" and does not
+  /// say what it resolves to, nor guarantee it stays fixed. On iOS 26 it is
+  /// *observed* to mean no minimization on iPhone, so this package resolves
+  /// [automatic] to [never] — matching what a user sees on device today, and
+  /// keeping the default non-breaking for bars that never opted in.
+  ///
+  /// Because that resolution is an observation rather than a documented
+  /// contract, opt in explicitly with [onScrollDown] rather than relying on
+  /// it.
+  automatic,
+
+  /// The bar does not minimize.
+  never,
+
+  /// The bar minimizes when scrolling down, and expands when scrolling back
+  /// up.
+  onScrollDown,
+
+  /// The bar minimizes when scrolling up, and expands when scrolling back
+  /// down.
+  ///
+  /// Recommended when the scroll view's content is aligned to the bottom — a
+  /// chat transcript, a log — where the resting position is the end of the
+  /// content rather than the start.
+  onScrollUp,
+}

--- a/lib/widgets/surfaces/shared/tab_bar_minimize_controller.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_minimize_controller.dart
@@ -1,0 +1,408 @@
+// Scroll-driven minimize state machine for GlassTabBar.minimizable.
+//
+// The decision function ([GlassTabBarMinimizeController.handleSample]) takes a
+// plain value object rather than a ScrollPosition, so every branch of the
+// behaviour can be unit tested without a widget tree — the same constraint
+// SearchableBottomBarController is written under.
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart' show ScrollDirection;
+import 'package:flutter/widgets.dart' show ScrollController, ScrollPosition;
+
+import 'glass_bar_minimize_behavior.dart';
+
+// =============================================================================
+// GlassTabBarScrollSample — one observation of a scroll view
+// =============================================================================
+
+/// A single sample of a scroll view's state, fed to
+/// [GlassTabBarMinimizeController.handleSample].
+///
+/// Exists so the minimize decision can be driven from synthetic values in
+/// tests, without a live [ScrollPosition].
+@immutable
+class GlassTabBarScrollSample {
+  /// Creates a scroll sample.
+  const GlassTabBarScrollSample({
+    required this.pixels,
+    required this.minScrollExtent,
+    required this.maxScrollExtent,
+    required this.viewportDimension,
+    required this.direction,
+    required this.outOfRange,
+  });
+
+  /// Reads the sample from a live scroll position.
+  GlassTabBarScrollSample.fromPosition(ScrollPosition position)
+      : pixels = position.pixels,
+        minScrollExtent = position.minScrollExtent,
+        maxScrollExtent = position.maxScrollExtent,
+        viewportDimension = position.viewportDimension,
+        direction = position.userScrollDirection,
+        outOfRange = position.outOfRange;
+
+  /// Current scroll offset.
+  final double pixels;
+
+  /// Offset of the start of the content.
+  final double minScrollExtent;
+
+  /// Offset of the end of the content.
+  final double maxScrollExtent;
+
+  /// Height of the viewport, used to recognise teleports.
+  final double viewportDimension;
+
+  /// The direction the user is scrolling in.
+  ///
+  /// [ScrollDirection.idle] means the offset changed without a scrolling
+  /// activity behind it — a `jumpTo`, a `PageStorage` restore, a keyboard
+  /// viewport inset, or a layout correction. See
+  /// [GlassTabBarMinimizeController.handleSample].
+  final ScrollDirection direction;
+
+  /// Whether the offset is currently outside the content range (rubber-band).
+  final bool outOfRange;
+}
+
+// =============================================================================
+// GlassTabBarMinimizeController
+// =============================================================================
+
+/// Drives [GlassTabBar.minimizable]'s minimize state from scrolling — the
+/// equivalent of SwiftUI's `.tabBarMinimizeBehavior(_:)`.
+///
+/// Create one per screen, give the bar both this controller and the scroll
+/// view's [ScrollController], and dispose it in `State.dispose()`. The bar
+/// reads its minimized state through the controller, so [GlassScaffold] stays
+/// in sync with the bar's real height — including the bottom edge fade and,
+/// with `extendBody: false`, the body inset.
+///
+/// ```dart
+/// class _HomeState extends State<Home> {
+///   final _scroll = ScrollController();
+///   final _minimize = GlassTabBarMinimizeController(
+///     behavior: GlassBarMinimizeBehavior.onScrollDown,
+///   );
+///
+///   @override
+///   void dispose() {
+///     _minimize.dispose();
+///     _scroll.dispose();
+///     super.dispose();
+///   }
+///
+///   @override
+///   Widget build(BuildContext context) => GlassScaffold(
+///         body: ListView.builder(controller: _scroll, ...),
+///         bottomBar: GlassTabBar.minimizable(
+///           tabs: _tabs,
+///           selectedIndex: _index,
+///           onTabSelected: (i) => setState(() => _index = i),
+///           minimizeController: _minimize,
+///           scrollController: _scroll,
+///           onMinimizedTabTap: _minimize.expand,
+///         ),
+///       );
+/// }
+/// ```
+///
+/// This controller **borrows** the [ScrollController] it observes and never
+/// disposes it — that belongs to the scroll view.
+class GlassTabBarMinimizeController extends ChangeNotifier {
+  /// Creates a minimize controller.
+  ///
+  /// [behavior] defaults to [GlassBarMinimizeBehavior.automatic], which
+  /// resolves to [GlassBarMinimizeBehavior.never] — opt in explicitly with
+  /// [GlassBarMinimizeBehavior.onScrollDown].
+  GlassTabBarMinimizeController({
+    GlassBarMinimizeBehavior behavior = GlassBarMinimizeBehavior.automatic,
+  }) : _behavior = behavior;
+
+  // ── Thresholds ────────────────────────────────────────────────────────────
+  //
+  // The trigger is distance accumulated since the last direction reversal, NOT
+  // a per-sample delta.
+  //
+  // A per-sample gate (`delta >= 12.0`, which the tab bar's since-removed
+  // collapse-to-extra-button used) is really a test on v/f: a scroll listener
+  // fires about once per frame, so the delta is velocity ÷ refresh rate. That
+  // makes the activation velocity 720 px/s at 60 Hz but 1440 px/s on a 120 Hz
+  // ProMotion display — and ProMotion switches rate adaptively, so it is not
+  // even stable on one device. It also never fired at all on a slow deliberate
+  // scroll, and fired spuriously on a dropped frame (one sample carrying three
+  // frames of travel). That frame-rate coupling is why the pattern was pulled
+  // in 1.0.0 as "unreliable on 120 Hz ProMotion displays".
+  //
+  // Accumulated distance has no such coupling: summing v/f over f·Δt samples
+  // gives v·Δt. Same finger travel, same trigger, on every device and at every
+  // refresh rate.
+  //
+  // Corollary, and the easy way to reintroduce the bug: never reset the
+  // accumulator on a timer, and never derive a velocity from the samples.
+  // Both put f back into the predicate.
+
+  /// Downward travel, since the last direction reversal, that reads as intent
+  /// to minimize.
+  ///
+  /// Roughly 1.5 lines of body text, or about 100 ms at a typical 200 px/s
+  /// reading scroll: far enough that a thumb resting on a settling list cannot
+  /// trip it, near enough that the bar is already shrinking before the first
+  /// row leaves the viewport.
+  static const double kMinimizeThreshold = 20.0;
+
+  /// Upward travel that re-expands.
+  ///
+  /// Deliberately smaller than [kMinimizeThreshold]: getting your tabs back
+  /// should be cheap, while losing them should take intent. The asymmetry also
+  /// stops the two thresholds forming a symmetric dead-band, which makes a
+  /// scrub up and down feel sticky.
+  static const double kExpandThreshold = 12.0;
+
+  /// Scrollable extent below which the content is treated as non-scrollable.
+  ///
+  /// Above [kMinimizeThreshold] on purpose — otherwise a page with 25 px of
+  /// scroll could minimize and immediately hit the end, shrinking the bar to
+  /// reveal nothing.
+  static const double kMinScrollableExtent = 40.0;
+
+  // ── State ─────────────────────────────────────────────────────────────────
+
+  GlassBarMinimizeBehavior _behavior;
+  bool _minimized = false;
+  bool _disposed = false;
+
+  /// Previous sampled offset. Null until the next sample establishes it.
+  double? _baseline;
+
+  /// Signed travel since the last direction reversal, in "minimizing is
+  /// positive" space (see [_effectiveDelta]).
+  double _accumulated = 0.0;
+
+  ScrollController? _scrollController;
+
+  /// Whether the bar is currently minimized.
+  bool get minimized => _minimized;
+
+  /// The scroll view currently being observed, if any.
+  ScrollController? get scrollController => _scrollController;
+
+  /// How scrolling maps to minimizing.
+  GlassBarMinimizeBehavior get behavior => _behavior;
+
+  /// Sets the behaviour. Switching to one that does not minimize expands the
+  /// bar immediately, so it can never be left stranded.
+  set behavior(GlassBarMinimizeBehavior value) {
+    if (_behavior == value) return;
+    _behavior = value;
+    _accumulated = 0.0;
+    if (!_minimizes) {
+      _setMinimized(false);
+    } else {
+      notifyListeners();
+    }
+  }
+
+  /// [behavior] with [GlassBarMinimizeBehavior.automatic] resolved.
+  GlassBarMinimizeBehavior get resolvedBehavior =>
+      _behavior == GlassBarMinimizeBehavior.automatic
+          ? GlassBarMinimizeBehavior.never
+          : _behavior;
+
+  bool get _minimizes =>
+      resolvedBehavior == GlassBarMinimizeBehavior.onScrollDown ||
+      resolvedBehavior == GlassBarMinimizeBehavior.onScrollUp;
+
+  // ── Imperative control ────────────────────────────────────────────────────
+
+  /// Minimizes the bar.
+  ///
+  /// Does nothing when [resolvedBehavior] does not minimize.
+  void minimize() {
+    if (!_minimizes) return;
+    _accumulated = 0.0;
+    _setMinimized(true);
+  }
+
+  /// Expands the bar.
+  ///
+  /// Always allowed, whatever the behaviour — expanding can only restore the
+  /// default state. Wire this to `onMinimizedTabTap` so the "bring my tabs
+  /// back" tap and the scroll state machine agree; otherwise the tap would
+  /// clear the app's flag while this controller still believed the bar was
+  /// minimized, and the next downward scroll would appear to do nothing.
+  void expand() {
+    _accumulated = 0.0;
+    _setMinimized(false);
+  }
+
+  // ── Attachment ────────────────────────────────────────────────────────────
+
+  /// Observes [controller], replacing any previously attached one.
+  ///
+  /// Call this when the driving scroll view changes — on iOS each tab owns its
+  /// own scroll view, and UIKit re-resolves `contentScrollView(for: .bottom)`
+  /// on every tab change. Pass `null`, or use [detach], to stop observing.
+  ///
+  /// The minimized state is deliberately left alone: attaching happens during
+  /// a build, so changing it here would have to notify listeners mid-build.
+  /// Call [expand] from your `onTabSelected` if you want the bar to come back
+  /// when the user switches tabs.
+  void attach(ScrollController? controller) {
+    if (_disposed || identical(controller, _scrollController)) return;
+    // Safe even if the app disposed its ScrollController first —
+    // ChangeNotifier.removeListener is documented to tolerate that.
+    _scrollController?.removeListener(_onScroll);
+    _scrollController = controller;
+    // A delta measured across two different scroll views is meaningless, and
+    // would read as one enormous jump.
+    _baseline = null;
+    _accumulated = 0.0;
+    _scrollController?.addListener(_onScroll);
+  }
+
+  /// Stops observing the current scroll view. The bar keeps its current state.
+  void detach() => attach(null);
+
+  /// The attached position, or null when it cannot be read safely.
+  ///
+  /// [ScrollController.position] throws when the controller has more than one
+  /// attached position, which happens for a few hundred milliseconds whenever
+  /// two scroll views share a controller across an `AnimatedSwitcher`
+  /// cross-fade or a `Navigator` transition. Not sampling during that window
+  /// is the correct behaviour — `GlassScaffold` guards its header fade the
+  /// same way.
+  ScrollPosition? get _singlePosition {
+    final controller = _scrollController;
+    if (controller == null || !controller.hasClients) return null;
+    if (controller.positions.length != 1) return null;
+    return controller.positions.single;
+  }
+
+  void _onScroll() {
+    if (_disposed) return;
+    final position = _singlePosition;
+    if (position == null) {
+      _baseline = null;
+      _accumulated = 0.0;
+      return;
+    }
+    handleSample(GlassTabBarScrollSample.fromPosition(position));
+  }
+
+  // ── The decision function ─────────────────────────────────────────────────
+
+  /// Feeds one scroll sample to the state machine.
+  ///
+  /// Pure with respect to Flutter — visible for testing so the behaviour can
+  /// be driven from synthetic samples.
+  ///
+  /// The order of the rules matters, and each early return also decides
+  /// whether the accumulator survives.
+  @visibleForTesting
+  void handleSample(GlassTabBarScrollSample sample) {
+    if (!_minimizes) return;
+
+    final previous = _baseline;
+    _baseline = sample.pixels;
+
+    // 1. Content that cannot scroll never minimizes — and content that shrinks
+    //    below the threshold while minimized must expand, or the bar is
+    //    stranded as a circle with nothing to scroll back.
+    if (sample.maxScrollExtent - sample.minScrollExtent <
+        kMinScrollableExtent) {
+      _accumulated = 0.0;
+      _setMinimized(false);
+      return;
+    }
+
+    // 2. At the resting edge, always expand — no threshold, no accumulation.
+    //    `<=` rather than `==` so top rubber-band counts as "at the top":
+    //    outOfRange is strict, so pixels == 0.0 is not out of range and would
+    //    otherwise fall through to the accumulator below.
+    if (_atRestingEdge(sample)) {
+      _accumulated = 0.0;
+      _setMinimized(false);
+      return;
+    }
+
+    // 3. First sample after attaching — establish the baseline, decide
+    //    nothing. This is what stops a restored scroll offset from minimizing
+    //    the bar before the user has touched anything.
+    if (previous == null) return;
+
+    final delta = sample.pixels - previous;
+
+    // 4. Not a user scroll at all: jumpTo, a PageStorage restore, the keyboard
+    //    changing the viewport inset, or a layout correction. None of these
+    //    begin a scrolling activity, so the direction is still idle — whereas
+    //    a real drag, and the entire momentum phase after it, is not.
+    if (sample.direction == ScrollDirection.idle) {
+      _accumulated = 0.0;
+      return;
+    }
+
+    // 5. A teleport rather than a scroll. Covers animateTo, which keeps a
+    //    stale non-idle direction, and single-frame content-dimension jumps.
+    if (delta.abs() > sample.viewportDimension * 0.5) {
+      _accumulated = 0.0;
+      return;
+    }
+
+    // 6. Rubber-band at the far edge: the offset keeps moving with no intent
+    //    behind it. This must sit after the idle check and before accumulation
+    //    — during a bounce the delta reverses sign while the direction is
+    //    still the direction of the fling, which would otherwise read as a
+    //    scroll back the other way and expand the bar.
+    if (sample.outOfRange) {
+      _accumulated = 0.0;
+      return;
+    }
+
+    // 7. Accumulate since the last reversal.
+    final effective = _effectiveDelta(delta);
+    if (effective == 0.0) return;
+    if (effective.sign != _accumulated.sign) _accumulated = 0.0;
+    _accumulated += effective;
+
+    if (_accumulated >= kMinimizeThreshold) {
+      _accumulated = 0.0;
+      _setMinimized(true);
+    } else if (_accumulated <= -kExpandThreshold) {
+      _accumulated = 0.0;
+      _setMinimized(false);
+    }
+  }
+
+  /// Maps a raw offset delta into "minimizing is positive" space.
+  ///
+  /// [GlassBarMinimizeBehavior.onScrollUp] is the same state machine with the
+  /// input sign flipped — never a second code path.
+  double _effectiveDelta(double delta) =>
+      resolvedBehavior == GlassBarMinimizeBehavior.onScrollUp ? -delta : delta;
+
+  /// Whether the content is at the edge it rests at.
+  ///
+  /// For [GlassBarMinimizeBehavior.onScrollDown] that is the start of the
+  /// content. For [GlassBarMinimizeBehavior.onScrollUp] — recommended for
+  /// bottom-aligned content — it is the end.
+  bool _atRestingEdge(GlassTabBarScrollSample sample) =>
+      resolvedBehavior == GlassBarMinimizeBehavior.onScrollUp
+          ? sample.pixels >= sample.maxScrollExtent
+          : sample.pixels <= sample.minScrollExtent;
+
+  void _setMinimized(bool value) {
+    if (_minimized == value) return; // idempotent — no notify storm
+    _minimized = value;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _scrollController?.removeListener(_onScroll);
+    _scrollController = null;
+    _disposed = true;
+    super.dispose();
+  }
+}

--- a/lib/widgets/surfaces/shared/tab_bar_searchable_controller.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_searchable_controller.dart
@@ -441,10 +441,18 @@ class SearchableBottomBarController extends ChangeNotifier {
   // ── Convenience spring factory ────────────────────────────────────────────
 
   /// Creates a [SpringSimulation] from [from] → [to] using [spring].
+  ///
+  /// [velocity] carries the in-flight speed of the axis being retargeted.
+  /// Passing it matters whenever a morph reverses before it settles — which
+  /// scroll-driven minimizing makes routine, since scrolling down and straight
+  /// back up is an ordinary gesture. Relaunching from rest in that case reads
+  /// as a stall followed by a restart. Defaults to 0.0, which is what an idle
+  /// [AnimationController] reports, so a first-launch spring is unchanged.
   static SpringSimulation makeSpring({
     required SpringDescription spring,
     required double from,
     required double to,
+    double velocity = 0.0,
   }) =>
-      SpringSimulation(spring, from, to, 0.0);
+      SpringSimulation(spring, from, to, velocity);
 }

--- a/test/widgets/surfaces/glass_tab_bar_scroll_to_minimize_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_scroll_to_minimize_test.dart
@@ -1,0 +1,328 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _testTabs = [
+  GlassTab(label: 'For You', icon: Icon(CupertinoIcons.news)),
+  GlassTab(label: 'Following', icon: Icon(CupertinoIcons.person_2)),
+  GlassTab(label: 'Saved', icon: Icon(CupertinoIcons.bookmark)),
+];
+
+/// Expanded height with the defaults: barHeight 64 + verticalPadding 20 * 2.
+const _expandedHeight = 104.0;
+
+/// Minimized: minimizedBarHeight 50 + 40.
+const _minimizedHeight = 90.0;
+
+double _barHeight(WidgetTester tester) =>
+    tester.widget<GlassTabBar>(find.byType(GlassTabBar)).preferredSize.height;
+
+/// A scaffold whose body scrolls under a minimizable bar.
+Widget _app({
+  required GlassTabBarMinimizeController minimize,
+  required ScrollController scroll,
+  int itemCount = 60,
+  bool extendBody = true,
+  Widget? bottomAccessory,
+  GlassTabBarAccessoryPlacement? accessoryPlacement,
+}) {
+  return MaterialApp(
+    home: GlassScaffold(
+      extendBody: extendBody,
+      edgeFade: false,
+      body: ListView.builder(
+        controller: scroll,
+        itemCount: itemCount,
+        itemBuilder: (_, i) => SizedBox(height: 60, child: Text('row $i')),
+      ),
+      bottomBar: GlassTabBar.minimizable(
+        tabs: _testTabs,
+        selectedIndex: 0,
+        onTabSelected: (_) {},
+        minimizeController: minimize,
+        scrollController: scroll,
+        onMinimizedTabTap: minimize.expand,
+        bottomAccessory: bottomAccessory,
+        bottomAccessoryHeight: bottomAccessory == null ? null : 48,
+        bottomAccessoryPlacement: accessoryPlacement,
+        maskingQuality: MaskingQuality.off,
+      ),
+    ),
+  );
+}
+
+/// Drags the list by [dy] in many small steps, the way a finger actually
+/// moves. `tester.drag` dispatches the whole delta in about two move events,
+/// which cannot exercise a threshold that accumulates.
+Future<void> _slowDrag(WidgetTester tester, double dy) async {
+  final gesture = await tester.startGesture(const Offset(200, 300));
+  const steps = 12;
+  for (var i = 0; i < steps; i++) {
+    await gesture.moveBy(Offset(0, dy / steps));
+    await tester.pump(const Duration(milliseconds: 16));
+  }
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('GlassTabBar.minimizable — scroll to minimize', () {
+    testWidgets('a slow scroll down minimizes, and back up expands',
+        (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(_app(minimize: minimize, scroll: scroll));
+      await tester.pumpAndSettle();
+      expect(_barHeight(tester), _expandedHeight);
+
+      await _slowDrag(tester, -80); // content up = scrolling down
+      expect(minimize.minimized, isTrue);
+      expect(_barHeight(tester), _minimizedHeight);
+
+      await _slowDrag(tester, 40);
+      expect(minimize.minimized, isFalse);
+      expect(_barHeight(tester), _expandedHeight);
+    });
+
+    testWidgets('a fling minimizes and stays minimized once it settles',
+        (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(_app(minimize: minimize, scroll: scroll));
+      await tester.pumpAndSettle();
+
+      await tester.fling(find.byType(ListView), const Offset(0, -300), 2000);
+      await tester.pumpAndSettle();
+
+      // The state is latched, so it survives userScrollDirection going idle
+      // when the ballistic activity ends — that is what makes momentum safe.
+      expect(minimize.minimized, isTrue);
+      expect(_barHeight(tester), _minimizedHeight);
+    });
+
+    testWidgets('scrolling back to the top expands', (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(_app(minimize: minimize, scroll: scroll));
+      await tester.pumpAndSettle();
+      await _slowDrag(tester, -80);
+      expect(minimize.minimized, isTrue);
+
+      await tester.fling(find.byType(ListView), const Offset(0, 600), 3000);
+      await tester.pumpAndSettle();
+      expect(scroll.position.pixels, 0);
+      expect(minimize.minimized, isFalse);
+    });
+
+    testWidgets('content shorter than the viewport never minimizes',
+        (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(
+        _app(minimize: minimize, scroll: scroll, itemCount: 2),
+      );
+      await tester.pumpAndSettle();
+
+      await _slowDrag(tester, -120);
+      expect(minimize.minimized, isFalse);
+      expect(_barHeight(tester), _expandedHeight);
+    });
+
+    testWidgets('tapping the minimized circle expands', (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(_app(minimize: minimize, scroll: scroll));
+      await tester.pumpAndSettle();
+      await _slowDrag(tester, -80);
+      expect(minimize.minimized, isTrue);
+
+      await tester.tap(find.byIcon(CupertinoIcons.news).first);
+      await tester.pumpAndSettle();
+      expect(minimize.minimized, isFalse);
+      expect(_barHeight(tester), _expandedHeight);
+    });
+
+    testWidgets('never does not minimize', (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.never,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(_app(minimize: minimize, scroll: scroll));
+      await tester.pumpAndSettle();
+
+      await _slowDrag(tester, -200);
+      expect(minimize.minimized, isFalse);
+    });
+  });
+
+  group('GlassTabBar.minimizable — scaffold synchronisation', () {
+    testWidgets('the body inset tracks the bar with extendBody: false',
+        (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(
+        _app(minimize: minimize, scroll: scroll, extendBody: false),
+      );
+      await tester.pumpAndSettle();
+      final expandedBody = tester.getRect(find.byType(ListView));
+
+      minimize.minimize();
+      await tester.pumpAndSettle();
+      final minimizedBody = tester.getRect(find.byType(ListView));
+
+      // The bar shrank by 14, so the body it sits above grows by the same.
+      expect(
+        minimizedBody.height - expandedBody.height,
+        _expandedHeight - _minimizedHeight,
+        reason: 'GlassScaffold must re-read preferredSize when the bar '
+            'minimizes from its own state',
+      );
+    });
+
+    testWidgets('the bar re-renders even though the widget instance is reused',
+        (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(_app(minimize: minimize, scroll: scroll));
+      await tester.pumpAndSettle();
+      final expandedBar = tester.getSize(find.byType(GlassTabBar));
+
+      // No pumpWidget — nothing above the bar rebuilds, so only the bar's own
+      // subscription can drive this.
+      minimize.minimize();
+      await tester.pumpAndSettle();
+
+      expect(tester.getSize(find.byType(GlassTabBar)).height,
+          lessThan(expandedBar.height));
+    });
+  });
+
+  group('GlassTabBar.minimizable — lifecycle', () {
+    testWidgets('asserts when both a controller and minimized: true are passed',
+        (tester) async {
+      expect(
+        () => GlassTabBar.minimizable(
+          tabs: _testTabs,
+          selectedIndex: 0,
+          onTabSelected: (_) {},
+          minimized: true,
+          minimizeController: GlassTabBarMinimizeController(),
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    testWidgets('swapping the scroll controller re-targets without a spurious '
+        'minimize', (tester) async {
+      final first = ScrollController();
+      addTearDown(first.dispose);
+      final second = ScrollController(initialScrollOffset: 900);
+      addTearDown(second.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(_app(minimize: minimize, scroll: first));
+      await tester.pumpAndSettle();
+
+      // A new tab with its own, already-scrolled list. The cross-controller
+      // delta would be +900 if the baseline were not reset.
+      await tester.pumpWidget(_app(minimize: minimize, scroll: second));
+      await tester.pumpAndSettle();
+
+      expect(minimize.minimized, isFalse);
+      expect(minimize.scrollController, same(second));
+    });
+
+    testWidgets('one controller on two mounted lists does not throw',
+        (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      // The AnimatedSwitcher / Navigator-transition case: two scroll views
+      // share one controller, so ScrollController.position throws.
+      await tester.pumpWidget(MaterialApp(
+        home: GlassScaffold(
+          body: Column(
+            children: [
+              Expanded(
+                child: ListView(
+                  controller: scroll,
+                  children: const [SizedBox(height: 2000)],
+                ),
+              ),
+              Expanded(
+                child: ListView(
+                  controller: scroll,
+                  children: const [SizedBox(height: 2000)],
+                ),
+              ),
+            ],
+          ),
+          bottomBar: GlassTabBar.minimizable(
+            tabs: _testTabs,
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            minimizeController: minimize,
+            scrollController: scroll,
+            maskingQuality: MaskingQuality.off,
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.byType(ListView).first, const Offset(0, -100));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/widgets/surfaces/glass_tab_bar_scroll_to_minimize_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_scroll_to_minimize_test.dart
@@ -28,8 +28,6 @@ Widget _app({
   required ScrollController scroll,
   int itemCount = 60,
   bool extendBody = true,
-  Widget? bottomAccessory,
-  GlassTabBarAccessoryPlacement? accessoryPlacement,
 }) {
   return MaterialApp(
     home: GlassScaffold(
@@ -47,9 +45,6 @@ Widget _app({
         minimizeController: minimize,
         scrollController: scroll,
         onMinimizedTabTap: minimize.expand,
-        bottomAccessory: bottomAccessory,
-        bottomAccessoryHeight: bottomAccessory == null ? null : 48,
-        bottomAccessoryPlacement: accessoryPlacement,
         maskingQuality: MaskingQuality.off,
       ),
     ),

--- a/test/widgets/surfaces/tab_bar_minimize_controller_test.dart
+++ b/test/widgets/surfaces/tab_bar_minimize_controller_test.dart
@@ -1,0 +1,309 @@
+import 'package:flutter/rendering.dart' show ScrollDirection;
+import 'package:flutter/widgets.dart' show ScrollController;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+GlassTabBarScrollSample _sample(
+  double pixels, {
+  ScrollDirection direction = ScrollDirection.reverse,
+  double min = 0,
+  double max = 2000,
+  double viewport = 800,
+  bool outOfRange = false,
+}) =>
+    GlassTabBarScrollSample(
+      pixels: pixels,
+      minScrollExtent: min,
+      maxScrollExtent: max,
+      viewportDimension: viewport,
+      direction: direction,
+      outOfRange: outOfRange,
+    );
+
+GlassTabBarMinimizeController _controller([
+  GlassBarMinimizeBehavior behavior = GlassBarMinimizeBehavior.onScrollDown,
+]) =>
+    GlassTabBarMinimizeController(behavior: behavior);
+
+/// Feeds a run of samples starting from [from], stepping by [step].
+void _scroll(
+  GlassTabBarMinimizeController c, {
+  required double from,
+  required double step,
+  required int count,
+  ScrollDirection direction = ScrollDirection.reverse,
+}) {
+  for (var i = 0; i <= count; i++) {
+    c.handleSample(_sample(from + i * step, direction: direction));
+  }
+}
+
+void main() {
+  group('GlassTabBarMinimizeController — frame-rate invariance', () {
+    // The regression test for the failure that got the tab bar's previous
+    // scroll-collapse removed in 1.0.0 ("unreliable on 120 Hz ProMotion
+    // displays"). The same physical gesture — 200 px/s for 120 ms — sampled at
+    // both refresh rates must produce the same outcome, and the per-sample
+    // delta is under the old 12.0 gate at BOTH rates, so this also proves the
+    // old gate was not ported forward.
+    for (final (label, hz) in [('60 Hz', 60.0), ('120 Hz ProMotion', 120.0)]) {
+      test('a slow deliberate scroll minimizes at $label', () {
+        final c = _controller();
+        const velocity = 200.0; // px/s — an ordinary reading scroll
+        final perSample = velocity / hz;
+
+        expect(
+          perSample,
+          lessThan(12.0),
+          reason: 'the removed per-sample gate would never have fired',
+        );
+
+        _scroll(c, from: 0, step: perSample, count: (hz * 0.12).round());
+
+        expect(c.minimized, isTrue);
+      });
+    }
+
+    test('a dropped frame fires at the same distance, not sooner', () {
+      final smooth = _controller();
+      _scroll(smooth, from: 100, step: 4, count: 4); // 100 -> 116, 16px
+
+      final janky = _controller();
+      janky.handleSample(_sample(100));
+      janky.handleSample(_sample(112)); // one sample carrying three frames
+      janky.handleSample(_sample(116));
+
+      expect(smooth.minimized, isFalse);
+      expect(janky.minimized, isFalse,
+          reason: '16px of travel is 16px however it was sampled');
+
+      smooth.handleSample(_sample(121));
+      janky.handleSample(_sample(121));
+      expect(smooth.minimized, isTrue);
+      expect(janky.minimized, isTrue);
+    });
+  });
+
+  group('GlassTabBarMinimizeController — direction detection', () {
+    test('minimizes once accumulated travel passes the threshold', () {
+      final c = _controller();
+      c.handleSample(_sample(100));
+      c.handleSample(_sample(115)); // 15px — under 20
+      expect(c.minimized, isFalse);
+      c.handleSample(_sample(122)); // 22px total
+      expect(c.minimized, isTrue);
+    });
+
+    test('jitter never minimizes', () {
+      final c = _controller();
+      c.handleSample(_sample(100));
+      for (var i = 0; i < 50; i++) {
+        c.handleSample(_sample(102, direction: ScrollDirection.reverse));
+        c.handleSample(_sample(100, direction: ScrollDirection.forward));
+      }
+      expect(c.minimized, isFalse);
+    });
+
+    test('a direction reversal zeroes the accumulator', () {
+      final c = _controller();
+      c.handleSample(_sample(100));
+      c.handleSample(_sample(118)); // +18, just under
+      c.handleSample(_sample(110, direction: ScrollDirection.forward)); // flip
+      c.handleSample(_sample(128)); // +18 again from a zeroed accumulator
+      expect(c.minimized, isFalse,
+          reason: 'the two +18 runs must not sum across the reversal');
+    });
+
+    test('expands on upward travel past the smaller expand threshold', () {
+      final c = _controller()..minimize();
+      expect(c.minimized, isTrue);
+      c.handleSample(_sample(500));
+      c.handleSample(_sample(494, direction: ScrollDirection.forward)); // -6
+      expect(c.minimized, isTrue);
+      c.handleSample(_sample(486, direction: ScrollDirection.forward)); // -14
+      expect(c.minimized, isFalse);
+    });
+
+    test('momentum keeps accumulating — the direction survives the lift-off',
+        () {
+      final c = _controller();
+      c.handleSample(_sample(100));
+      // Finger lifts after 8px; ballistic frames carry the rest, and
+      // userScrollDirection is not reset by goBallistic.
+      c.handleSample(_sample(108));
+      c.handleSample(_sample(140));
+      expect(c.minimized, isTrue);
+    });
+  });
+
+  group('GlassTabBarMinimizeController — guards', () {
+    test('a restored scroll offset does not minimize on the first sample', () {
+      final c = _controller();
+      c.handleSample(_sample(4000)); // PageStorage restore, nothing before it
+      expect(c.minimized, isFalse);
+    });
+
+    test('idle offset changes are ignored (jumpTo, keyboard inset)', () {
+      final c = _controller();
+      c.handleSample(_sample(500));
+      c.handleSample(_sample(800, direction: ScrollDirection.idle));
+      expect(c.minimized, isFalse);
+    });
+
+    test('a teleport is ignored even with a stale non-idle direction', () {
+      final c = _controller();
+      c.handleSample(_sample(100));
+      // animateTo across 60% of the viewport keeps direction == reverse.
+      c.handleSample(_sample(580));
+      expect(c.minimized, isFalse);
+    });
+
+    test('overscroll does not minimize, and the bounce back does not expand',
+        () {
+      final c = _controller()..minimize();
+      c.handleSample(_sample(1990));
+      c.handleSample(_sample(2030, outOfRange: true));
+      expect(c.minimized, isTrue);
+      // Bounce-back: pixels fall while the direction is still `reverse`.
+      c.handleSample(_sample(2000, outOfRange: true));
+      expect(c.minimized, isTrue);
+    });
+
+    test('non-scrollable content never minimizes', () {
+      final c = _controller();
+      c.handleSample(_sample(0, max: 20));
+      c.handleSample(_sample(15, max: 20));
+      expect(c.minimized, isFalse);
+    });
+
+    test('content shrinking below the scrollable floor expands a minimized bar',
+        () {
+      final c = _controller()..minimize();
+      expect(c.minimized, isTrue);
+      c.handleSample(_sample(0, max: 10));
+      expect(c.minimized, isFalse);
+    });
+
+    test('reaching the top expands with no threshold', () {
+      final c = _controller()..minimize();
+      c.handleSample(_sample(0));
+      expect(c.minimized, isFalse);
+    });
+
+    test('top overscroll counts as being at the top', () {
+      final c = _controller()..minimize();
+      c.handleSample(_sample(-30, outOfRange: true));
+      expect(c.minimized, isFalse);
+    });
+  });
+
+  group('GlassTabBarMinimizeController — behaviour', () {
+    test('automatic resolves to never and decides nothing', () {
+      final c = _controller(GlassBarMinimizeBehavior.automatic);
+      expect(c.resolvedBehavior, GlassBarMinimizeBehavior.never);
+      _scroll(c, from: 100, step: 10, count: 20);
+      expect(c.minimized, isFalse);
+    });
+
+    test('never decides nothing', () {
+      final c = _controller(GlassBarMinimizeBehavior.never);
+      _scroll(c, from: 100, step: 10, count: 20);
+      expect(c.minimized, isFalse);
+    });
+
+    test('minimize() is a no-op unless the behaviour minimizes', () {
+      expect((_controller(GlassBarMinimizeBehavior.never)..minimize()).minimized,
+          isFalse);
+      expect((_controller()..minimize()).minimized, isTrue);
+    });
+
+    test('switching to a non-minimizing behaviour expands immediately', () {
+      final c = _controller()..minimize();
+      expect(c.minimized, isTrue);
+      c.behavior = GlassBarMinimizeBehavior.never;
+      expect(c.minimized, isFalse);
+    });
+
+    test('onScrollUp mirrors onScrollDown', () {
+      final c = _controller(GlassBarMinimizeBehavior.onScrollUp);
+      c.handleSample(_sample(500, direction: ScrollDirection.forward));
+      c.handleSample(_sample(478, direction: ScrollDirection.forward));
+      expect(c.minimized, isTrue,
+          reason: 'scrolling up minimizes under onScrollUp');
+
+      c.handleSample(_sample(492));
+      expect(c.minimized, isFalse,
+          reason: 'scrolling back down expands under onScrollUp');
+    });
+
+    test('onScrollUp rests at the end of the content, not the start', () {
+      final c = _controller(GlassBarMinimizeBehavior.onScrollUp)..minimize();
+      c.handleSample(_sample(0));
+      expect(c.minimized, isTrue, reason: 'the top is not the resting edge');
+
+      c.handleSample(_sample(2000));
+      expect(c.minimized, isFalse, reason: 'the end is');
+    });
+  });
+
+  group('GlassTabBarMinimizeController — notifications and lifecycle', () {
+    test('notifies exactly once across a run of samples in one direction', () {
+      final c = _controller();
+      var notifications = 0;
+      c.addListener(() => notifications++);
+      _scroll(c, from: 100, step: 5, count: 20);
+      expect(c.minimized, isTrue);
+      expect(notifications, 1);
+    });
+
+    test('expand() on an already-expanded bar does not notify', () {
+      final c = _controller();
+      var notifications = 0;
+      c.addListener(() => notifications++);
+      c.expand();
+      expect(notifications, 0);
+    });
+
+    test('dispose() while attached does not throw, and stops deciding', () {
+      final c = _controller();
+      c.handleSample(_sample(100));
+      c.dispose();
+      expect(c.minimized, isFalse);
+    });
+
+    test('attach() is idempotent on identity', () {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final c = _controller();
+      addTearDown(c.dispose);
+      c
+        ..attach(scroll)
+        ..attach(scroll);
+      expect(c.scrollController, same(scroll));
+    });
+
+    test('attach() does not dispose the borrowed ScrollController', () {
+      final first = ScrollController();
+      addTearDown(first.dispose);
+      final second = ScrollController();
+      addTearDown(second.dispose);
+      final c = _controller();
+      addTearDown(c.dispose);
+
+      c
+        ..attach(first)
+        ..attach(second);
+
+      // Still usable — proves it was not disposed out from under the app.
+      expect(() => first.hasClients, returnsNormally);
+      expect(c.scrollController, same(second));
+    });
+
+    test('detach() stops observing but keeps the current state', () {
+      final c = _controller()..minimize();
+      c.detach();
+      expect(c.minimized, isTrue);
+      expect(c.scrollController, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Fixes #225 — the roadmap's scroll-to-minimize, which `ROADMAP.md` sketches as "tab bar shrinks on scroll-down, re-expands on scroll-up. Matches iOS 26 `tabBarMinimizeBehavior`."

`GlassTabBar.minimizable` (#219) shipped the morph but deliberately not the *policy* — `minimized` is a controlled prop and the caller decides when to flip it. This adds the policy: a controller that drives the minimize from a scroll view, the Flutter equivalent of `.tabBarMinimizeBehavior(_:)`.

```dart
final _scroll = ScrollController();
final _minimize = GlassTabBarMinimizeController(
  behavior: GlassBarMinimizeBehavior.onScrollDown,
);

GlassScaffold(
  body: ListView.builder(controller: _scroll, ...),
  bottomBar: GlassTabBar.minimizable(
    tabs: _tabs,
    selectedIndex: _index,
    onTabSelected: (i) => setState(() => _index = i),
    minimizeController: _minimize,      // owns `minimized` when supplied
    scrollController: _scroll,          // the existing param, reused
    onMinimizedTabTap: _minimize.expand,
  ),
)
```

New public surface is one enum, one controller, one optional parameter. `minimized` is untouched, so a bar without a controller is byte-for-byte the released behaviour.

`GlassBarMinimizeBehavior` mirrors [`TabBarMinimizeBehavior`](https://developer.apple.com/documentation/swiftui/tabbarminimizebehavior) case for case. `automatic` resolves to `never`: Apple documents it only as "the system default" without saying what that is, and on iOS 26 it's *observed* to mean no minimization on iPhone. The dartdoc says exactly that, and marks it as an observation rather than a contract.

## The threshold model, and why it isn't a per-frame delta

This is the load-bearing decision, because getting it wrong is what killed the last attempt. The collapse-to-extra-button pattern removed in 1.0.0 gated on `delta >= 12.0` where `delta` was one scroll-listener tick. A tick is a frame, so that predicate is really a test on `v/f`:

| Display | Velocity needed to trigger |
|---|---|
| 60 Hz | 720 px/s |
| 120 Hz ProMotion | 1440 px/s |

The same physical gesture needs to be twice as fast on ProMotion — and ProMotion switches rate adaptively with content and thermal state, so it isn't stable even on one device. A dropped frame makes one sample carry three frames of travel and fires it spuriously, so it's *hardest* to trigger on the smoothest device and easiest when the app is struggling. And at either refresh rate a slow deliberate reading scroll (~200 px/s) never crossed it at all. Which is the 1.0.0 note, from the inside:

> The collapse-to-extra-button pattern is not an iOS 26 design primitive and was unreliable on 120 Hz ProMotion displays.

So the trigger here is **distance accumulated since the last direction reversal**. Summing `v/f` over `f·Δt` samples gives `v·Δt` — `f` cancels, and the trigger becomes finger travel, identical on every device and at every refresh rate. It also inverts the other two failures: an adaptive refresh switch mid-gesture only changes how the same total is partitioned, and a dropped frame produces one large sample carrying the true travel instead of a false positive.

Two corollaries are commented in the source next to the constants, because they're the easy way to reintroduce the coupling: never reset the accumulator on a timer, and never derive a velocity from the samples. Both put `f` back into the predicate.

Thresholds are 20.0 to minimize and 12.0 to expand. The asymmetry is deliberate — getting your tabs back should be cheap, losing them should take intent — and it stops the pair forming a symmetric dead-band that makes a scrub up-and-down feel sticky.

## Behaviour

Documented by Apple: minimize on scroll down, expand on scrolling back up; `onScrollUp` inverted for bottom-aligned content. `onScrollUp` is the same state machine with the input sign flipped and the resting edge moved to the end of the content — one sign flip at the boundary, never a second code path.

Observed rather than documented, and marked as such in the dartdoc: expand on reaching the resting edge, expand on tapping the minimized circle, and stay inert when the content can't scroll. Guards for rubber-band overscroll, `jumpTo` / `PageStorage` restores, `animateTo` teleports, and keyboard viewport insets — all of which change `pixels` without a user scroll behind them.

The keyboard case is worth calling out because it's invisible in manual QA on a device you don't type on: the keyboard shrinks the viewport, `applyContentDimensions` reduces `maxScrollExtent`, and the position is corrected upward by up to ~300px in one frame. Without a guard that's an instant minimize. `userScrollDirection` is still `idle` there, because `beginActivity` only forces idle for non-scrolling activities — and `BallisticScrollActivity.isScrolling` is true, so the drag's direction survives the whole momentum phase, which is what makes a fling minimize correctly for free.

Per-tab re-targeting, since UIKit resolves the driving scroll view via `contentScrollView(for: .bottom)`: passing the selected tab's controller re-attaches, nulls the baseline and zeroes the accumulator. The baseline reset matters — without it, switching from a tab at offset 0 to one at 900 reads as a 900px scroll and minimizes instantly. Whether the bar should *reset to expanded* on a tab switch is undocumented and observation suggests the pill persists, so that's left as an app-side `expand()` rather than a baked-in guess.

Minimizing is [iPhone-only](https://developer.apple.com/documentation/swiftui/tabbarminimizebehavior/onscrolldown) on iOS. That's documented rather than gated on platform or screen size — a behaviour that silently switches itself off on a large screen is worse to debug than one that always does what it says, and the package has no runtime platform gates on any other widget behaviour.

## Why a controller, and the two subscriptions

`NotificationListener<UserScrollNotification>` is what the demo used and the package can't use it: in `GlassScaffold` the bar is a *sibling* of the body inside a `Stack`, never an ancestor of the scroll view. It also fires on the first pixel past touch slop, so it has no notion of intent, and it bubbles from every `Scrollable` in the subtree including horizontal carousels in list rows. A borrowed `ScrollController` observes exactly the one it was handed.

The decision function takes a plain value object rather than a `ScrollPosition`, so every branch is unit-testable without a widget tree — the same discipline `SearchableBottomBarController` is written under, and what keeps this comfortably inside the coverage gate.

Two subscriptions are needed and the second is easy to miss. `GlassTabBar.preferredSize` branches on the minimize state and `GlassScaffold` reads it for the body inset and the bottom edge-fade extent, so the bar resolves through the controller (never stale) and the scaffold subscribes via a new internal `GlassDynamicPreferredSize` — a `PreferredSizeWidget` that exposes the `Listenable` it resizes in response to. Only `GlassScaffold.build` re-runs; `body` is the same `Widget` instance each time, so the app's content element is re-parented rather than rebuilt. **But** the scaffold re-parents the same `GlassTabBar` instance too, and the framework short-circuits an update when the widget is identical — so the bar also subscribes on its own account, or it would never re-render. There's a regression test for each half.

Direction-detection rather than an offset-proportional morph is also what makes that affordable: a proportional bar would notify every frame with the finger down, and since `preferredSize` has to be re-read, that's a scaffold rebuild at 120 Hz. A latched state machine notifies at most twice per gesture.

## Two pre-existing bugs, fixed here

Both sit directly in this path and go from rare to routine once scrolling drives the morph:

1. **`makeSpring` discarded in-flight velocity.** It hardcoded the simulation's start velocity to `0.0`, so retargeting a morph mid-flight relaunched from rest and read as a stall then a restart. `checkRetarget` was already retargeting correctly — only the kinetics were wrong. Now carries velocity through (new optional param, defaulting to the old behaviour, so a first launch is bit-identical), and the launch sites read `.value`/`.velocity` inside the post-frame callback rather than a frame earlier during `build`. Barely visible when only a tap toggled the bar; scrolling down and straight back up is an ordinary gesture. Also improves `.searchable`.
2. **Whiten-at-bottom crashed with a shared `ScrollController`.** `_onScrollMaybeWhiten` read `ScrollController.position` guarded only by `hasClients`, which asserts when two scroll views share one controller — the few hundred ms of an `AnimatedSwitcher` cross-fade or a `Navigator` push. `GlassScaffold` already guards its header fade with `positions.length == 1`; this path now does too. Found by a test written for the new controller's own guard.

## Back-compat

Additive. No existing parameter changes meaning, no enum gains a value, and a bar with no `minimizeController` takes exactly the paths it took before. The one behavioural difference to released code is the spring-velocity fix, which changes how `.searchable` feels on a mid-flight reversal — strictly an improvement, but it isn't nothing, so flagging it rather than burying it.

Making the bottom accessory follow the bar inline as it minimizes is the natural companion and is a behaviour change rather than an addition, so it's a **separate branch and its own issue** — this PR lands without it.

## Tests & coverage

Effective project coverage **92.80%** (gate is 90%); the new controller is at **97.8%**. 28 pure-Dart unit tests on the state machine and 11 widget tests.

The headline unit test is parameterised over both refresh rates — it asserts the same 200 px/s gesture minimizes at 60 Hz *and* 120 Hz, and asserts the per-sample delta stays under the old `12.0` gate at both, so it fails if anyone reintroduces a per-frame threshold. Alongside it: jitter never minimizes (50 × ±2px), a dropped frame fires at the same distance rather than sooner, reversal zeroes the accumulator, momentum keeps accumulating after lift-off, and one test per guard.

Widget tests drive real gestures — a manual `TestGesture` with many small `moveBy` calls for the slow path, since `tester.drag` dispatches its delta in ~2 move events and can't exercise an accumulator, and `tester.fling` for momentum (asserting the latched state survives the direction going idle, which is the property that makes momentum safe). Plus the `preferredSize`/scaffold-inset regression tests, controller swaps, and the two-lists-one-controller guard.

`flutter test` is green apart from 11 golden tests that fail byte-identically on `main` — verified by stashing and re-running.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Platforms Tested

- [x] iOS (Impeller)

Verified on the iPhone 17 simulator via `example/lib/demos/minimizable_bar_demo.dart`, which the PR rewrites to use the controller and to cover all four behaviours, per-tab scroll views, a deliberately non-scrollable tab, and an `extendBody: false` toggle. The change is platform-agnostic Dart — no shader or rendering code — so I haven't separately verified the other platforms.

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation / CHANGELOG.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/golden tests pass locally (`flutter test`) — golden failures are pre-existing, see above
- [ ] ~If this changes shader code~ — n/a, no shader changes
- [ ] ~No dynamic indexing or unsupported GLSL builtins~ — n/a, no shader changes

## Screenshots / Recordings


https://github.com/user-attachments/assets/541cd1f9-f32b-4c6b-a63d-d2289429ad4c

