### PR TITLE
chore(exports): export GlassNavPinnedMetrics from the package barrel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - **Configurable `maxSigma` & Signed Fade Extents:** Exposes `maxSigma` (default 18.0) for `GlassScrollEdgeStyle.blur`, alongside signed `topEdgeFadeExtent` and `bottomEdgeFadeExtent` (default 20.0) on `GlassScaffold` and `GlassScrollEdgeEffect` for granular transition zone control (including negative extents for tight floating-bar insets).
 - **Scroll Edge Playground Demo:** Added a comprehensive interactive showcase in the example app (`example/lib/demos/scroll_edge_style_demo.dart`) featuring live style switching (`soft`, `hard`, `blur`), real-time extent/sigma sliders, top/bottom toggles, and floating `GlassAppBar` & `GlassTabBar.bottom` integration with solid content cards.
 
+## API
+
+- **`GlassNavPinnedMetrics` is now exported from the package barrel:** The geometry the pinned shell redraws hoisted chrome at — 44pt back circle, 46pt action slots, 44pt toolbar band, 8pt edge inset. A bar that is not a `GlassAppBar` had no supported way to reach it and had to hardcode the numbers, which drift the first time the package retunes them. The `show` clause exposes the metrics only; `GlassNavPinnedHost` and the cluster render objects stay internal. Documented under [Glass Navigation Transition](docs/GLASS_NAVIGATION_TRANSITION.md#if-your-bar-is-not-a-glassappbar).
+
 ---
 
 # 1.1.0

--- a/docs/GLASS_NAVIGATION_TRANSITION.md
+++ b/docs/GLASS_NAVIGATION_TRANSITION.md
@@ -42,6 +42,36 @@ CupertinoApp.router(
 With go_router, use `CupertinoPage` in your `pageBuilder`s to keep the native
 slide and back-swipe.
 
+### If your bar is not a `GlassAppBar`
+
+The shell hoists chrome above the `Navigator` and redraws it at
+`GlassNavPinnedMetrics`. A bar that draws its own back button and actions —
+an app with an existing design system adopting pinning incrementally — must
+use the same numbers, or the chrome visibly resizes and shifts at the moment
+of hand-over:
+
+```dart
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+SizedBox(
+  height: GlassNavPinnedMetrics.toolbarHeight,      // 44
+  child: Padding(
+    padding: const EdgeInsets.symmetric(
+      horizontal: GlassNavPinnedMetrics.horizontalPadding, // 8
+    ),
+    child: ...,
+  ),
+);
+```
+
+The two clusters are **not** the same size: the back button is
+`backDiameter` (44) while each action slot is `slot` (46). Mirroring both
+takes two numbers.
+
+Align to the geometry members only. `crossFadeStart`, `crossFadeEnd`,
+`swapAt` and `capsuleStretch` describe the shell's own choreography and may be
+retuned.
+
 ## Declaring a screen's bar items
 
 Screens opt in with the `GlassAppBar.pinned` constructor, declaring items as

--- a/lib/liquid_glass_widgets.dart
+++ b/lib/liquid_glass_widgets.dart
@@ -123,6 +123,9 @@ export 'widgets/surfaces/glass_navigation_shell.dart'
         GlassNavigationShell,
         GlassNavigationShellState,
         GlassNavBarRegistration;
+// Geometry a bar that is not a GlassAppBar aligns its in-route chrome to.
+export 'widgets/surfaces/shared/glass_nav_pinned_host.dart'
+    show GlassNavPinnedMetrics;
 export 'widgets/surfaces/glass_large_title.dart';
 export 'widgets/shared/glass_isolation_scope.dart';
 export 'widgets/surfaces/glass_scaffold.dart';

--- a/lib/widgets/surfaces/shared/glass_nav_pinned_host.dart
+++ b/lib/widgets/surfaces/shared/glass_nav_pinned_host.dart
@@ -15,6 +15,13 @@ import '../glass_navigation_shell.dart';
 /// Geometry and timing constants for the pinned chrome.
 ///
 /// Grouped here so the choreography can be tuned in one place.
+///
+/// The geometry members are exported so a bar that is not a [GlassAppBar] can
+/// draw its in-route chrome to the same numbers; without that, the chrome
+/// resizes at the moment the shell takes it over. The timing members
+/// ([crossFadeStart], [crossFadeEnd], [swapAt], [capsuleStretch]) and the
+/// helpers that read them describe the shell's own choreography and may be
+/// retuned — align to the geometry, not to these.
 abstract final class GlassNavPinnedMetrics {
   /// Width and height of one icon slot inside the actions capsule.
   ///
@@ -240,7 +247,7 @@ class _PinnedBackButton extends StatelessWidget {
 
 /// One item's place in the morph between two routes' action clusters.
 ///
-/// Public for testing; this library is not exported from the package barrel.
+/// Public for testing; held back from the barrel's `show` clause.
 @immutable
 @visibleForTesting
 class GlassNavActionSlot {
@@ -275,7 +282,7 @@ class GlassNavActionSlot {
 /// Returned slots are ordered leading-to-trailing in the incoming cluster,
 /// with items that only exist on the outgoing route appended.
 ///
-/// Public for testing; this library is not exported from the package barrel.
+/// Public for testing; held back from the barrel's `show` clause.
 @visibleForTesting
 List<GlassNavActionSlot> matchGlassNavActions(
   List<GlassBarActionItem> from,

--- a/test/widgets/surfaces/glass_nav_pinned_host_test.dart
+++ b/test/widgets/surfaces/glass_nav_pinned_host_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart' as barrel;
 import 'package:liquid_glass_widgets/widgets/surfaces/glass_bar_item.dart';
 import 'package:liquid_glass_widgets/widgets/surfaces/shared/glass_nav_pinned_host.dart';
 
@@ -176,6 +177,18 @@ void main() {
       // Passive custom content still exposes a callable handler, so nothing
       // downstream has to null-check its way around a status readout.
       expect(passive.onTap, returnsNormally);
+    });
+  });
+
+  group('barrel export', () {
+    test('GlassNavPinnedMetrics is reachable from the package barrel', () {
+      // A bar that is not a GlassAppBar aligns its in-route chrome to these
+      // numbers. `show` works per declaration, so one reference guards the
+      // whole class: drop the export and this file stops compiling.
+      expect(
+        barrel.GlassNavPinnedMetrics.backDiameter,
+        GlassNavPinnedMetrics.backDiameter,
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

`GlassNavPinnedMetrics` — the geometry `GlassNavigationShell` redraws a route's hoisted chrome at (44pt back circle, 46pt action slots, 44pt toolbar band, 8pt edge inset) — is a public `abstract final class`, but the library holding it was never exported from the barrel.

That is fine while a consumer's bar is a `GlassAppBar`, because the package aligns the two itself. It is not fine otherwise. An app with an existing design system adopting pinning incrementally draws its own in-route chrome, and it has to draw it to those numbers or the chrome visibly resizes and shifts at the moment the shell takes it over — and every screen that pins ends up permanently drawn at different metrics from every screen that cannot.

There was no supported way to reach the class. `glass_app_bar.dart` gets at it with a relative import; a consumer doing the same trips `implementation_imports`. So the numbers get hardcoded instead, and silently drift the first time the package retunes them.

One export fixes it:

```dart
// Geometry a bar that is not a GlassAppBar aligns its in-route chrome to.
export 'widgets/surfaces/shared/glass_nav_pinned_host.dart'
    show GlassNavPinnedMetrics;
```

No issue filed — per README §Contributing this is not a major change. It exposes a class that already exists and changes no rendered pixel.

### On the `show` clause

The clause names `GlassNavPinnedMetrics` and nothing else, so `GlassNavPinnedHost`, `GlassNavPinnedState`, `GlassNavActionSlot`, `matchGlassNavActions` and the cluster render objects all stay internal.

It is worth being explicit that `show` cannot go finer than that. It selects **declarations**, not members, so the timing constants (`crossFadeStart`, `crossFadeEnd`, `swapAt`, `capsuleStretch`) come along with the geometry whether or not that is wanted — the only way to separate them would be splitting the class in two, which is a larger and more disruptive change than this PR should make.

Rather than split it, the class dartdoc now says which half is the contract:

> The geometry members are exported so a bar that is not a `GlassAppBar` can draw its in-route chrome to the same numbers […] The timing members (`crossFadeStart`, `crossFadeEnd`, `swapAt`, `capsuleStretch`) and the helpers that read them describe the shell's own choreography and may be retuned — align to the geometry, not to these.

The docs repeat it. If you would rather the split were real, say so and I will do it in a follow-up.

### Also in this PR

- **Two stale dartdocs corrected.** `GlassNavActionSlot` and `matchGlassNavActions` both read *"Public for testing; this library is not exported from the package barrel."* The second clause stops being true of the library. They now read *"held back from the barrel's `show` clause"*, which stays true of them specifically.
- **A `docs/GLASS_NAVIGATION_TRANSITION.md` section**, *"If your bar is not a `GlassAppBar`"*, under Setup. It calls out the one asymmetry nothing currently documents: **the back button is `backDiameter` 44 while each action slot is `slot` 46**. A consumer mirroring both needs two numbers, and finding that out empirically costs a debugging session.
- **A test** asserting the class is reachable from the barrel. Because `show` works per declaration, one reference guards the whole class — drop the export and the test file stops compiling.
- **A CHANGELOG entry** under 1.2.0.

## Type of Change

- [x] 🧹 Refactor / cleanup (no behavior change)

## Platforms Tested

- [x] iOS (Impeller)
- [ ] Android (Impeller)
- [ ] macOS
- [ ] Windows
- [ ] Web
- [ ] Linux

iOS only — the example app's `nav_bar_patterns_demo` built and launched on an iPhone 17 (iOS 26) simulator. The change adds an export and edits comments and docs, so there is nothing platform-specific to cover and no rendered pixel that could differ; the run is a build-and-launch sanity check, not a visual verification.

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (shaders, painting logic)
- [x] I have made corresponding changes to the documentation / CHANGELOG.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/golden tests pass locally (`flutter test`)
- [ ] If this changes shader code, I have verified it compiles on both Metal (macOS) and SkSL/SPIR-V (Windows) — n/a
- [x] No dynamic indexing or unsupported GLSL builtins were introduced in shader code

### Verification

- `flutter analyze` — clean across the package and example.
- `flutter test` — 2717 pass. 11 golden tests fail, identically on `main` at the same commit with no changes applied, so they are pre-existing and environment-related.
- Internals confirmed hidden: in the example app, a file importing only `package:liquid_glass_widgets/liquid_glass_widgets.dart` resolves `GlassNavPinnedMetrics.backDiameter` and `.slot`, while `GlassNavPinnedHost` fails with `undefined_class`.
- No golden tests were added or regenerated — glass is shader-drawn and environment-sensitive, so a regenerated golden would prove nothing here.

## Future direction (not in this PR)

The stronger version of this is making the metrics **themable**, so an app aligns the shell to its design system rather than aligning itself to the shell. They are `static const` on an `abstract final class`, so there is no seam today and adding one is a real API decision — worth raising, not worth smuggling into an export-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NKsdg2iYEYjLDsAp6eogr
