### PR TITLE
feat(GlassTabBar): move the bottom accessory inline when the bar minimizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,26 @@
 - **`GlassModalSheet` swipe-dismissals morph back from the release point (#223):** Dragging a morphed sheet away used to skip the morph and slide the sheet off. Below the lowest detent the sheet now shrinks about the grabbed point as it follows the finger — the interactive zoom-dismissal measured off iOS 26 — and the release hands that exact frame to the closing morph. Sideways, the card chases the finger through a tracking spring, pinning at the screen edge. A release short of the dismiss threshold springs back. Sheets shown without `morphFrom` keep their plain slide-away unchanged.
 - **Scroll-to-minimize for `GlassTabBar.minimizable` (#228):** A new `GlassTabBarMinimizeController` drives the minimize from scrolling — the Flutter equivalent of SwiftUI's `.tabBarMinimizeBehavior(_:)`. `GlassBarMinimizeBehavior` mirrors Apple's enum case for case. The trigger is accumulated distance, not a per-frame delta — fixing the 1.0.0 ProMotion 120 Hz reliability issue.
 
+- **Bottom accessory follows the bar (behaviour change):** on
+  `GlassTabBar.minimizable`, a `bottomAccessory` with no explicit
+  `bottomAccessoryPlacement` now resolves to
+  `GlassTabBarAccessoryPlacement.inline` while the bar is minimized, matching
+  how iOS 26 animates a `tabViewBottomAccessory` down into the minimized bar.
+  Previously it stayed `expanded` unless `inline` was passed explicitly.
+
+  **This changes what `GlassTabBarAccessoryPlacementScope.of(context)` returns**
+  for affected callers — an accessory that switches on it will render its
+  compact variant on scroll where it previously did not, with no code change on
+  your side — and shrinks `preferredSize` by
+  `bottomAccessorySpacing + bottomAccessoryHeight` while minimized. Affects only
+  bars that have an accessory, pass no explicit placement, and reach the
+  minimized state. Pass `GlassTabBarAccessoryPlacement.expanded` to keep the
+  previous behaviour.
+
+  `GlassTabBar.searchable` is deliberately unchanged. Auto-collapsing on search
+  was removed in 0.x because it hid the mini-player behind the search capsule,
+  and that decision stands — a search field expanding is not the bar minimizing.
+
 ## Bug Fixes
 
 - **Spring reversals no longer stall (#228):** `SearchableBottomBarController.makeSpring` now carries in-flight velocity through retargets; reversing mid-morph no longer reads as a stall followed by a restart. Also benefits `GlassTabBar.searchable`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,7 @@
 - **Progressive Blur Scroll Edge Style (`GlassScrollEdgeStyle.blur`):** Introduces a hardware-accelerated GPU progressive Gaussian frost option via `ProgressiveBlur`, applying an `ImageFilter.shader` pass with ease-in quadratic falloff (`falloff: 2.0`) directly over live scrolling content. Default remains `GlassScrollEdgeStyle.soft` (the diffused gradient fade matching iOS 26's `.scrollEdgeEffectStyle(.soft)`). Developers can opt into `.blur` for richer frosting over custom dynamic gradients, video backdrops, or media grids.
 - **Configurable `maxSigma` & Signed Fade Extents:** Exposes `maxSigma` (default 18.0) for `GlassScrollEdgeStyle.blur`, alongside signed `topEdgeFadeExtent` and `bottomEdgeFadeExtent` (default 20.0) on `GlassScaffold` and `GlassScrollEdgeEffect` for granular transition zone control (including negative extents for tight floating-bar insets).
 - **Scroll Edge Playground Demo:** Added a comprehensive interactive showcase in the example app (`example/lib/demos/scroll_edge_style_demo.dart`) featuring live style switching (`soft`, `hard`, `blur`), real-time extent/sigma sliders, top/bottom toggles, and floating `GlassAppBar` & `GlassTabBar.bottom` integration with solid content cards.
-
----
-
-# 1.1.0
-
-## New Features
-
-- **GlassNavigationTransition — pinned navigation-bar chrome:** New `GlassNavigationShell` hosts the glass back button and trailing actions capsule *above* the `Navigator`, reproducing the iOS 26 navigation bar: page content and title slide during push/pop (including the interactive back-swipe, scrubbed proportionally) while the glass chrome stays pinned and morphs in place. Screens opt in with the `GlassAppBar.pinned` constructor, declaring actions as data (`GlassBarItem.icon` / `GlassBarItem.custom`); items sharing an `id` are treated as the same item across routes, mirroring `UIBarButtonItem.identifier`. Custom widgets are measured at intrinsic width, exactly as UIKit measures a `customView`. Works with any Pages-API router (go_router, auto_route, beamer) — the shell only reads `ModalRoute` animations. Without a shell, or where the effect cannot render, the same data renders in-route as today's glass capsule.
-- **`GlassBarItem.menu` — pull-down menus in a pinned bar:** The `UIBarButtonItem.menu` analogue, and the iOS 26 overflow button. The whole capsule morphs into the pull-down, matching `GlassButtonGroupItem.menu`. Menus cannot be opened mid-transition, and one already open is dismissed when navigation starts — the pinned capsule outlives the route that owns it, so nothing else would. Falls back to `GlassButtonGroupItem.menu` in-route wherever pinning does.
-- **GlassAppBar single-line titles:** The inline title no longer wraps to a second line when wide actions squeeze it; it truncates with an ellipsis, matching iOS.
-- **`GlassModalSheet` swipe-dismissals morph back from the release point (#223):** Dragging a morphed sheet away used to skip the morph and slide the sheet off. Below the lowest detent the sheet now shrinks about the grabbed point as it follows the finger — the interactive zoom-dismissal measured off iOS 26 — and the release hands that exact frame to the closing morph. Sideways, the card chases the finger through a tracking spring, pinning at the screen edge. A release short of the dismiss threshold springs back. Sheets shown without `morphFrom` keep their plain slide-away unchanged.
-- **Scroll-to-minimize for `GlassTabBar.minimizable` (#228):** A new `GlassTabBarMinimizeController` drives the minimize from scrolling — the Flutter equivalent of SwiftUI's `.tabBarMinimizeBehavior(_:)`. `GlassBarMinimizeBehavior` mirrors Apple's enum case for case. The trigger is accumulated distance, not a per-frame delta — fixing the 1.0.0 ProMotion 120 Hz reliability issue.
-
-- **Bottom accessory follows the bar (behaviour change):** on
+- **Bottom accessory follows the bar (behaviour change) (#226):** on
   `GlassTabBar.minimizable`, a `bottomAccessory` with no explicit
   `bottomAccessoryPlacement` now resolves to
   `GlassTabBarAccessoryPlacement.inline` while the bar is minimized, matching
@@ -37,6 +24,18 @@
   `GlassTabBar.searchable` is deliberately unchanged. Auto-collapsing on search
   was removed in 0.x because it hid the mini-player behind the search capsule,
   and that decision stands — a search field expanding is not the bar minimizing.
+
+---
+
+# 1.1.0
+
+## New Features
+
+- **GlassNavigationTransition — pinned navigation-bar chrome:** New `GlassNavigationShell` hosts the glass back button and trailing actions capsule *above* the `Navigator`, reproducing the iOS 26 navigation bar: page content and title slide during push/pop (including the interactive back-swipe, scrubbed proportionally) while the glass chrome stays pinned and morphs in place. Screens opt in with the `GlassAppBar.pinned` constructor, declaring actions as data (`GlassBarItem.icon` / `GlassBarItem.custom`); items sharing an `id` are treated as the same item across routes, mirroring `UIBarButtonItem.identifier`. Custom widgets are measured at intrinsic width, exactly as UIKit measures a `customView`. Works with any Pages-API router (go_router, auto_route, beamer) — the shell only reads `ModalRoute` animations. Without a shell, or where the effect cannot render, the same data renders in-route as today's glass capsule.
+- **`GlassBarItem.menu` — pull-down menus in a pinned bar:** The `UIBarButtonItem.menu` analogue, and the iOS 26 overflow button. The whole capsule morphs into the pull-down, matching `GlassButtonGroupItem.menu`. Menus cannot be opened mid-transition, and one already open is dismissed when navigation starts — the pinned capsule outlives the route that owns it, so nothing else would. Falls back to `GlassButtonGroupItem.menu` in-route wherever pinning does.
+- **GlassAppBar single-line titles:** The inline title no longer wraps to a second line when wide actions squeeze it; it truncates with an ellipsis, matching iOS.
+- **`GlassModalSheet` swipe-dismissals morph back from the release point (#223):** Dragging a morphed sheet away used to skip the morph and slide the sheet off. Below the lowest detent the sheet now shrinks about the grabbed point as it follows the finger — the interactive zoom-dismissal measured off iOS 26 — and the release hands that exact frame to the closing morph. Sideways, the card chases the finger through a tracking spring, pinning at the screen edge. A release short of the dismiss threshold springs back. Sheets shown without `morphFrom` keep their plain slide-away unchanged.
+- **Scroll-to-minimize for `GlassTabBar.minimizable` (#228):** A new `GlassTabBarMinimizeController` drives the minimize from scrolling — the Flutter equivalent of SwiftUI's `.tabBarMinimizeBehavior(_:)`. `GlassBarMinimizeBehavior` mirrors Apple's enum case for case. The trigger is accumulated distance, not a per-frame delta — fixing the 1.0.0 ProMotion 120 Hz reliability issue.
 
 ## Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -457,10 +457,11 @@ and when you tap the minimized circle, and stays put when the content is too
 short to scroll. Each tab owns its own scroll view on iOS — pass the current
 tab's controller and call `expand()` from `onTabSelected` to match.
 
-A `bottomAccessory` does not follow the bar on its own — pass
-`GlassTabBarAccessoryPlacement.inline` in the same rebuild the minimize lands
-in, and it animates down into the bar. Note that the bar positions your
-accessory but paints no surface behind it, so give it its own glass.
+A `bottomAccessory` with no explicit `bottomAccessoryPlacement` moves inline as
+the bar minimizes, the way iOS animates a `tabViewBottomAccessory` down into
+the bar. Read the placement inside your accessory to swap its layout, and note
+that the bar positions the accessory but does not paint a surface behind it —
+give it its own glass. Pass `GlassTabBarAccessoryPlacement.expanded` to pin it.
 
 Minimizing is an iPhone-only behaviour on iOS — the iPad tab bar is a top bar
 and never minimizes. This package does not gate on platform or screen size, so

--- a/example/lib/demos/minimizable_bar_demo.dart
+++ b/example/lib/demos/minimizable_bar_demo.dart
@@ -8,6 +8,7 @@
 ///   - per-tab scroll views, re-targeted on tab change the way UIKit
 ///     re-resolves `contentScrollView(for: .bottom)`
 ///   - a tab whose content is shorter than the viewport, which never minimizes
+///   - a bottom accessory that moves inline as the bar shrinks
 ///   - `extendBody: false`, where the body inset tracks the bar's height
 ///
 /// Run standalone:
@@ -108,6 +109,7 @@ class _DemoHomeState extends State<_DemoHome> {
   int _selectedIndex = 0;
   _TrailingMode _trailingMode = _TrailingMode.always;
   int _composerTaps = 0;
+  bool _showAccessory = false;
   bool _extendBody = true;
 
   /// One scroll view per tab, as on iOS — the minimize follows whichever one
@@ -182,6 +184,10 @@ class _DemoHomeState extends State<_DemoHome> {
         scrollController: _scrollControllers[_selectedIndex],
         onMinimizedTabTap: _minimize.expand,
         trailingButton: _trailingButton,
+        bottomAccessory: _showAccessory ? const _MiniPlayer() : null,
+        bottomAccessoryHeight: _showAccessory ? 56 : null,
+        // No explicit placement — the accessory follows the bar inline as it
+        // minimizes, the way iOS moves a tabViewBottomAccessory.
       ),
     );
   }
@@ -273,6 +279,12 @@ class _DemoHomeState extends State<_DemoHome> {
           ),
           const SizedBox(height: 8),
           _toggle(
+            value: _showAccessory,
+            onChanged: (v) => setState(() => _showAccessory = v),
+            title: 'Bottom accessory (mini player)',
+            subtitle: 'Moves inline as the bar minimizes',
+          ),
+          _toggle(
             value: _extendBody,
             onChanged: (v) => setState(() => _extendBody = v),
             title: 'extendBody',
@@ -334,6 +346,48 @@ class _DemoHomeState extends State<_DemoHome> {
           color: Colors.white.withValues(alpha: 0.45),
         ),
       );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bottom accessory — reads the placement the bar publishes
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _MiniPlayer extends StatelessWidget {
+  const _MiniPlayer();
+
+  @override
+  Widget build(BuildContext context) {
+    // The Flutter equivalent of @Environment(\.tabViewBottomAccessoryPlacement).
+    final placement = GlassTabBarAccessoryPlacementScope.of(context);
+    final inline = placement == GlassTabBarAccessoryPlacement.inline;
+
+    // The bar positions the accessory but does not paint a surface behind it —
+    // the accessory is the app's widget, so it brings its own glass.
+    return GlassContainer(
+      useOwnLayer: true,
+      shape: LiquidRoundedSuperellipse(borderRadius: inline ? 22 : 20),
+      padding: EdgeInsets.symmetric(horizontal: inline ? 12 : 16),
+      child: Row(
+        children: [
+          const Icon(CupertinoIcons.music_note_2, size: 18),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              inline ? 'Now playing' : 'Liquid Glass — Side A',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+            ),
+          ),
+          if (!inline) ...[
+            const Icon(CupertinoIcons.backward_fill, size: 18),
+            const SizedBox(width: 14),
+          ],
+          const Icon(CupertinoIcons.play_fill, size: 18),
+        ],
+      ),
+    );
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
@@ -49,6 +49,7 @@ class TabBarSearchableLayout extends StatefulWidget {
     this.controller,
     this.isSearchActive = false,
     this.minimizeController,
+    this.isMinimizablePlacement = false,
     this.extraButton,
     this.bottomAccessoryPlacement,
     this.bottomAccessory,
@@ -126,6 +127,11 @@ class TabBarSearchableLayout extends StatefulWidget {
   /// [scrollController] — the resulting state arrives through
   /// [isSearchActive], which [GlassTabBar] resolves.
   final GlassTabBarMinimizeController? minimizeController;
+
+  /// Whether the host is [GlassTabBar.minimizable] rather than
+  /// [GlassTabBar.searchable]. Only the former pulls its bottom accessory
+  /// inline as the bar shrinks.
+  final bool isMinimizablePlacement;
   final GlassTabBarExtraButton? extraButton;
   final GlassTabBarAccessoryPlacement? bottomAccessoryPlacement;
   final Widget? bottomAccessory;
@@ -890,7 +896,13 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
 
       final innerBarContent = barContent;
 
-      final accessoryInline = widget.bottomAccessoryPlacement ==
+      // Must resolve identically to GlassTabBar.preferredSize's call, or the
+      // scaffold reserves a height this engine does not draw.
+      final accessoryInline = resolveAccessoryPlacement(
+            explicit: widget.bottomAccessoryPlacement,
+            minimized: searching,
+            isMinimizablePlacement: widget.isMinimizablePlacement,
+          ) ==
           GlassTabBarAccessoryPlacement.inline;
 
       barContent = GlassTabBarAccessoryPlacementScope(

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -623,9 +623,10 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
   /// Without one, [minimized] stays a plain controlled prop and the caller
   /// decides when to flip it.
   ///
-  /// A [bottomAccessory] does not follow the bar on its own — pass
-  /// [GlassTabBarAccessoryPlacement.inline] in the same rebuild the minimize
-  /// lands in and it animates down into the bar.
+  /// A [bottomAccessory] follows the bar: with no explicit
+  /// [bottomAccessoryPlacement] it moves inline as the bar minimizes, the way
+  /// iOS 26 animates a `tabViewBottomAccessory` down into the minimized bar.
+  /// Pass [GlassTabBarAccessoryPlacement.expanded] to pin it.
   const GlassTabBar.minimizable({
     required List<GlassTab> tabs,
     required int selectedIndex,
@@ -1165,10 +1166,14 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
     double total = effectivePillH;
 
     // In inline mode the accessory sits BESIDE the pill (no extra height).
-    // Only explicit .inline placement counts — never auto-infer from search state,
-    // because the layout engine (TabBarSearchableLayout) does NOT auto-collapse either.
-    final isInline =
-        bottomAccessoryPlacement == GlassTabBarAccessoryPlacement.inline;
+    // This MUST resolve identically to the layout engine's own call, or the
+    // scaffold reserves a height the bar does not draw.
+    final isInline = resolveAccessoryPlacement(
+          explicit: bottomAccessoryPlacement,
+          minimized: minimized,
+          isMinimizablePlacement: isMinimizable,
+        ) ==
+        GlassTabBarAccessoryPlacement.inline;
 
     if (bottomAccessory != null &&
         !isInline &&
@@ -1407,6 +1412,8 @@ class _GlassTabBarState extends State<GlassTabBar> {
       controller: widget.controller,
       isSearchActive: widget._effectiveMinimized,
       minimizeController: widget.minimizeController,
+      isMinimizablePlacement:
+          widget._placement == _GlassTabBarPlacement.minimizable,
       extraButton: widget.extraButton,
       bottomAccessoryPlacement: widget.bottomAccessoryPlacement,
       bottomAccessory: widget.bottomAccessory,

--- a/lib/widgets/surfaces/shared/tab_bar_accessory_placement.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_accessory_placement.dart
@@ -16,6 +16,34 @@ enum GlassTabBarAccessoryPlacement {
   inline,
 }
 
+/// Resolves the placement an accessory should actually render at.
+///
+/// An [explicit] value always wins. When it is null the placement follows the
+/// bar: a minimized [GlassTabBar.minimizable] pulls its accessory [inline],
+/// matching how iOS 26 animates a `tabViewBottomAccessory` down into the bar
+/// as it minimizes.
+///
+/// Only the minimizable placement auto-resolves. `GlassTabBar.searchable`
+/// keeps its accessory [expanded] while the search field is open — a search
+/// bar expanding is not the bar minimizing, and auto-collapsing on search was
+/// removed deliberately in 0.x because it hid the mini-player behind the
+/// search capsule.
+///
+/// This is the single authoritative resolution, and both callers must use it:
+/// [GlassTabBar.preferredSize], which tells the scaffold how tall the bar is,
+/// and the searchable layout engine, which renders it. If those two ever
+/// disagree the scaffold's body inset desyncs from what is actually drawn.
+GlassTabBarAccessoryPlacement resolveAccessoryPlacement({
+  required GlassTabBarAccessoryPlacement? explicit,
+  required bool minimized,
+  required bool isMinimizablePlacement,
+}) {
+  if (explicit != null) return explicit;
+  return isMinimizablePlacement && minimized
+      ? GlassTabBarAccessoryPlacement.inline
+      : GlassTabBarAccessoryPlacement.expanded;
+}
+
 /// Provides the current [GlassTabBarAccessoryPlacement] to the widget tree.
 ///
 /// This is the Flutter equivalent of SwiftUI's

--- a/test/widgets/surfaces/glass_tab_bar_scroll_to_minimize_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_scroll_to_minimize_test.dart
@@ -28,6 +28,8 @@ Widget _app({
   required ScrollController scroll,
   int itemCount = 60,
   bool extendBody = true,
+  Widget? bottomAccessory,
+  GlassTabBarAccessoryPlacement? accessoryPlacement,
 }) {
   return MaterialApp(
     home: GlassScaffold(
@@ -45,6 +47,9 @@ Widget _app({
         minimizeController: minimize,
         scrollController: scroll,
         onMinimizedTabTap: minimize.expand,
+        bottomAccessory: bottomAccessory,
+        bottomAccessoryHeight: bottomAccessory == null ? null : 48,
+        bottomAccessoryPlacement: accessoryPlacement,
         maskingQuality: MaskingQuality.off,
       ),
     ),
@@ -232,6 +237,83 @@ void main() {
 
       expect(tester.getSize(find.byType(GlassTabBar)).height,
           lessThan(expandedBar.height));
+    });
+  });
+
+  group('GlassTabBar.minimizable — bottom accessory placement', () {
+    late GlassTabBarAccessoryPlacement observed;
+
+    Widget probe() => Builder(
+          builder: (context) {
+            observed = GlassTabBarAccessoryPlacementScope.of(context);
+            return const SizedBox(height: 48, child: Text('mini player'));
+          },
+        );
+
+    testWidgets('moves inline when the bar minimizes and no placement is set',
+        (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(_app(
+        minimize: minimize,
+        scroll: scroll,
+        bottomAccessory: probe(),
+      ));
+      await tester.pumpAndSettle();
+      expect(observed, GlassTabBarAccessoryPlacement.expanded);
+
+      minimize.minimize();
+      await tester.pumpAndSettle();
+      expect(observed, GlassTabBarAccessoryPlacement.inline);
+    });
+
+    testWidgets('an explicit placement always wins', (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(_app(
+        minimize: minimize,
+        scroll: scroll,
+        bottomAccessory: probe(),
+        accessoryPlacement: GlassTabBarAccessoryPlacement.expanded,
+      ));
+      await tester.pumpAndSettle();
+
+      minimize.minimize();
+      await tester.pumpAndSettle();
+      expect(observed, GlassTabBarAccessoryPlacement.expanded);
+    });
+
+    testWidgets('searchable does not pull its accessory inline on search',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: GlassScaffold(
+          body: const SizedBox.expand(),
+          bottomBar: GlassTabBar.searchable(
+            tabs: _testTabs,
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            isSearchActive: true,
+            searchConfig: GlassSearchBarConfig(onSearchToggle: (_) {}),
+            bottomAccessory: probe(),
+            bottomAccessoryHeight: 48,
+            maskingQuality: MaskingQuality.off,
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(observed, GlassTabBarAccessoryPlacement.expanded,
+          reason: 'a search field expanding is not the bar minimizing');
     });
   });
 

--- a/test/widgets/surfaces/glass_tab_bar_scroll_to_minimize_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_scroll_to_minimize_test.dart
@@ -293,6 +293,36 @@ void main() {
       expect(observed, GlassTabBarAccessoryPlacement.expanded);
     });
 
+    testWidgets('the reserved height drops to match, so the scaffold stays in '
+        'sync', (tester) async {
+      final scroll = ScrollController();
+      addTearDown(scroll.dispose);
+      final minimize = GlassTabBarMinimizeController(
+        behavior: GlassBarMinimizeBehavior.onScrollDown,
+      );
+      addTearDown(minimize.dispose);
+
+      await tester.pumpWidget(_app(
+        minimize: minimize,
+        scroll: scroll,
+        bottomAccessory: probe(),
+      ));
+      await tester.pumpAndSettle();
+      expect(_barHeight(tester), greaterThan(_expandedHeight),
+          reason: 'expanded, the accessory adds its own row above the pill');
+
+      minimize.minimize();
+      await tester.pumpAndSettle();
+
+      // Inline, the accessory sits beside the pill and costs no height, so the
+      // bar is exactly as tall as one with no accessory at all. This is the
+      // invariant the shared resolver exists to hold: preferredSize is what
+      // GlassScaffold insets the body by, and the layout engine has to draw
+      // the same thing.
+      expect(_barHeight(tester), _minimizedHeight);
+      expect(tester.getSize(find.byType(GlassTabBar)).height, _minimizedHeight);
+    });
+
     testWidgets('searchable does not pull its accessory inline on search',
         (tester) async {
       await tester.pumpWidget(MaterialApp(


### PR DESCRIPTION
Closes #226.

Follow-up to #228, now that it has landed. Rebased on `main` at 1.2.0. On `GlassTabBar.minimizable`, a `bottomAccessory` with no explicit `bottomAccessoryPlacement` now resolves to `inline` while the bar is minimized, the way iOS 26 animates a `tabViewBottomAccessory` down into the minimized bar. An explicit placement always wins, so `GlassTabBarAccessoryPlacement.expanded` is the opt-out.

Implements exactly what was agreed in #226 — single shared resolver, `.searchable` excluded, explicit `expanded` as the opt-out, shipped directly in the minor with no staging flag, plus the docs note about the accessory bringing its own glass.

https://github.com/user-attachments/assets/15cbe430-ce1a-4c45-a27a-0e491a252209

## The resolver

`resolveAccessoryPlacement` lives in `lib/widgets/surfaces/shared/tab_bar_accessory_placement.dart`, next to the enum it resolves:

```dart
GlassTabBarAccessoryPlacement resolveAccessoryPlacement({
  required GlassTabBarAccessoryPlacement? explicit,
  required bool minimized,
  required bool isMinimizablePlacement,
});
```

Both call sites go through it, and that is the point rather than an incidental tidy-up. `GlassTabBar.preferredSize` tells `GlassScaffold` how tall the bar is; `TabBarSearchableLayout` draws it. If the two ever disagree the body inset desyncs from what is on screen — the invariant the in-source comment from `b6b3862` exists to protect. Both now read the same `_effectiveMinimized`, and the dartdoc on the function says why it is a function.

`.searchable` is untouched: `isMinimizablePlacement` gates the auto-resolution, so a search field expanding never collapses a mini-player. That was removed deliberately in `b6b3862` for exactly that reason and the decision stands.

## Semver

Source-compatible, not behaviour-compatible, and the CHANGELOG calls it out under its own heading. `GlassTabBarAccessoryPlacementScope.of(context)` starts returning a different value on scroll, so an accessory that switches on it renders its compact variant where it previously did not, with no caller-side change; `preferredSize` drops by `bottomAccessorySpacing + bottomAccessoryHeight` while minimized. It reaches only bars that have an accessory, pass no explicit placement, **and** reach the minimized state — no example in this repo qualifies.

## Tests

Four new widget tests, all green (2,637 non-golden tests pass on the rebase; the 9 golden failures are pre-existing on `main` locally and excluded by CI):

- placement auto-resolves to `inline` on minimize with a null placement
- an explicit placement always wins
- `.searchable` does not pull its accessory inline on search
- the reserved height drops to match — inline, the accessory costs no height, so the bar measures exactly as tall as one with no accessory, and `tester.getSize` agrees with `preferredSize`. This is the sync invariant asserted directly.

## Demo

The minimizable demo gains a "Bottom accessory (mini player)" toggle. The mini-player reads `GlassTabBarAccessoryPlacementScope.of(context)` and swaps its own layout — the Flutter equivalent of `@Environment(\.tabViewBottomAccessoryPlacement)` — and brings its own `GlassContainer`, since the bar positions the accessory but paints no surface behind it. The README now says that explicitly; it is a sharp edge that gets more reachable once inline is the default.
