### PR TITLE
fix(renderer): scope the premium UV freeze to the push-back it was written for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Bug Fixes
+
+- **Premium glass no longer strands its shape when a sheet is swiped away (#229):** `RenderLiquidGlassLayer` freezes its shader UVs under a uniform scale-down, for the CupertinoSheet push-back (#192) where the sampled page shrinks with the glass. A swipe-dismissed `GlassModalSheet` produces the same matrix but holds its backdrop still, so the freeze left the surface's rim at the resting frame and squared off its rounded corners. The widget applying the scale now says which arrangement it is, via `LiquidGlassSelfScaleScope`; the push-back path is unchanged.
+
+---
+
 # 1.1.0
 
 ## New Features

--- a/lib/src/renderer/internal/liquid_glass_self_scale_scope.dart
+++ b/lib/src/renderer/internal/liquid_glass_self_scale_scope.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/widgets.dart';
+
+/// Marks a subtree whose ancestor scale is applied to the glass alone, and not
+/// to the backdrop that glass samples.
+///
+/// [RenderLiquidGlassLayer] freezes its shader UV coordinates when it sees a
+/// uniform scale-down above it, because the case that motivated it — the
+/// CupertinoSheet push-back (#192) — scales the glass *and* the page it samples
+/// together, leaving the sampled texture in unscaled coordinates.
+///
+/// A surface that scales itself is the opposite arrangement: the backdrop
+/// behind it holds still, so the live transform is the correct one and freezing
+/// strands the shader's shape at the size and position the surface had when the
+/// scale began. The two are indistinguishable from the matrix, so the widget
+/// applying the scale says which it is.
+class LiquidGlassSelfScaleScope extends InheritedWidget {
+  /// Declares that an ancestor scale over [child] does not move its backdrop.
+  const LiquidGlassSelfScaleScope({
+    required this.selfScaled,
+    required super.child,
+    super.key,
+  });
+
+  /// Whether such a scale is currently in effect.
+  ///
+  /// Held false while the surface sits at its natural size, so an ordinary
+  /// push-back over a resting surface still freezes as it should.
+  final bool selfScaled;
+
+  /// The scale below which [RenderLiquidGlassLayer] freezes, so a caller can
+  /// declare itself on exactly the same boundary rather than an invented one.
+  static const double freezeScaleThreshold = 0.9999;
+
+  /// Whether [context] sits under a scope that is currently self-scaling.
+  static bool of(BuildContext context) =>
+      context
+          .dependOnInheritedWidgetOfExactType<LiquidGlassSelfScaleScope>()
+          ?.selfScaled ??
+      false;
+
+  @override
+  bool updateShouldNotify(LiquidGlassSelfScaleScope oldWidget) =>
+      selfScaled != oldWidget.selfScaled;
+}

--- a/lib/src/renderer/liquid_glass_renderer.dart
+++ b/lib/src/renderer/liquid_glass_renderer.dart
@@ -17,6 +17,8 @@ export 'liquid_glass.dart' show LiquidGlass;
 export 'liquid_glass_blend_group.dart' show LiquidGlassBlendGroup;
 export 'liquid_glass_settings.dart' show LiquidGlassSettings;
 export 'liquid_shape.dart';
+export 'internal/liquid_glass_self_scale_scope.dart'
+    show LiquidGlassSelfScaleScope;
 export 'rendering/liquid_glass_layer.dart' show LiquidGlassLayer;
 export 'stretch.dart'
     show

--- a/lib/src/renderer/rendering/liquid_glass_layer.dart
+++ b/lib/src/renderer/rendering/liquid_glass_layer.dart
@@ -242,6 +242,7 @@ class _LiquidGlassLayerState extends State<LiquidGlassLayer>
                 clipExpansion: widget.clipExpansion,
                 captureImage: widget.captureImage,
                 captureOriginInScreenSpace: widget.captureOriginInScreenSpace,
+                selfScaled: LiquidGlassSelfScaleScope.of(context),
                 child: child!,
               ),
               child: widget.child,
@@ -264,6 +265,7 @@ class _RawShapes extends SingleChildRenderObjectWidget {
     this.clipExpansion = EdgeInsets.zero,
     this.captureImage,
     this.captureOriginInScreenSpace = Offset.zero,
+    this.selfScaled = false,
   });
 
   final FragmentShader renderShader;
@@ -274,6 +276,9 @@ class _RawShapes extends SingleChildRenderObjectWidget {
   final EdgeInsets clipExpansion;
   final ui.Image? captureImage;
   final Offset captureOriginInScreenSpace;
+
+  /// See [LiquidGlassSelfScaleScope].
+  final bool selfScaled;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
@@ -287,6 +292,7 @@ class _RawShapes extends SingleChildRenderObjectWidget {
       clipExpansion: clipExpansion,
       captureImage: captureImage,
       captureOriginInScreenSpace: captureOriginInScreenSpace,
+      selfScaled: selfScaled,
     );
   }
 
@@ -303,7 +309,8 @@ class _RawShapes extends SingleChildRenderObjectWidget {
       ..backdropKey = backdropKey
       ..clipExpansion = clipExpansion
       ..captureImage = captureImage
-      ..captureOriginInScreenSpace = captureOriginInScreenSpace;
+      ..captureOriginInScreenSpace = captureOriginInScreenSpace
+      ..selfScaled = selfScaled;
   }
 }
 
@@ -319,7 +326,9 @@ class RenderLiquidGlassLayer extends LiquidGlassRenderObject
     super.captureImage,
     super.captureOriginInScreenSpace,
     EdgeInsets clipExpansion = EdgeInsets.zero,
-  }) : _clipExpansion = clipExpansion;
+    bool selfScaled = false,
+  })  : _clipExpansion = clipExpansion,
+        _selfScaled = selfScaled;
 
   // ── Cached blur filter ──────────────────────────────────────────────────
   // The BackdropFilterLayer's blur filter is rebuilt only when blurSigma
@@ -339,6 +348,15 @@ class RenderLiquidGlassLayer extends LiquidGlassRenderObject
     markNeedsPaint();
   }
 
+  /// See [LiquidGlassSelfScaleScope]. Repaints on change: the shader's shape
+  /// bounds are derived from [matteTransform], which this switches.
+  bool _selfScaled;
+  set selfScaled(bool value) {
+    if (_selfScaled == value) return;
+    _selfScaled = value;
+    markNeedsPaint();
+  }
+
   List<BoxShadow> shadows;
 
   @override
@@ -352,6 +370,9 @@ class RenderLiquidGlassLayer extends LiquidGlassRenderObject
   Offset? _unscaledCaptureOrigin;
 
   bool _hasScale(Matrix4 m) {
+    // A surface scaling itself leaves its backdrop where it was, so the live
+    // transform is the right one and freezing would strand the shape.
+    if (_selfScaled) return false;
     // Detects the CupertinoSheet push-back, which scales the page down
     // uniformly on both X and Y axes simultaneously (< 1.0 on both).
     //
@@ -364,8 +385,9 @@ class RenderLiquidGlassLayer extends LiquidGlassRenderObject
     // Use a very tight tolerance (0.9999) to catch the very first frame of the CupertinoSheet
     // scale animation. A looser tolerance (0.99) allowed early frames of the animation
     // (e.g., 0.995) to overwrite the snapshot before freezing, causing a slight jump.
-    return (scaleX < 0.9999 && scaleX > 0.0) &&
-        (scaleY < 0.9999 && scaleY > 0.0);
+    const threshold = LiquidGlassSelfScaleScope.freezeScaleThreshold;
+    return (scaleX < threshold && scaleX > 0.0) &&
+        (scaleY < threshold && scaleY > 0.0);
   }
 
   /// Snapshots the layer's current screen-space transform and capture origin

--- a/lib/widgets/overlays/shared/glass_modal_sheet_morph.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_morph.dart
@@ -1200,7 +1200,20 @@ class _GlassSheetMorphPresenterState extends State<GlassSheetMorphPresenter>
         target.top - rawFallen.top * scale,
         0.0,
       )..scaleByDouble(scale, scale, 1.0, 1.0),
-      child: child,
+      // The premium renderer freezes its shader UVs under a uniform scale-down,
+      // for the CupertinoSheet push-back — where the sampled page shrinks along
+      // with the glass. A swipe is the other arrangement: the page behind holds
+      // still, and freezing strands the surface's rim and rounded corners at
+      // the size the sheet had when the drag began. Always present, so the
+      // sheet's depth in the element tree never changes; only the flag moves.
+      child: LiquidGlassSelfScaleScope(
+        // The renderer's own threshold, not an invented one: the flag is set
+        // exactly when the freeze would otherwise fire. A sheet at its detent
+        // sits a hair under 1.0 (its live position lags its layout by a sub-
+        // pixel), which must not read as a swipe.
+        selfScaled: scale < LiquidGlassSelfScaleScope.freezeScaleThreshold,
+        child: child,
+      ),
     );
   }
 

--- a/test/widgets/overlays/glass_modal_sheet_morph_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_morph_test.dart
@@ -1556,6 +1556,40 @@ void main() {
       expect(tester.getRect(body).width, closeTo(resting.width, 0.5));
     });
 
+    testWidgets('the swipe declares its scale to the premium renderer',
+        (tester) async {
+      // The renderer freezes its shader UVs under a uniform scale-down, for
+      // the CupertinoSheet push-back — where the page being sampled shrinks
+      // with the glass. A swipe is the opposite: the page behind holds still,
+      // and a frozen transform strands the surface's rim and rounded corners
+      // at the size the sheet had when the drag began.
+      final anchor = await pumpTrigger(tester);
+      await present(tester, anchor);
+      await tester.pumpAndSettle();
+
+      bool selfScaled() => tester
+          .widget<LiquidGlassSelfScaleScope>(
+            find.descendant(
+              of: find.byType(GlassSheetMorphPresenter),
+              matching: find.byType(LiquidGlassSelfScaleScope),
+            ),
+          )
+          .selfScaled;
+
+      expect(selfScaled(), isFalse,
+          reason: 'at rest the sheet is not scaling itself, so a push-back '
+              'over it must still freeze');
+
+      final drag = await tester.startGesture(const Offset(200, 420));
+      await drag.moveBy(const Offset(0, 60));
+      await tester.pump();
+      expect(selfScaled(), isTrue, reason: 'the shrink is under way');
+
+      await drag.up();
+      await tester.pumpAndSettle();
+      expect(selfScaled(), isFalse, reason: 'and released, it is over');
+    });
+
     testWidgets('the rendered mid-swipe frame is exactly the geometry\'s',
         (tester) async {
       // The release hands [SheetMorphGeometry.dismissedRect] to the morph as


### PR DESCRIPTION
Fixes #229.

## What changed

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/79326ee3-43e2-4b1e-99a7-a896eb93f4c4" /> | <video src="https://github.com/user-attachments/assets/8f745199-108d-4b5b-9067-a66c6286ad18" /> | 

`RenderLiquidGlassLayer` freezes `matteTransform` / `captureOriginInScreenSpace` whenever it sees a uniform scale-down on both axes. That heuristic was written for the CupertinoSheet push-back (#192), where the glass and the page it samples shrink together — so the sampled texture genuinely is in unscaled coordinates and the freeze is right.

A swipe-dismissed `GlassModalSheet` (#223) produces an identical matrix and the opposite arrangement: only the sheet scales, the page behind it holds still. Frozen, the shader kept placing its SDF shape via `transformRect(matteTransform, _geometryLocalBounds)` at the resting rect — so the surface's rim drew where the sheet used to be, and the shrunken card fell entirely inside an over-sized shape, leaving its top corners square instead of rounded.

The two cases are indistinguishable from the matrix alone, so the widget applying the scale now declares which one it is. `LiquidGlassSelfScaleScope` (internal — no public API) marks a subtree whose ancestor scale moves the glass but not its backdrop; `_hasScale()` returns false under it and the layer tracks the live transform.

Nothing declares the scope on the push-back path, so #192 is unchanged.

## Details worth flagging

- **The flag is dynamic, not permanent.** The sheet sets it only while the shrink is actually under way, so a CupertinoSheet pushed back over a *resting* glass sheet still freezes as it should.
- **One threshold, not two.** `LiquidGlassSelfScaleScope.freezeScaleThreshold` is the 0.9999 the renderer already used, and the sheet declares itself on exactly that boundary. A sheet parked at its detent sits a hair under 1.0 — its live position lags its layout by a sub-pixel — which must not read as a swipe; an invented threshold would have drifted from the one that matters.
- **The scope is always mounted**, only its value changes, so the sheet's depth in the element tree never shifts mid-gesture. (A depth change tears down and rebuilds the subtree, remounting every glass layer and re-seeding every spring inside the sheet.)

## Verification

- Reproduced and fixed on the iOS 27 simulator (iPhone 17, Impeller, `GlassQuality.premium`): both artifacts — the stranded rim and the square corners — are gone, and the swipe is otherwise unchanged.
- Root cause confirmed before the fix by making `_hasScale()` return `false` outright: same result, but that removes the freeze #192 needs, which is why the scope exists instead.
- New regression test pins the declaration at all three points of the gesture — false at rest, true mid-shrink, false again after release — so the freeze cannot be silently disabled for a resting sheet.
- 89 tests in the morph suite, 2634 across the package. The 11 golden failures on this machine are pre-existing and reproduce on an untouched tree.
- `flutter analyze` and `dart format` clean.
- Not verified on Android or desktop; this is the Impeller premium path only.

## Notes

- `CHANGELOG.md` entry sits under `# Unreleased` — move it under whatever version is cut next.
- The heuristic is still a heuristic for everyone else: any glass surface that scales itself while its backdrop holds still will hit the same freeze until it declares the scope. Worth considering whether the default should invert — freeze only when told to — but that's a wider change than this fix.
