### PR TITLE
fix(GlassTabBarMinimizeController): drive the minimize without a ScrollController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - **Configurable `maxSigma` & Signed Fade Extents:** Exposes `maxSigma` (default 18.0) for `GlassScrollEdgeStyle.blur`, alongside signed `topEdgeFadeExtent` and `bottomEdgeFadeExtent` (default 20.0) on `GlassScaffold` and `GlassScrollEdgeEffect` for granular transition zone control (including negative extents for tight floating-bar insets).
 - **Scroll Edge Playground Demo:** Added a comprehensive interactive showcase in the example app (`example/lib/demos/scroll_edge_style_demo.dart`) featuring live style switching (`soft`, `hard`, `blur`), real-time extent/sigma sliders, top/bottom toggles, and floating `GlassAppBar` & `GlassTabBar.bottom` integration with solid content cards.
 
+## Bug Fixes
+
+- **`GlassTabBarMinimizeController` drivable without a `ScrollController`:** The state machine's only controller-free entry point, `handleSample`, was annotated `@visibleForTesting`, so a host that observes scrolling with a `NotificationListener` — an app-level scaffold wrapping arbitrary screen bodies, which cannot reach whichever `ScrollController` the current screen owns — could not use the controller at all. The annotation is gone, and a new `handleNotification(ScrollNotification)` drives the minimize from notifications directly, carrying the `UserScrollNotification` direction across the updates that follow it. Leave `GlassTabBar.minimizable`'s `scrollController` off when driving it this way; the example app's minimizable bar demo switches between both sources.
+
 ---
 
 # 1.1.0

--- a/README.md
+++ b/README.md
@@ -466,6 +466,20 @@ Minimizing is an iPhone-only behaviour on iOS — the iPad tab bar is a top bar
 and never minimizes. This package does not gate on platform or screen size, so
 if you want that parity, choose a different surface for the regular size class.
 
+Where you cannot reach the scroll view's controller — an app-level scaffold
+wrapping arbitrary screen bodies, each tab owning a different one — drive the
+controller from scroll notifications instead and leave `scrollController` off:
+
+```dart
+NotificationListener<ScrollNotification>(
+  onNotification: (notification) {
+    _minimize.handleNotification(notification);
+    return false;
+  },
+  child: body,
+)
+```
+
 Without a controller, `minimized` stays a plain controlled prop and you decide
 when to flip it.
 

--- a/example/lib/demos/minimizable_bar_demo.dart
+++ b/example/lib/demos/minimizable_bar_demo.dart
@@ -5,6 +5,8 @@
 /// `.tabBarMinimizeBehavior(_:)`:
 ///
 ///   - all four [GlassBarMinimizeBehavior] cases, switchable at runtime
+///   - both scroll sources: the bar's `scrollController`, and a
+///     `NotificationListener` for hosts that cannot reach one
 ///   - per-tab scroll views, re-targeted on tab change the way UIKit
 ///     re-resolves `contentScrollView(for: .bottom)`
 ///   - a tab whose content is shorter than the viewport, which never minimizes
@@ -47,8 +49,17 @@ class _DemoApp extends StatelessWidget {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Trailing-slot modes
+// Demo modes
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// Where the minimize controller gets its scrolling from.
+enum _ScrollSource {
+  controller('Controller'),
+  notifications('Listener');
+
+  const _ScrollSource(this.label);
+  final String label;
+}
 
 enum _TrailingMode {
   none('None'),
@@ -107,6 +118,7 @@ class _DemoHome extends StatefulWidget {
 class _DemoHomeState extends State<_DemoHome> {
   int _selectedIndex = 0;
   _TrailingMode _trailingMode = _TrailingMode.always;
+  _ScrollSource _scrollSource = _ScrollSource.controller;
   int _composerTaps = 0;
   bool _extendBody = true;
 
@@ -176,10 +188,13 @@ class _DemoHomeState extends State<_DemoHome> {
         tabs: _tabs,
         selectedIndex: _selectedIndex,
         onTabSelected: _onTabSelected,
-        // The controller owns `minimized` — no `minimized:` prop, no
-        // NotificationListener, no scroll bookkeeping in this file.
+        // The controller owns `minimized` — no `minimized:` prop and no
+        // scroll bookkeeping in this file.
         minimizeController: _minimize,
-        scrollController: _scrollControllers[_selectedIndex],
+        // Null under `Listener`, where the body feeds the controller instead.
+        scrollController: _scrollSource == _ScrollSource.controller
+            ? _scrollControllers[_selectedIndex]
+            : null,
         onMinimizedTabTap: _minimize.expand,
         trailingButton: _trailingButton,
       ),
@@ -195,7 +210,7 @@ class _DemoHomeState extends State<_DemoHome> {
       _ => 40,
     };
 
-    return CustomScrollView(
+    final scrollView = CustomScrollView(
       controller: controller,
       reverse: reverse,
       slivers: [
@@ -212,6 +227,18 @@ class _DemoHomeState extends State<_DemoHome> {
           ),
         ),
       ],
+    );
+
+    if (_scrollSource == _ScrollSource.controller) return scrollView;
+
+    // What an app-level scaffold does when it wraps arbitrary screen bodies
+    // and cannot reach whichever ScrollController the current screen owns.
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        _minimize.handleNotification(notification);
+        return false; // let it keep bubbling
+      },
+      child: scrollView,
     );
   }
 
@@ -230,7 +257,8 @@ class _DemoHomeState extends State<_DemoHome> {
           Text(
             'Scroll to minimize — .tabBarMinimizeBehavior(_:). Tap the '
             'minimized circle to bring the tabs back. "Chat" is bottom-'
-            'aligned (try Up); "Short" cannot scroll, so it never minimizes.',
+            'aligned (try Up); "Short" cannot scroll, so it never minimizes. '
+            'Either scroll source drives it identically.',
             style: TextStyle(
               fontSize: 13,
               color: Colors.white.withValues(alpha: 0.6),
@@ -249,6 +277,23 @@ class _DemoHomeState extends State<_DemoHome> {
                 b: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 6),
                   child: Text(b.label,
+                      style:
+                          const TextStyle(fontSize: 13, color: Colors.white)),
+                ),
+            },
+          ),
+          const SizedBox(height: 12),
+          _label('SCROLL SOURCE'),
+          const SizedBox(height: 6),
+          CupertinoSlidingSegmentedControl<_ScrollSource>(
+            groupValue: _scrollSource,
+            onValueChanged: (s) =>
+                setState(() => _scrollSource = s ?? _ScrollSource.controller),
+            children: {
+              for (final s in _ScrollSource.values)
+                s: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  child: Text(s.label,
                       style:
                           const TextStyle(fontSize: 13, color: Colors.white)),
                 ),
@@ -282,6 +327,7 @@ class _DemoHomeState extends State<_DemoHome> {
           Text(
             'minimized: ${_minimize.minimized}   ·   '
             'resolved: ${_minimize.resolvedBehavior.name}   ·   '
+            'source: ${_scrollSource.label}   ·   '
             'composer taps: $_composerTaps',
             style: TextStyle(
               fontSize: 12,

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -620,6 +620,11 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
   /// )
   /// ```
   ///
+  /// A host that cannot reach the current screen's [ScrollController] leaves
+  /// [scrollController] off and feeds the minimize controller from a
+  /// `NotificationListener` instead — see
+  /// [GlassTabBarMinimizeController.handleNotification].
+  ///
   /// Without one, [minimized] stays a plain controlled prop and the caller
   /// decides when to flip it.
   ///
@@ -1134,7 +1139,9 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
   ///
   /// When supplied it owns the minimize state and [minimized] is ignored;
   /// pass the same [ScrollController] to [scrollController] and to the scroll
-  /// view the bar floats over. See [GlassTabBarMinimizeController].
+  /// view the bar floats over, or drive the controller from a
+  /// `NotificationListener` and leave [scrollController] null. See
+  /// [GlassTabBarMinimizeController].
   final GlassTabBarMinimizeController? minimizeController;
 
   /// Whether the bar is minimized right now, from whichever source owns it.

--- a/lib/widgets/surfaces/shared/tab_bar_minimize_controller.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_minimize_controller.dart
@@ -8,7 +8,14 @@ library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart' show ScrollDirection;
-import 'package:flutter/widgets.dart' show ScrollController, ScrollPosition;
+import 'package:flutter/widgets.dart'
+    show
+        Axis,
+        ScrollController,
+        ScrollNotification,
+        ScrollPosition,
+        ScrollUpdateNotification,
+        UserScrollNotification;
 
 import 'glass_bar_minimize_behavior.dart';
 
@@ -291,16 +298,74 @@ class GlassTabBarMinimizeController extends ChangeNotifier {
     handleSample(GlassTabBarScrollSample.fromPosition(position));
   }
 
+  // ── Notification driving ──────────────────────────────────────────────────
+
+  /// Direction of the most recent [UserScrollNotification].
+  ///
+  /// [ScrollMetrics] carries no direction, and a [UserScrollNotification] is
+  /// dispatched once per gesture rather than once per update, so the direction
+  /// the state machine needs has to be remembered between the two.
+  ScrollDirection _notificationDirection = ScrollDirection.idle;
+
+  /// Feeds a [ScrollNotification] to the state machine, for hosts that observe
+  /// scrolling with a [NotificationListener] rather than owning a
+  /// [ScrollController].
+  ///
+  /// The alternative to [attach], for the shape [attach] cannot serve: an
+  /// app-level scaffold wrapping arbitrary screen bodies has no way to reach
+  /// whichever [ScrollController] the current screen happens to own, and on a
+  /// tab bar each tab owns a different one. Use one source or the other —
+  /// both at once counts every scroll twice.
+  ///
+  /// ```dart
+  /// NotificationListener<ScrollNotification>(
+  ///   onNotification: (notification) {
+  ///     _minimize.handleNotification(notification);
+  ///     return false; // let it keep bubbling
+  ///   },
+  ///   child: body,
+  /// )
+  /// ```
+  ///
+  /// Horizontal notifications are ignored, so a carousel in the body cannot
+  /// minimize the bar. Every vertical scroll view under the listener does
+  /// drive it, so scope the listener to the body you want followed.
+  void handleNotification(ScrollNotification notification) {
+    if (_disposed) return;
+    final metrics = notification.metrics;
+    if (metrics.axis != Axis.vertical) return;
+
+    if (notification is UserScrollNotification) {
+      _notificationDirection = notification.direction;
+      return;
+    }
+
+    // Only an update carries an offset change. Start, end and overscroll
+    // notifications would re-run the rules against an offset already sampled.
+    if (notification is! ScrollUpdateNotification) return;
+
+    handleSample(GlassTabBarScrollSample(
+      pixels: metrics.pixels,
+      minScrollExtent: metrics.minScrollExtent,
+      maxScrollExtent: metrics.maxScrollExtent,
+      viewportDimension: metrics.viewportDimension,
+      direction: _notificationDirection,
+      outOfRange: metrics.outOfRange,
+    ));
+  }
+
   // ── The decision function ─────────────────────────────────────────────────
 
   /// Feeds one scroll sample to the state machine.
   ///
-  /// Pure with respect to Flutter — visible for testing so the behaviour can
-  /// be driven from synthetic samples.
+  /// Pure with respect to Flutter, which is what makes it safe to call from
+  /// anywhere: a host that observes scrolling some other way than owning a
+  /// [ScrollController] can build its own samples and drive the controller
+  /// directly. [handleNotification] is the ready-made path for the common
+  /// case of a [NotificationListener].
   ///
   /// The order of the rules matters, and each early return also decides
   /// whether the accumulator survives.
-  @visibleForTesting
   void handleSample(GlassTabBarScrollSample sample) {
     if (!_minimizes) return;
 

--- a/test/widgets/surfaces/tab_bar_minimize_controller_test.dart
+++ b/test/widgets/surfaces/tab_bar_minimize_controller_test.dart
@@ -1,5 +1,19 @@
 import 'package:flutter/rendering.dart' show ScrollDirection;
-import 'package:flutter/widgets.dart' show ScrollController;
+import 'package:flutter/widgets.dart'
+    show
+        AxisDirection,
+        BuildContext,
+        Directionality,
+        FixedScrollMetrics,
+        ListView,
+        NotificationListener,
+        ScrollController,
+        ScrollMetrics,
+        ScrollNotification,
+        ScrollUpdateNotification,
+        SizedBox,
+        TextDirection,
+        UserScrollNotification;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
 
@@ -35,6 +49,54 @@ void _scroll(
 }) {
   for (var i = 0; i <= count; i++) {
     c.handleSample(_sample(from + i * step, direction: direction));
+  }
+}
+
+ScrollMetrics _metrics(
+  double pixels, {
+  double min = 0,
+  double max = 2000,
+  double viewport = 800,
+  AxisDirection axisDirection = AxisDirection.down,
+}) =>
+    FixedScrollMetrics(
+      pixels: pixels,
+      minScrollExtent: min,
+      maxScrollExtent: max,
+      viewportDimension: viewport,
+      axisDirection: axisDirection,
+      devicePixelRatio: 1.0,
+    );
+
+/// A context to hang synthetic notifications off. [ScrollNotification] requires
+/// one; the state machine never reads it.
+Future<BuildContext> _pumpContext(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox());
+  return tester.element(find.byType(SizedBox));
+}
+
+/// Feeds the notifications one drag produces: the [UserScrollNotification]
+/// dispatched once as the gesture starts, then a run of updates.
+void _drag(
+  GlassTabBarMinimizeController c,
+  BuildContext context, {
+  required double from,
+  required double step,
+  required int count,
+  ScrollDirection direction = ScrollDirection.reverse,
+  AxisDirection axisDirection = AxisDirection.down,
+}) {
+  c.handleNotification(UserScrollNotification(
+    metrics: _metrics(from, axisDirection: axisDirection),
+    context: context,
+    direction: direction,
+  ));
+  for (var i = 1; i <= count; i++) {
+    c.handleNotification(ScrollUpdateNotification(
+      metrics: _metrics(from + i * step, axisDirection: axisDirection),
+      context: context,
+      scrollDelta: step,
+    ));
   }
 }
 
@@ -244,6 +306,125 @@ void main() {
 
       c.handleSample(_sample(2000));
       expect(c.minimized, isFalse, reason: 'the end is');
+    });
+  });
+
+  group('GlassTabBarMinimizeController — notification driving', () {
+    testWidgets('minimizes after the threshold of accumulated travel',
+        (tester) async {
+      final context = await _pumpContext(tester);
+      final c = _controller();
+      _drag(c, context, from: 100, step: 5, count: 3); // 15px — under 20
+      expect(c.minimized, isFalse);
+      _drag(c, context, from: 115, step: 5, count: 2); // 25px in total
+      expect(c.minimized, isTrue);
+    });
+
+    testWidgets('expands after the smaller threshold of upward travel',
+        (tester) async {
+      final context = await _pumpContext(tester);
+      final c = _controller()..minimize();
+      _drag(c, context,
+          from: 500, step: -4, count: 4, direction: ScrollDirection.forward);
+      expect(c.minimized, isFalse);
+    });
+
+    testWidgets('the direction survives the updates after it', (tester) async {
+      // UserScrollNotification is dispatched once per gesture, not once per
+      // update. A controller reading the direction off each update would see
+      // idle every time, rule 4 of handleSample would zero the accumulator on
+      // every sample, and the bar would never minimize — silently.
+      final context = await _pumpContext(tester);
+      final c = _controller();
+      c.handleNotification(UserScrollNotification(
+        metrics: _metrics(100),
+        context: context,
+        direction: ScrollDirection.reverse,
+      ));
+      for (final pixels in [104.0, 108.0, 112.0, 116.0, 121.0, 125.0]) {
+        c.handleNotification(ScrollUpdateNotification(
+          metrics: _metrics(pixels),
+          context: context,
+          scrollDelta: 4,
+        ));
+      }
+      expect(c.minimized, isTrue);
+    });
+
+    testWidgets('updates with no user scroll behind them decide nothing',
+        (tester) async {
+      final context = await _pumpContext(tester);
+      final c = _controller();
+      for (final pixels in [100.0, 120.0, 140.0, 160.0]) {
+        c.handleNotification(ScrollUpdateNotification(
+          metrics: _metrics(pixels),
+          context: context,
+          scrollDelta: 20,
+        ));
+      }
+      expect(c.minimized, isFalse,
+          reason: 'a jumpTo dispatches no UserScrollNotification');
+    });
+
+    testWidgets('horizontal notifications are ignored', (tester) async {
+      final context = await _pumpContext(tester);
+      final c = _controller();
+      _drag(c, context,
+          from: 100, step: 10, count: 5, axisDirection: AxisDirection.right);
+      expect(c.minimized, isFalse,
+          reason: 'a carousel in the body must not minimize the bar');
+    });
+
+    testWidgets('reaching the top expands, as through a ScrollController',
+        (tester) async {
+      final context = await _pumpContext(tester);
+      final c = _controller()..minimize();
+      c.handleNotification(ScrollUpdateNotification(
+        metrics: _metrics(0),
+        context: context,
+        scrollDelta: -10,
+      ));
+      expect(c.minimized, isFalse);
+    });
+
+    testWidgets('a real drag through a NotificationListener minimizes',
+        (tester) async {
+      // The synthetic tests above assume the order Flutter dispatches in; this
+      // one takes it from the framework.
+      final c = _controller();
+      addTearDown(c.dispose);
+
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: NotificationListener<ScrollNotification>(
+          onNotification: (notification) {
+            c.handleNotification(notification);
+            return false;
+          },
+          child: ListView.builder(
+            itemCount: 100,
+            itemBuilder: (context, i) => const SizedBox(height: 80),
+          ),
+        ),
+      ));
+
+      await tester.drag(find.byType(ListView), const Offset(0, -120));
+      await tester.pumpAndSettle();
+      expect(c.minimized, isTrue);
+
+      await tester.drag(find.byType(ListView), const Offset(0, 40));
+      await tester.pumpAndSettle();
+      expect(c.minimized, isFalse);
+    });
+
+    testWidgets('notifications after dispose() do not throw', (tester) async {
+      final context = await _pumpContext(tester);
+      final c = _controller();
+      _drag(c, context, from: 100, step: 5, count: 2);
+      c.dispose();
+      expect(() => _drag(c, context, from: 200, step: 5, count: 10),
+          returnsNormally);
+      expect(c.minimized, isFalse);
     });
   });
 


### PR DESCRIPTION
## Description

`GlassTabBarMinimizeController` currently has two ways in, and only one of them
is usable from app code:

* `attach(ScrollController)` — needs a `ScrollController`, and only samples while
  `controller.positions.length == 1`.
* `handleSample(GlassTabBarScrollSample)` — the pure decision function, and the
  only entry that needs no controller. It was annotated `@visibleForTesting`.

So a host that observes scrolling with a `NotificationListener<ScrollNotification>`
instead of owning a controller could not use the controller at all without an
`// ignore: invalid_use_of_visible_for_testing_member` in production code. That
host shape is often the only option: an app-level scaffold that wraps arbitrary
screen bodies has no way to reach whichever `ScrollController` the current screen
owns — and on a tab bar, each tab owns a different one.

It reads as an oversight rather than a decision, because the argument type is
already fully public: `GlassTabBarScrollSample` has both a public const
constructor and a public `fromPosition` factory. Meanwhile the reason the
controller exists — the accumulated-distance fix for the 1.0.0 ProMotion issue
(#225/#228) — never reaches those apps, which keep their own cruder
direction-only logic instead.

This PR does both halves:

1. **Drops `@visibleForTesting` from `handleSample`.** It is documented as "pure
   with respect to Flutter", which is exactly what makes it safe to call from
   anywhere. The note that the order of its rules is load-bearing stays.
2. **Adds `handleNotification(ScrollNotification)`** — the ready-made path, so a
   host with an unusual scroll source isn't blocked again:

```dart
NotificationListener<ScrollNotification>(
  onNotification: (notification) {
    _minimize.handleNotification(notification);
    return false; // let it keep bubbling
  },
  child: body,
)
```

Leave `GlassTabBar.minimizable`'s `scrollController` off when driving it this way.

### The trap in (2)

The direction the state machine needs (`ScrollDirection`) is **not** on
`ScrollMetrics`. It only arrives on `UserScrollNotification`, which is dispatched
once per gesture rather than once per update — so `handleNotification` remembers
the last user-scroll direction across the `ScrollUpdateNotification`s that follow
it. Reading it per-update would yield `ScrollDirection.idle` every time, rule 4 of
`handleSample` would treat that as "not a user scroll" and zero the accumulator,
and the bar would silently never minimize. There is a test for exactly that, and
mutating the field to `idle` fails it (plus three of its neighbours).

Nothing about the existing `ScrollController` path changes, and no rendered pixel
moves.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Platforms Tested

- [x] iOS (Impeller)
- [ ] Android (Impeller)
- [ ] macOS
- [ ] Windows
- [ ] Web
- [ ] Linux

Verified on an iPhone 17 simulator (iOS 26): the example app's minimizable bar
demo gained a **Scroll source** switch (`Controller` / `Listener`), and a real
drag minimizes and re-expands the bar identically under both. Not run on the
other five platforms — this is platform-agnostic Dart, but I have only tested
what is ticked.

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (shaders, painting logic)
- [x] I have made corresponding changes to the documentation / CHANGELOG.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/golden tests pass locally (`flutter test`) — 2724 pass. The 11 failures are golden tests that also fail on a clean checkout in my environment (unrelated widgets: text field, button, chip, inputs), so I have left them alone.
- [ ] If this changes shader code, I have verified it compiles on both Metal (macOS) and SkSL/SPIR-V (Windows) — n/a, no shader code
- [x] No dynamic indexing or unsupported GLSL builtins were introduced in shader code

## Tests

Eight new tests in `test/widgets/surfaces/tab_bar_minimize_controller_test.dart`,
driven by synthetic notifications, plus one that takes the dispatch order from the
framework by dragging a real `ListView` through a real `NotificationListener`:

* minimizes after `kMinimizeThreshold` of accumulated downward travel
* expands after `kExpandThreshold` of upward travel
* the direction survives the updates after the gesture starts (the trap above)
* updates with no user scroll behind them decide nothing (a `jumpTo`)
* horizontal notifications are ignored, so a carousel cannot minimize the bar
* reaching the top expands, as it does through a `ScrollController`
* a real drag through a `NotificationListener` minimizes, and dragging back expands
* notifications after `dispose()` do not throw

No golden tests: glass is shader-drawn and environment-sensitive, and this change
renders nothing new.
