### PR TITLE
feat(renderer): PlatformViewGlassMode, so glass over a platform view can stay clear instead of black

### DIFF
--- a/lib/liquid_glass_widgets.dart
+++ b/lib/liquid_glass_widgets.dart
@@ -9,6 +9,7 @@ export 'src/renderer/liquid_glass_renderer.dart'
     show
         AnchorStretchSettings,
         LiquidGlassSettings,
+        PlatformViewGlassMode,
         LiquidGlassLayer,
         LiquidGlassBlendGroup,
         GlassGlow,

--- a/lib/src/renderer/liquid_glass_renderer.dart
+++ b/lib/src/renderer/liquid_glass_renderer.dart
@@ -15,7 +15,8 @@ import 'package:flutter/foundation.dart' show kDebugMode;
 export 'glass_glow.dart' show GlassGlow, GlassGlowLayer;
 export 'liquid_glass.dart' show LiquidGlass;
 export 'liquid_glass_blend_group.dart' show LiquidGlassBlendGroup;
-export 'liquid_glass_settings.dart' show LiquidGlassSettings;
+export 'liquid_glass_settings.dart'
+    show LiquidGlassSettings, PlatformViewGlassMode;
 export 'liquid_shape.dart';
 export 'internal/liquid_glass_self_scale_scope.dart'
     show LiquidGlassSelfScaleScope;

--- a/lib/src/renderer/liquid_glass_settings.dart
+++ b/lib/src/renderer/liquid_glass_settings.dart
@@ -8,6 +8,36 @@ import '../../types/glass_specular_sharpness.dart';
 import 'liquid_glass_renderer.dart';
 import 'liquid_glass_render_scope.dart';
 
+/// How a glass surface resolves the parts of its body that had nothing to
+/// sample.
+///
+/// The body's colour comes from the backdrop texture. Over a platform view
+/// (a map, a camera preview, a video, a webview) that texture is empty, which
+/// in premultiplied terms is transparent black, so a body that is forced fully
+/// opaque resolves to solid black.
+enum PlatformViewGlassMode {
+  /// The body stays fully opaque over the whole shape. Where nothing was
+  /// sampled it resolves to [LiquidGlassSettings.platformViewFallbackColor],
+  /// or to black when that is unset.
+  ///
+  /// This is the default and the historical behaviour.
+  fallbackColor,
+
+  /// Coverage follows what was actually sampled: opaque where the backdrop
+  /// held content, clear where it held nothing, so the platform view shows
+  /// through instead of a black or invented fill. The rim keeps its own
+  /// coverage, so the edge still reads.
+  ///
+  /// On an ordinary backdrop every sample is opaque, so this is identical to
+  /// [fallbackColor]. It only differs where there was nothing to read.
+  ///
+  /// Note for tab bars: over a platform view the indicator refracts the bar's
+  /// own icon layer, and that layer is drawn on screen as well. With a body
+  /// that is no longer opaque, both copies become visible. See
+  /// `SearchableTabIndicator.passthroughOverPlatformView`.
+  passthrough,
+}
+
 /// Represents the settings for a liquid glass effect.
 class LiquidGlassSettings {
   /// Creates a new [LiquidGlassSettings] with the given settings.
@@ -40,6 +70,7 @@ class LiquidGlassSettings {
     this.edgeAbsorption = 0.0,
     this.backerColor,
     this.platformViewFallbackColor,
+    this.platformViewMode = PlatformViewGlassMode.fallbackColor,
   }) : pinchStrength = 0.0;
 
   /// Private constructor used exclusively by [copyWithPinch].
@@ -70,6 +101,7 @@ class LiquidGlassSettings {
     required this.edgeAbsorption,
     this.backerColor,
     this.platformViewFallbackColor,
+    this.platformViewMode = PlatformViewGlassMode.fallbackColor,
     required this.pinchStrength,
   });
 
@@ -372,6 +404,7 @@ class LiquidGlassSettings {
         edgeAbsorption: edgeAbsorption,
         backerColor: backerColor,
         platformViewFallbackColor: platformViewFallbackColor,
+        platformViewMode: platformViewMode,
         pinchStrength: value,
       );
 
@@ -409,6 +442,12 @@ class LiquidGlassSettings {
   /// recipes that relied on `backerColor` doubling as the PlatformView fill are
   /// unchanged.
   final Color? platformViewFallbackColor;
+
+  /// How the body resolves where the backdrop had nothing to sample.
+  ///
+  /// Defaults to [PlatformViewGlassMode.fallbackColor], which is the existing
+  /// behaviour, so this changes nothing unless it is asked for.
+  final PlatformViewGlassMode platformViewMode;
 
   /// The effective saturation taking visibility into account.
   double get effectiveSaturation => 1 + (saturation - 1) * visibility;
@@ -460,6 +499,9 @@ class LiquidGlassSettings {
         backerColor: Color.lerp(a.backerColor, b.backerColor, t),
         platformViewFallbackColor: Color.lerp(
             a.platformViewFallbackColor, b.platformViewFallbackColor, t),
+        // A mode is not interpolable: it switches at the midpoint like any
+        // other enum in this class.
+        platformViewMode: t < 0.5 ? a.platformViewMode : b.platformViewMode,
         // pinchStrength is interaction state — lerp it so transitions are smooth
         // when the indicator fades between active/resting states.
         pinchStrength: lerpDouble(a.pinchStrength, b.pinchStrength, t)!);
@@ -498,6 +540,7 @@ class LiquidGlassSettings {
     double? edgeAbsorption,
     Color? backerColor,
     Color? platformViewFallbackColor,
+    PlatformViewGlassMode? platformViewMode,
   }) =>
       LiquidGlassSettings._withPinch(
         visibility: visibility ?? this.visibility,
@@ -524,6 +567,7 @@ class LiquidGlassSettings {
         backerColor: backerColor ?? this.backerColor,
         platformViewFallbackColor:
             platformViewFallbackColor ?? this.platformViewFallbackColor,
+        platformViewMode: platformViewMode ?? this.platformViewMode,
         pinchStrength: pinchStrength,
       );
 
@@ -554,6 +598,7 @@ class LiquidGlassSettings {
         other.edgeAbsorption == edgeAbsorption &&
         other.backerColor == backerColor &&
         other.platformViewFallbackColor == platformViewFallbackColor &&
+        other.platformViewMode == platformViewMode &&
         other.pinchStrength == pinchStrength;
   }
 
@@ -581,6 +626,7 @@ class LiquidGlassSettings {
         edgeAbsorption,
         backerColor,
         platformViewFallbackColor,
+        platformViewMode,
         pinchStrength,
       ]);
 }

--- a/lib/src/renderer/rendering/liquid_glass_render_object.dart
+++ b/lib/src/renderer/rendering/liquid_glass_render_object.dart
@@ -337,6 +337,14 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
               settings.edgeAbsorption,
             ]);
           })
+          // Slot 32: uPlatformViewMode.
+          ..setFloatUniforms(initialIndex: 32, (value) {
+            value.setFloat(
+              settings.platformViewMode == PlatformViewGlassMode.passthrough
+                  ? 1.0
+                  : 0.0,
+            );
+          })
           ..setImageSampler(
             1,
             geometryImage,
@@ -475,6 +483,14 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
           scale,
           settings.edgeAbsorption,
         ]);
+      })
+      // Slot 32: uPlatformViewMode.
+      ..setFloatUniforms(initialIndex: 32, (value) {
+        value.setFloat(
+          settings.platformViewMode == PlatformViewGlassMode.passthrough
+              ? 1.0
+              : 0.0,
+        );
       })
       // Slot 0: captured background image (replaces the BackdropFilter read).
       ..setImageSampler(0, capture)

--- a/lib/src/widgets/surfaces/tab_bar_searchable_internal.dart
+++ b/lib/src/widgets/surfaces/tab_bar_searchable_internal.dart
@@ -117,6 +117,7 @@ class SearchableTabIndicator extends StatefulWidget {
     required this.magnification,
     required this.innerBlur,
     required this.maskingQuality,
+    this.passthroughOverPlatformView = false,
     required this.isSearchActive,
     required this.onDismissSearch,
     this.indicatorColor,
@@ -156,6 +157,18 @@ class SearchableTabIndicator extends StatefulWidget {
   final double magnification;
   final double innerBlur;
   final MaskingQuality maskingQuality;
+
+  /// The glass sits over a platform view whose pixels cannot be captured, so
+  /// its body is transparent rather than an invented fill colour.
+  ///
+  /// The indicator refracts the bar's own icon layer in that situation, and
+  /// that layer is also drawn on screen - with a see-through body the crisp
+  /// copy shows next to the refracted one, i.e. every label appears twice.
+  /// So when this is set the selected content is lifted OUT of the refracted
+  /// icon layer and drawn ABOVE the glass instead: the layer under the pill
+  /// holds nothing, the glass still refracts what surrounds it, and each
+  /// label exists exactly once.
+  final bool passthroughOverPlatformView;
   final GlobalKey? backgroundKey;
   final bool isSearchActive;
   final VoidCallback onDismissSearch;
@@ -617,24 +630,25 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                                     child: widget.childUnselected,
                                   ),
                                 ),
-                                ClipPath(
-                                  clipBehavior: Clip.antiAliasWithSaveLayer,
-                                  clipper: JellyClipper(
-                                    itemCount: widget.tabCount,
-                                    alignment: alignment,
-                                    thickness: thickness,
-                                    expansion: widget.indicatorExpansion
-                                        .resolve(Directionality.of(context)),
-                                    transform: jellyTransform,
-                                    borderRadius: effRadius * 2,
+                                if (!widget.passthroughOverPlatformView)
+                                  ClipPath(
+                                    clipBehavior: Clip.antiAliasWithSaveLayer,
+                                    clipper: JellyClipper(
+                                      itemCount: widget.tabCount,
+                                      alignment: alignment,
+                                      thickness: thickness,
+                                      expansion: widget.indicatorExpansion
+                                          .resolve(Directionality.of(context)),
+                                      transform: jellyTransform,
+                                      borderRadius: effRadius * 2,
+                                    ),
+                                    child: Container(
+                                      padding: widget.tabPadding,
+                                      height: widget.barHeight,
+                                      child: widget.selectedTabBuilder(
+                                          context, thickness, alignment),
+                                    ),
                                   ),
-                                  child: Container(
-                                    padding: widget.tabPadding,
-                                    height: widget.barHeight,
-                                    child: widget.selectedTabBuilder(
-                                        context, thickness, alignment),
-                                  ),
-                                ),
                               ],
                             ),
                           ),
@@ -673,6 +687,33 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                 ? _iconLayerKey
                 : widget.backgroundKey,
           ),
+
+          // 4. The selected content, lifted above the glass. Only in
+          // passthrough: the pill's body is see-through there, so this copy
+          // cannot live under it (see [passthroughOverPlatformView]).
+          if (widget.passthroughOverPlatformView)
+            Positioned.fill(
+              child: IgnorePointer(
+                child: ClipPath(
+                  clipBehavior: Clip.antiAliasWithSaveLayer,
+                  clipper: JellyClipper(
+                    itemCount: widget.tabCount,
+                    alignment: alignment,
+                    thickness: thickness,
+                    expansion: widget.indicatorExpansion
+                        .resolve(Directionality.of(context)),
+                    transform: jellyTransform,
+                    borderRadius: indicatorRadius * 2,
+                  ),
+                  child: Container(
+                    padding: widget.tabPadding,
+                    height: widget.barHeight,
+                    child: widget.selectedTabBuilder(
+                        context, thickness, alignment),
+                  ),
+                ),
+              ),
+            ),
         ],
       ),
     );

--- a/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
@@ -89,6 +89,7 @@ class TabBarSearchableLayout extends StatefulWidget {
     this.magnification = 1.15,
     this.innerBlur = 0.0,
     this.platformViewBackdrop = false,
+    this.passthroughOverPlatformView = false,
     this.maskingQuality = MaskingQuality.high,
     this.backgroundKey,
     this.springDescription,
@@ -166,6 +167,11 @@ class TabBarSearchableLayout extends StatefulWidget {
   final double magnification;
   final double innerBlur;
   final bool platformViewBackdrop;
+
+  /// See [SearchableTabIndicator.passthroughOverPlatformView]. Set this when
+  /// the bar floats over a map, camera preview or other platform view and its
+  /// glass is configured to stay transparent instead of painting a body.
+  final bool passthroughOverPlatformView;
   final MaskingQuality maskingQuality;
   final GlobalKey? backgroundKey;
   final SpringDescription? springDescription;
@@ -760,6 +766,8 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                                   widget.indicatorPinchStrength,
                               backgroundKey: widget.backgroundKey,
                               platformViewBackdrop: widget.platformViewBackdrop,
+                              passthroughOverPlatformView:
+                                  widget.passthroughOverPlatformView,
                               isSearchActive: searching,
                               interactionGlowColor:
                                   widget.interactionBehavior.hasGlow

--- a/lib/widgets/shared/animated_glass_indicator.dart
+++ b/lib/widgets/shared/animated_glass_indicator.dart
@@ -280,6 +280,14 @@ class AnimatedGlassIndicator extends StatelessWidget {
               _settingsDefaults.platformViewFallbackColor
           ? override.platformViewFallbackColor
           : null,
+      // Forwarded for the same reason as the two above: without it an
+      // indicator over a platform view silently ignores the caller's
+      // PlatformViewGlassMode and renders its body opaque (black), while
+      // every other surface on the same bar honours it.
+      platformViewMode:
+          override.platformViewMode != _settingsDefaults.platformViewMode
+              ? override.platformViewMode
+              : null,
     );
   }
 

--- a/shaders/liquid_glass_final_render.frag
+++ b/shaders/liquid_glass_final_render.frag
@@ -94,6 +94,10 @@ uniform vec2 uCaptureOffset;
 // Slot 28-31: uEdgeConfig — x: ambientRim (scaled by DPR/3.0), y: fresnelStrength, z: dprScale (DPR/3.0), w: pad
 uniform vec4 uEdgeConfig;
 
+// Slot 32: uPlatformViewMode — 0 = fallbackColor (default), 1 = passthrough.
+// See PlatformViewGlassMode. At 0 this shader is bit for bit unchanged.
+uniform float uPlatformViewMode;
+
 // uThickness directly and is already DPR-independent).
 // uniform float uRefractScale; // Removed in favor of scaling uThickness
 
@@ -551,6 +555,41 @@ void main() {
     float fresnel = rimBase * 0.12 * uEdgeConfig.y + ring * 0.45;
     finalColor.rgb = clamp(finalColor.rgb + vec3(fresnel), 0.0, 1.0);
 
-    float alpha  = geometryData.a;
+    // sortd patch: PASSTHROUGH mode, for glass over a platform view.
+    //
+    // Stock, the body is opaque over its whole shape. Over a platform view
+    // (a map, camera preview, video, webview) the backdrop texture holds
+    // nothing, so the body resolved to opaque BLACK - the black pill.
+    //
+    // The tab bar's own answer over a platform view is to refract its ICON
+    // LAYER instead of the uncapturable backdrop. That is why simply making
+    // the body transparent is not enough: the icon layer is also drawn
+    // directly, so a see-through body reveals the crisp copy next to the
+    // refracted one, i.e. doubled labels. The opaque body was hiding it.
+    //
+    // In passthrough the body is therefore dropped entirely and only the
+    // rim and its highlights are drawn. What shows inside the shape is the
+    // real content beneath, at its own crisp scale, over the live platform
+    // view - no black, no invented fill colour, and nothing drawn twice.
+    //
+    bool passthrough = uPlatformViewMode > 0.5;
+    float alpha = geometryData.a;
+    if (passthrough) {
+        // Body coverage follows what was actually sampled: opaque where the
+        // refracted content is real, clear where the backdrop held nothing,
+        // so the platform view shows through instead of resolving to black.
+        // The rim keeps its own coverage so the edge still reads.
+        // The doubling this used to cause is handled above the shader: the
+        // content under the shape is not drawn there at all (see
+        // SearchableTabIndicator.passthroughOverPlatformView).
+        float rim = clamp(fresnel * 3.0, 0.0, 1.0);
+        alpha *= max(refractColor.a, rim);
+        // Over an empty backdrop the body contributes no colour, so the edge
+        // would resolve to a flat grey band. Glass edges read as SPECULAR:
+        // push the rim toward white in proportion to its own strength, so
+        // the droplet keeps a lit, reflective edge over the platform view.
+        finalColor.rgb = mix(finalColor.rgb, vec3(1.0),
+                             rim * (1.0 - refractColor.a) * 0.85);
+    }
     fragColor    = vec4(finalColor.rgb * alpha, alpha);
 }


### PR DESCRIPTION
Closes #246

Glass over a platform view (`UiKitView` / `AndroidView`, so maps, camera previews, video, webviews) renders as a solid black slab. The shape, rim and lighting are all correct; only the body is wrong.

The cause is the last line of `main()` in `liquid_glass_final_render.frag`:

```glsl
float alpha  = geometryData.a;
fragColor    = vec4(finalColor.rgb * alpha, alpha);
```

`geometryData.a` is the shape's SDF coverage, so the body is drawn fully opaque whether or not the backdrop sample returned anything. Platform views are composited outside the Flutter scene, so for them it never does: `BackdropFilter` reads a compositor hole and `toImageSync` cannot capture them at all. An empty sample is premultiplied `vec4(0)`, which resolves to black at full alpha.

`platformViewFallbackColor` already exists for this and composites an opaque stand-in colour. That is right for a flat, known background and cannot serve a live map, where no single colour is correct and leaving it unset means black.

## What this adds

`PlatformViewGlassMode`, on `LiquidGlassSettings`:

| | |
|---|---|
| `fallbackColor` | **Default.** Exactly today's behaviour. Body opaque; unsampled regions take `platformViewFallbackColor`, or black when unset. |
| `passthrough` | Coverage follows what was actually sampled: opaque where the backdrop held content, clear where it held nothing. The rim keeps its own coverage, so the edge still reads. |

The trade-off is why this is a mode and not a behaviour change: there is nothing to refract in an unsampled region, so `passthrough` yields a clear shape with rim and lighting rather than a lens. Both answers are wrong in different ways and only the caller knows which is less wrong for their screen.

## Why it cannot regress an existing app

A real backdrop arrives premultiplied with `a == 1`, so the multiply is by `1.0`. The default is `fallbackColor`, which sets the new uniform to `0`, and at `0` the shader is bit for bit unchanged. No existing surface changes.

## The tab bar consequence

A body that is no longer opaque means `SearchableTabIndicator` refracts the bar's own icon layer while that layer is also on screen, so both copies show. `passthroughOverPlatformView` is the matching opt-in, plumbed through `tab_bar_searchable_layout.dart`. `AnimatedGlassIndicator` also forwards `platformViewMode`, without which an indicator silently ignores the caller's mode and renders opaque while every other surface on the same bar honours it.

## Before / after

Glass over a **stock `mapbox_maps_flutter` MapWidget**, which is a `UiKitView`.
Same build, same glass settings, same simulator, same camera. The only
difference between the two runs is `platformViewMode`.

| Before (`fallbackColor`, today's default) | After (`passthrough`) |
|---|---|
| <img src="https://raw.githubusercontent.com/Nixxx19/liquid_glass_widgets/assets/pr-247-screens/before.png" width="320"> | <img src="https://raw.githubusercontent.com/Nixxx19/liquid_glass_widgets/assets/pr-247-screens/after.png" width="320"> |
| The capsule and the tab bar are opaque slabs. The map behind them is rendering fine; only the glass is wrong. With no `platformViewFallbackColor` set they resolve to black. | The same two surfaces are clear. Streets and labels read through them, and the rim and specular still draw, so it reads as glass rather than as a hole. |

## Changes

| File | Lines | What |
|---|---|---|
| `liquid_glass_settings.dart` | 46 | the enum and the `platformViewMode` field |
| `liquid_glass_final_render.frag` | 41 | `uPlatformViewMode` at slot 32 |
| `tab_bar_searchable_internal.dart` | 75 | `passthroughOverPlatformView` |
| `liquid_glass_render_object.dart` | 16 | writes the uniform |
| `animated_glass_indicator.dart` | 8 | forwards the mode |
| `tab_bar_searchable_layout.dart` | 8 | plumbs the opt-in |
| `liquid_glass_renderer.dart` | 3 | export |
| `liquid_glass_widgets.dart` | 1 | export |

8 files, 179 insertions, 19 deletions.

## Verification

* `flutter analyze` on every touched file: clean.
* `flutter test`: 2727 passed.
* `scripts/validate_shaders.sh`: 5 passed, 0 warnings, 0 failed.
* Running in production over a Mapbox map on iOS, premium quality, on device and simulator.
