### PR TITLE
feat(GlassChip): expose platformViewBackdrop so chips can render over a platform view

### DIFF
--- a/lib/widgets/interactive/glass_chip.dart
+++ b/lib/widgets/interactive/glass_chip.dart
@@ -107,6 +107,7 @@ class GlassChip extends StatelessWidget {
     this.settings,
     this.useOwnLayer = false,
     this.quality,
+    this.platformViewBackdrop = false,
     // GlassButton properties
     this.interactionScale = 1.03,
     this.stretch = 0.3,
@@ -221,6 +222,16 @@ class GlassChip extends StatelessWidget {
   ///
   /// Use [GlassQuality.premium] for shader-based glass in static layouts only.
   final GlassQuality? quality;
+
+  /// Render the backdrop through a live [BackdropFilter] instead of the
+  /// shader's captured backdrop.
+  ///
+  /// Set this when the chip floats over a platform view (a map, a camera
+  /// preview, a video). The premium and standard shaders read their backdrop
+  /// from a capture, which cannot see a platform view, so over one they
+  /// render inert. [GlassButton] already exposes this; without it here a chip
+  /// has no correct rendering path above a platform view.
+  final bool platformViewBackdrop;
 
   // ===========================================================================
   // Interaction Properties (from GlassButton)
@@ -352,6 +363,7 @@ class GlassChip extends StatelessWidget {
           settings: settings,
           useOwnLayer: useOwnLayer,
           quality: quality ?? GlassQuality.standard,
+          platformViewBackdrop: platformViewBackdrop,
           interactionScale: effectiveInteractionScale,
           stretch: effectiveStretch,
           glowRadius: glowRadius,


### PR DESCRIPTION
closes #249

`GlassButton` exposes `platformViewBackdrop` and forwards it to `AdaptiveGlass`. `GlassChip` builds on `GlassButton.custom` but never exposed it, so a chip over a platform view had no correct rendering path: the shaders read their backdrop from a capture, and a capture cannot see a platform view.

this adds the parameter, documents why it exists, and forwards it. default is `false`, so nothing changes for anyone not asking for it.

```dart
GlassChip(
  label: 'Restaurant',
  platformViewBackdrop: true, // over a map, camera preview, video
)
```

verified with `flutter analyze` on the changed file.
