### PR TITLE
fix(GlassNavigationShell): let a presented route cover the pinned chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Thanks to [@JakeThomson](https://github.com/JakeThomson) for the materialize tra
 
 Thanks to [@Nixxx19](https://github.com/Nixxx19) for the platform-view glass passthrough mode and `GlassChip` backdrop parameter (#247, #250).
 
+## Bug Fixes
+
+- **Presented routes now cover the pinned chrome (#257):** A dialog, action sheet, `GlassModalSheet` or `fullscreenDialog` route is pushed *into* the `Navigator` the chrome is drawn above, so it arrived underneath — and drives no `secondaryAnimation` for the existing retreat to catch. The shell now hands the chrome back to the route while one is up, where the presentation and its barrier cover it as they cover the page; pushes are unchanged.
+
 ---
 
 # 1.1.0

--- a/docs/GLASS_NAVIGATION_TRANSITION.md
+++ b/docs/GLASS_NAVIGATION_TRANSITION.md
@@ -219,7 +219,8 @@ enabled: ModalRoute.of(context)?.impliesAppBarDismissal ?? false,
 | Leading changes between a glass item and a bare one | The same materialize window, not a cross-fade: glass cannot cross-fade into something that is not glass |
 | Tap while a transition runs | Ignored. The chrome is showing a blend of two routes' items, so a tap would fire an action the user can no longer see |
 | Navigation starts with a menu open | The menu is dismissed; the capsule outlives the route, so nothing else would |
-| Non-participating route or modal sheet on top | Chrome retreats with the covering route's transition and returns on pop |
+| Non-participating route **pushed** on top | Chrome retreats with the covering route's transition and returns on pop |
+| Dialog, action sheet, modal sheet or fullscreen dialog **presented** | Chrome returns to the route, so the presentation and its barrier cover it as they cover the rest of the page; pinned again on dismissal |
 | No shell installed, or `GlassQuality.minimal` | `GlassAppBar.pinned` renders in-route: the same leading and trailing groups, drawn inside the bar |
 
 A glass surface's backdrop pass still renders fully or not at all, so glass is
@@ -291,7 +292,10 @@ that future.
   that appears or disappears. The effect is driven by route progress, and at
   rest there is none to drive it.
 - One navigator per shell; nested navigators (for example go_router's
-  `StatefulShellRoute` branches) are not yet supported.
+  `StatefulShellRoute` branches) are not yet supported. A presentation made on
+  a *different* navigator from the route that owns the chrome — a
+  `useRootNavigator: true` dialog raised from inside a nested stack — is not
+  seen as covering it, for the same reason.
 - RTL layouts are untested. The clusters themselves are now placed with
   `Positioned.directional` and anchored to the logical edge, but item order
   within a cluster is not mirrored.

--- a/example/lib/demos/nav_bar_patterns_demo.dart
+++ b/example/lib/demos/nav_bar_patterns_demo.dart
@@ -14,6 +14,8 @@
 ///  10. Leading items — a custom leading that replaces, supplements, or drops
 ///      the glass behind itself entirely
 ///  11. Custom bar pinning — a plain Material AppBar pinned via GlassPinnedBarChrome
+///  12. Presented sheets — a dialog, action sheet, modal sheet or fullscreen
+///      dialog covering the pinned chrome the way it covers the page (#257)
 ///
 /// Run standalone:
 ///   flutter run -t lib/demos/nav_bar_patterns_demo.dart
@@ -170,6 +172,14 @@ class NavBarPatternsDemo extends StatelessWidget {
                       'A plain Material AppBar that still pins — GlassPinnedBarChrome',
                   icon: CupertinoIcons.rectangle_stack_badge_plus,
                   onTap: () => _push(context, const _CustomBarPinningDemo()),
+                ),
+                SizedBox(height: 16),
+                _PatternTile(
+                  title: 'Presented Sheets',
+                  subtitle: 'A sheet, dialog or fullscreen dialog covering the '
+                      'pinned chrome the way it covers the page',
+                  icon: CupertinoIcons.rectangle_stack,
+                  onTap: () => _push(context, const _PresentedSheetsDemo()),
                 ),
                 SizedBox(height: 16),
                 _PatternTile(
@@ -1764,6 +1774,277 @@ class _CustomBarPinningDemo extends StatelessWidget {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// 13. Presented Sheets — what a modal presentation covers, and what it doesn't
+// =============================================================================
+
+/// A pinned screen that presents each kind of modal route over itself.
+///
+/// Pushing and presenting need opposite treatment, and this is the presenting
+/// half. A pushed route slides the covered bar away with its page, so the
+/// chrome retreats with it; a presented one comes up over the whole navigation
+/// stack with the bar inside it, so the chrome has to be *under* it — still on
+/// screen behind a sheet, dimming with the barrier like the rest of the page.
+///
+/// The shell cannot draw it there, because it draws above the `Navigator` the
+/// presentation was pushed into, so each of these hands the chrome back to the
+/// route for as long as it is up (#257).
+///
+/// The full-height sheet reads clearest: it goes opaque at the `large` detent,
+/// so a back button still drawn on top would be left floating on a solid
+/// surface with nothing behind it to refract.
+class _PresentedSheetsDemo extends StatelessWidget {
+  const _PresentedSheetsDemo();
+
+  /// The headline case: a sheet tall enough to sit behind the whole bar.
+  void _showSheet(BuildContext context) {
+    GlassModalSheet.show<void>(
+      context: context,
+      initialState: GlassSheetState.full,
+      detents: const {GlassSheetDetent.large},
+      builder: (_) => const _PresentedSheetBody(
+        title: 'Full-height sheet',
+        body: 'This surface is opaque at the large detent, and nothing is '
+            'drawn on top of it — the back button and actions capsule are '
+            'behind it, with the rest of the page.',
+      ),
+    );
+  }
+
+  void _showActionSheet(BuildContext context) {
+    showCupertinoModalPopup<void>(
+      context: context,
+      builder: (sheetContext) => CupertinoActionSheet(
+        title: const Text('Share'),
+        message: const Text(
+          'The barrier dims the page behind this sheet, the pinned back '
+          'button and actions capsule included.',
+        ),
+        actions: [
+          CupertinoActionSheetAction(
+            onPressed: () => Navigator.of(sheetContext).pop(),
+            child: const Text('Copy Link'),
+          ),
+          CupertinoActionSheetAction(
+            onPressed: () => Navigator.of(sheetContext).pop(),
+            child: const Text('Add to Reading List'),
+          ),
+        ],
+        cancelButton: CupertinoActionSheetAction(
+          onPressed: () => Navigator.of(sheetContext).pop(),
+          child: const Text('Cancel'),
+        ),
+      ),
+    );
+  }
+
+  void _showDialog(BuildContext context) {
+    showCupertinoDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      builder: (dialogContext) => CupertinoAlertDialog(
+        title: const Text('Discard draft?'),
+        content: const Text(
+          'An alert dims the whole screen. Look at the bar: the back button '
+          'and the capsule dim with everything else.',
+        ),
+        actions: [
+          CupertinoDialogAction(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+          CupertinoDialogAction(
+            isDestructiveAction: true,
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Discard'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// An ordinary page route, but presented rather than pushed — so
+  /// `canTransitionTo` refuses it and no exit transition runs beneath it,
+  /// which is why the retreat a push gets cannot cover this case.
+  void _showFullscreenDialog(BuildContext context) {
+    Navigator.of(context).push(
+      CupertinoPageRoute<void>(
+        fullscreenDialog: true,
+        builder: (_) => const _ComposeScreen(),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final topPad = MediaQuery.paddingOf(context).top;
+
+    return GlassScaffold(
+      background: const ShowcaseBackground(),
+      settings: RecommendedGlassSettings.standard,
+      statusBarStyle: GlassStatusBarStyle.auto,
+      appBar: GlassAppBar.pinned(
+        title: Text(
+          'Presented Sheets',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: CupertinoColors.label.resolveFrom(context),
+          ),
+        ),
+        actions: [
+          GlassBarItem.icon(
+            icon: const Icon(CupertinoIcons.share),
+            label: 'Share',
+            onTap: () => _showActionSheet(context),
+          ),
+          GlassBarItem.icon(
+            icon: const Icon(CupertinoIcons.ellipsis),
+            label: 'More',
+            onTap: () {},
+          ),
+        ],
+      ),
+      body: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(child: SizedBox(height: topPad + 44 + 16)),
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            sliver: SliverList.list(
+              children: [
+                Text(
+                  'Each of these is presented over this screen, and each '
+                  'covers the pinned chrome along with the rest of the page. '
+                  'Watch the back button and the capsule dim with the barrier: '
+                  'presenting hands them back to the route, where a '
+                  'presentation can reach them.',
+                  style: TextStyle(
+                    fontSize: 15,
+                    height: 1.4,
+                    color: CupertinoColors.secondaryLabel.resolveFrom(context),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                _PatternTile(
+                  title: 'Full-Height Sheet',
+                  subtitle: 'Opaque at the large detent — the clearest read',
+                  icon: CupertinoIcons.rectangle_expand_vertical,
+                  onTap: () => _showSheet(context),
+                ),
+                const SizedBox(height: 16),
+                _PatternTile(
+                  title: 'Action Sheet',
+                  subtitle:
+                      'showCupertinoModalPopup — barrier dims the bar too',
+                  icon: CupertinoIcons.share,
+                  onTap: () => _showActionSheet(context),
+                ),
+                const SizedBox(height: 16),
+                _PatternTile(
+                  title: 'Alert Dialog',
+                  subtitle:
+                      'showCupertinoDialog — full-screen dim, bar included',
+                  icon: CupertinoIcons.exclamationmark_bubble,
+                  onTap: () => _showDialog(context),
+                ),
+                const SizedBox(height: 16),
+                _PatternTile(
+                  title: 'Fullscreen Dialog',
+                  subtitle: 'An opaque page, presented rather than pushed',
+                  icon: CupertinoIcons.square_arrow_up,
+                  onTap: () => _showFullscreenDialog(context),
+                ),
+              ],
+            ),
+          ),
+          _buildDummyContent(),
+          const SliverToBoxAdapter(child: SizedBox(height: 100)),
+        ],
+      ),
+    );
+  }
+}
+
+/// Content for the presented sheet — deliberately plain, so the only glass in
+/// frame is the pinned chrome sitting on top of it.
+class _PresentedSheetBody extends StatelessWidget {
+  const _PresentedSheetBody({required this.title, required this.body});
+
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 28,
+              fontWeight: FontWeight.w700,
+              letterSpacing: -0.4,
+              color: CupertinoColors.label.resolveFrom(context),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            body,
+            style: TextStyle(
+              fontSize: 16,
+              height: 1.4,
+              color: CupertinoColors.secondaryLabel.resolveFrom(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The destination behind [_PresentedSheetsDemo]'s fullscreen dialog.
+///
+/// Opaque and full-screen, with a bar of its own — so anything still drawn
+/// above it would unambiguously be the chrome belonging to the screen
+/// underneath.
+class _ComposeScreen extends StatelessWidget {
+  const _ComposeScreen();
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      backgroundColor: CupertinoColors.systemBackground.resolveFrom(context),
+      navigationBar: CupertinoNavigationBar(
+        middle: const Text('New Message'),
+        trailing: CupertinoButton(
+          padding: EdgeInsets.zero,
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Done'),
+        ),
+      ),
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Text(
+            'A fullscreen dialog covers the page completely — the pinned back '
+            'button and capsule from the screen behind included, with nothing '
+            'left showing through.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 16,
+              height: 1.4,
+              color: CupertinoColors.secondaryLabel.resolveFrom(context),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/widgets/surfaces/glass_navigation_shell.dart
+++ b/lib/widgets/surfaces/glass_navigation_shell.dart
@@ -144,6 +144,12 @@ class GlassNavigationShellState extends State<GlassNavigationShell>
   /// Fires whenever the rendered chrome may have changed.
   final _TickNotifier _tick = _TickNotifier();
 
+  /// Notifies when the answer [isHoisting] gives may have changed.
+  ///
+  /// Registrants follow this rather than reading the routes themselves, so
+  /// that the bar and the shell always swap in the same frame.
+  Listenable get chromeChanges => _tick;
+
   /// Whether a deferred notification is already queued for this frame.
   bool _notifyQueued = false;
 
@@ -364,6 +370,53 @@ class GlassNavigationShellState extends State<GlassNavigationShell>
   static double _coverageOf(ModalRoute<dynamic> route) =>
       route.secondaryAnimation?.value ?? 0.0;
 
+  /// Whether [route] should leave its chrome to the shell this frame.
+  ///
+  /// True for every registered route while the shell is drawing, not only the
+  /// topmost one: mid-transition the chrome is a blend of two routes' items,
+  /// so the outgoing route has to keep its placeholder or its own buttons
+  /// would slide out from underneath the pinned copy.
+  bool isHoisting(ModalRoute<dynamic> route) {
+    if (!isActive || !_registry.containsKey(route)) return false;
+    final ordered = _orderedEntries;
+    if (ordered.isEmpty) return false;
+    return !_isPresentedOver(ordered.first.key);
+  }
+
+  /// Whether a route this shell cannot rank has been *presented* over [route].
+  ///
+  /// UIKit's push/present split is the one that matters here, and the two need
+  /// opposite treatment. A pushed route slides the covered bar away with its
+  /// page, which the shell mirrors by retreating the chrome on the covered
+  /// route's `secondaryAnimation`. A presented one — a dialog, an action
+  /// sheet, a modal sheet, a fullscreen dialog — comes up over the whole
+  /// navigation stack with the bar inside it, and drives no exit transition to
+  /// retreat on: `CupertinoRouteTransitionMixin.canTransitionTo` refuses a
+  /// next route that is neither a `CupertinoRouteTransitionMixin` nor carries
+  /// a `delegatedTransition`, and refuses a fullscreen dialog outright.
+  ///
+  /// Retreating would be the wrong answer even if there were an animation to
+  /// retreat on. The chrome is not covered by a presentation, it is *under*
+  /// one — still on screen behind a sheet, dimming with the barrier like the
+  /// rest of the page. The shell cannot draw it there, because it draws above
+  /// the [Navigator] the presentation was pushed into, so it gives the chrome
+  /// back and the route renders it exactly where it renders when no shell is
+  /// installed at all.
+  ///
+  /// `isCurrent` cannot answer this on its own: a route being popped is not
+  /// current either, and it owns the chrome for the whole of its exit. What
+  /// separates the two is whether any transition is running.
+  static bool _isPresentedOver(ModalRoute<dynamic> route) =>
+      !route.isCurrent && _isAtRest(route);
+
+  /// Whether no transition involving [route] is in flight.
+  static bool _isAtRest(ModalRoute<dynamic> route) =>
+      (route.animation?.status ?? AnimationStatus.completed) ==
+          AnimationStatus.completed &&
+      (route.secondaryAnimation?.status ?? AnimationStatus.dismissed) ==
+          AnimationStatus.dismissed &&
+      !(route.navigator?.userGestureInProgress ?? false);
+
   /// The chrome progress to render, holding still under an active gesture.
   ///
   /// While the finger is down this returns the value the chrome had when the
@@ -427,6 +480,12 @@ class GlassNavigationShellState extends State<GlassNavigationShell>
     if (ordered.isEmpty) return null;
 
     final top = ordered.first;
+
+    // Nothing drawn above the `Navigator` can be underneath a route presented
+    // into it, so the shell stands down and the registrants take their chrome
+    // back for as long as one is up.
+    if (_isPresentedOver(top.key)) return null;
+
     final below = ordered.length > 1 ? ordered[1] : null;
 
     // Progress of the top route's own entrance: 1 at rest, 0 when it has just

--- a/lib/widgets/surfaces/glass_pinned_bar_chrome.dart
+++ b/lib/widgets/surfaces/glass_pinned_bar_chrome.dart
@@ -46,9 +46,12 @@ class GlassPinnedBarChromeData {
   /// Whether the shell has taken this route's chrome.
   ///
   /// False while the bar still draws it, and true once the shell has both
-  /// accepted the registration and had a frame to render its copy. [leading]
-  /// and [actions] already account for this — read it only to substitute your
-  /// own chrome for the package's.
+  /// accepted the registration and had a frame to render its copy. It goes
+  /// false again for as long as a dialog or a modal sheet is presented over
+  /// the route: the shell draws above the [Navigator] and cannot get beneath
+  /// one, so the bar takes its chrome back and the presentation covers it.
+  /// [leading] and [actions] already account for all of this — read it only to
+  /// substitute your own chrome for the package's.
   final bool hoisted;
 }
 
@@ -88,6 +91,12 @@ typedef GlassPinnedBarChromeBuilder = Widget Function(
 /// content, so the bar keeps the layout it had and the title never shifts. The
 /// hand-over is deliberately a frame late: at the swap both copies are static
 /// and identical, so they never overlap and never both disappear.
+///
+/// The hand-over runs in reverse too. While a dialog or a modal sheet is
+/// presented over the route the shell has nowhere valid to draw — it sits
+/// above the [Navigator] the presentation was pushed into — so the slots take
+/// the real buttons back and the presentation covers them along with the rest
+/// of the page.
 ///
 /// Where there is no shell — or the device cannot render the effect — the
 /// slots simply keep the real buttons, so a bar written this way works either
@@ -174,6 +183,9 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
   ModalRoute<dynamic>? _route;
   bool _handedOver = false;
 
+  /// The shell notification this bar is currently following, if any.
+  Listenable? _chromeChanges;
+
   /// Whether this route shows the automatic back button at all.
   ///
   /// A custom leading replaces it, mirroring UIKit — *"A custom left item
@@ -204,9 +216,11 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
 
     if (shell != _shell || route != _route) {
       _release();
+      _unfollow();
       _shell = shell;
       _route = route;
       _handedOver = false;
+      _follow();
     }
 
     // Deliberately no offstage or TickerMode guard here. Flutter builds a newly
@@ -234,16 +248,43 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
         buttonSettings: widget.buttonSettings,
       ),
     );
+  }
 
-    if (!_handedOver) {
-      // The shell renders the chrome on the next frame; hand over then, so the
-      // bar and the shell swap in the same frame rather than one before the
-      // other.
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && _shell != null && _shell!.isActive) {
-          setState(() => _handedOver = true);
-        }
-      });
+  /// Follows the shell's hand-over decision.
+  ///
+  /// The shell re-resolves on the frame *after* a registration lands or a
+  /// route changes, so the hand-over is deliberately a frame late: at the swap
+  /// both copies are static and identical, and they never overlap and never
+  /// both disappear. The same holds in reverse when a presentation takes the
+  /// chrome back — a route under a dialog or a modal sheet is not moving
+  /// either.
+  void _follow() {
+    final shell = _shell;
+    if (shell == null) return;
+    _chromeChanges = shell.chromeChanges..addListener(_onChromeChanged);
+  }
+
+  void _unfollow() {
+    _chromeChanges?.removeListener(_onChromeChanged);
+    _chromeChanges = null;
+  }
+
+  /// Takes the shell's decision as of this notification.
+  ///
+  /// Deliberately snapshotted rather than read during [build]: a bar that
+  /// asked the shell on every build would answer from routes the shell has not
+  /// re-resolved against yet, and swap a frame before it — a frame in which
+  /// both copies are on screen. Reading both from the same notification keeps
+  /// them one image.
+  void _onChromeChanged() {
+    final shell = _shell;
+    final route = _route;
+    final hoisted = widget.enabled &&
+        shell != null &&
+        route != null &&
+        shell.isHoisting(route);
+    if (mounted && hoisted != _handedOver) {
+      setState(() => _handedOver = hoisted);
     }
   }
 
@@ -258,6 +299,7 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
   @override
   void dispose() {
     _release();
+    _unfollow();
     super.dispose();
   }
 

--- a/test/widgets/surfaces/glass_navigation_shell_test.dart
+++ b/test/widgets/surfaces/glass_navigation_shell_test.dart
@@ -740,6 +740,206 @@ void main() {
     });
   });
 
+  group('presented routes', () {
+    /// The back button drawn by the route's own bar, as opposed to the shell's.
+    Finder inRouteBack() => find.descendant(
+          of: find.byType(GlassAppBar),
+          matching: find.byIcon(CupertinoIcons.back),
+        );
+
+    /// Pushes a screen that shows a pinned back button.
+    Future<void> pushDetail(WidgetTester tester) async {
+      await _push(tester, const _Screen(title: 'Detail', actions: []));
+      await settle(tester);
+    }
+
+    /// Exactly one copy of the back button is on screen, never two or none.
+    void expectOneCopy(String when) {
+      final copies =
+          pinnedBack().evaluate().length + inRouteBack().evaluate().length;
+      expect(copies, 1, reason: 'copies of the back button $when');
+    }
+
+    testWidgets('a modal popup takes the chrome back into the route',
+        (tester) async {
+      await tester.pumpWidget(
+        shellApp(const _Screen(title: 'Root', actions: [])),
+      );
+      await settle(tester);
+      await pushDetail(tester);
+      expect(pinnedBack(), findsOneWidget);
+
+      showCupertinoModalPopup<void>(
+        context: tester.element(find.text('Detail body')),
+        builder: (_) => const SizedBox(height: 400),
+      );
+      await settle(tester);
+
+      // The shell draws above the navigator, so it cannot draw beneath a route
+      // pushed into it. The route renders its own buttons instead.
+      expect(pinnedBack(), findsNothing);
+      expect(inRouteBack(), findsOneWidget);
+    });
+
+    testWidgets('so does a dialog', (tester) async {
+      await tester.pumpWidget(
+        shellApp(const _Screen(title: 'Root', actions: [])),
+      );
+      await settle(tester);
+      await pushDetail(tester);
+
+      showCupertinoDialog<void>(
+        context: tester.element(find.text('Detail body')),
+        builder: (_) => const CupertinoAlertDialog(title: Text('Alert')),
+      );
+      await settle(tester);
+
+      expect(pinnedBack(), findsNothing);
+      expect(inRouteBack(), findsOneWidget);
+    });
+
+    testWidgets('and a fullscreen dialog, which drives no exit transition',
+        (tester) async {
+      // `CupertinoRouteTransitionMixin.canTransitionTo` refuses one, so the
+      // covered route's `secondaryAnimation` never runs and the retreat that
+      // handles an ordinary push never starts.
+      await tester.pumpWidget(
+        shellApp(const _Screen(title: 'Root', actions: [])),
+      );
+      await settle(tester);
+      await pushDetail(tester);
+
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      navigator.push(CupertinoPageRoute<void>(
+        fullscreenDialog: true,
+        builder: (_) => const CupertinoPageScaffold(
+          child: Center(child: Text('Compose')),
+        ),
+      ));
+      await settle(tester);
+
+      expect(find.text('Compose'), findsOneWidget);
+      expect(pinnedBack(), findsNothing);
+    });
+
+    testWidgets('the chrome is pinned again once the presentation is gone',
+        (tester) async {
+      await tester.pumpWidget(
+        shellApp(const _Screen(title: 'Root', actions: [])),
+      );
+      await settle(tester);
+      await pushDetail(tester);
+
+      final context = tester.element(find.text('Detail body'));
+      showCupertinoDialog<void>(
+        context: context,
+        builder: (_) => const CupertinoAlertDialog(title: Text('Alert')),
+      );
+      await settle(tester);
+      Navigator.of(context, rootNavigator: true).pop();
+      await settle(tester);
+
+      expect(pinnedBack(), findsOneWidget);
+      expect(inRouteBack(), findsNothing);
+
+      // ...and it is live again, not just drawn.
+      await tester.tap(pinnedBack());
+      await settle(tester);
+      expect(find.text('Detail body'), findsNothing);
+    });
+
+    testWidgets('a committed swipe onto a non-pinned root keeps one copy',
+        (tester) async {
+      // Where the hand-back meets the commit-exit path. A committed swipe
+      // plays from a frozen snapshot while the outgoing route is popped but
+      // not yet unregistered, and the destination here contributes no chrome
+      // of its own — so this is the thinnest the registry ever gets with the
+      // shell still drawing.
+      await tester.pumpWidget(
+        shellApp(const _Screen(title: 'Root')), // null actions: not pinned
+      );
+      await settle(tester);
+      await _push(tester, const _Screen(title: 'Detail', actions: []));
+      await settle(tester);
+      expectOneCopy('at rest before the swipe');
+
+      final width =
+          tester.view.physicalSize.width / tester.view.devicePixelRatio;
+      final gesture = await tester.startGesture(const Offset(2, 300));
+      await gesture.moveTo(Offset(width * 0.9, 300));
+      await gesture.up();
+
+      for (var frame = 0; frame < 40; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        final copies =
+            pinnedBack().evaluate().length + inRouteBack().evaluate().length;
+        expect(copies, lessThanOrEqualTo(1),
+            reason: 'copies of the back button at commit frame $frame');
+      }
+
+      await settle(tester);
+      // Root shows no back button at all, from either side.
+      expect(find.byIcon(CupertinoIcons.back), findsNothing);
+    });
+
+    testWidgets('exactly one copy is on screen for every frame of the swap',
+        (tester) async {
+      await tester.pumpWidget(
+        shellApp(const _Screen(title: 'Root', actions: [])),
+      );
+      await settle(tester);
+      await pushDetail(tester);
+      expectOneCopy('at rest');
+
+      final context = tester.element(find.text('Detail body'));
+      showCupertinoDialog<void>(
+        context: context,
+        builder: (_) => const CupertinoAlertDialog(title: Text('Alert')),
+      );
+      for (var frame = 0; frame < 30; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        expectOneCopy('at presentation frame $frame');
+      }
+
+      Navigator.of(context, rootNavigator: true).pop();
+      for (var frame = 0; frame < 30; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        expectOneCopy('at dismissal frame $frame');
+      }
+    });
+
+    testWidgets('and for every frame of a push and pop between two routes',
+        (tester) async {
+      // The outgoing route has to keep its placeholder for the whole
+      // transition: the shell is drawing a blend of both routes' items, and a
+      // bar that took its own chrome back would slide a second copy out from
+      // underneath the pinned one.
+      await tester.pumpWidget(
+        shellApp(const _Screen(title: 'Root', actions: [])),
+      );
+      await settle(tester);
+      await pushDetail(tester);
+
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      navigator.push(CupertinoPageRoute<void>(
+        builder: (_) => const _Screen(title: 'Third', actions: []),
+      ));
+      // The first frame is Flutter's offstage build of the incoming route,
+      // where neither copy is on stage yet.
+      await tester.pump(const Duration(milliseconds: 16));
+      for (var frame = 1; frame < 40; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        expectOneCopy('at push frame $frame');
+      }
+
+      navigator.pop();
+      for (var frame = 0; frame < 40; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        expectOneCopy('at pop frame $frame');
+      }
+    });
+  });
+
   group('pull-down menus', () {
     List<GlassBarItem> menuActions({String label = 'Copy'}) => [
           GlassBarItem.menu(


### PR DESCRIPTION
## Description

A route presented over a pinned screen — a dialog, an action sheet, a `GlassModalSheet`, a `fullscreenDialog` — should cover the pinned chrome the way it covers the rest of the page. It didn't: the glass back button and actions capsule stayed painted over the presentation and over its barrier, at full brightness while everything else dimmed by half.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/7cca6518-a9e2-4382-a9e6-2c0c1b13a4f1" /> | <video src="https://github.com/user-attachments/assets/6b255e28-7a03-4f15-aab5-2858b8c093c7" /> | 

The chrome is drawn in an overlay that is a *sibling* of the `Navigator`, above it — exactly what keeps it still while page content slides. A presentation is pushed *into* that same `Navigator`, so it arrives underneath. The existing retreat can't catch it either: `coverage` reads the covered route's `secondaryAnimation`, and `canTransitionTo` drives none for these — with a `showCupertinoModalPopup` up the covered route reports `isCurrent=false`, `secondaryAnimation=dismissed/0.0`, so `coverage` is `0` and the host renders at full size.

Retreating would be the wrong answer even if there were an animation to retreat on, and that's the part worth agreeing on before the code. The split is UIKit's own: a route that is **pushed** slides the covered bar away with its page, which the shell mirrors by retreating on `secondaryAnimation` — unchanged here. A route that is **presented** comes up over the whole stack with the bar inside it, so the chrome isn't *covered* by it but sits *under* it — still on screen behind a sheet, dimming with the barrier like everything else.

The shell can't draw it there, so it stands down and the route renders the chrome exactly where it does when no shell is installed at all — the hand-over `GlassPinnedBarChrome` already performs at registration, run in reverse. No new mechanism, no new consumer API. `isCurrent` can't decide this alone, since a popped route isn't current either and owns its chrome for its whole exit; what separates them is whether any transition is running, which is what `_isAtRest` asks.

### One subtlety worth flagging for review

`_onChromeChanged` **snapshots** the shell's decision on notification rather than reading `isHoisting` during `build`. That looks like indirection until you try it the other way: a bar that asks on every build answers from routes the shell hasn't re-resolved against yet and swaps a frame early, putting both copies on screen for that frame. `ListenableBuilder` reads tidier and has exactly that bug, since its builder runs on every rebuild rather than only on notifications. It replaces the old post-frame `_handedOver` latch, so that latch's "deliberately a frame late" property now holds in both directions.

### Measured

Luma change with an action sheet presented, against the same screen with nothing presented, sampled from the new demo on the iPhone 17 simulator:

| Region | Before | After |
|---|---|---|
| Back button glass | −6.4% | **−48.1%** |
| Actions capsule glass | −11.8% | **−47.7%** |
| Bar title text | −47.9% | −47.9% |
| Body paragraph | −47.9% | −48.5% |

The bar's own title was always behind the barrier; only the two hoisted clusters weren't. The unchanged title and body figures confirm nothing else moved; the residual is the glass refracting a backdrop that itself got darker.

One gap remains: a presentation on a *different* navigator from the route owning the chrome — a `useRootNavigator: true` dialog from inside a nested stack — isn't seen as covering it, since the nested route stays `isCurrent`. Same root cause as the nested-navigator limitation already in the guide, and noted there beside it.

Fixes #257

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Platforms Tested

- [x] iOS (Impeller)

Verified by hand on the iPhone 17 simulator (iOS 27, Impeller) against all four presentations, presented and dismissed, with the chrome pinned again afterwards and still live.

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (shaders, painting logic)
- [x] I have made corresponding changes to the documentation / CHANGELOG.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/golden tests pass locally (`flutter test`)

On that last box: `flutter test` is **2793 passing, 11 failing**, and all 11 are golden tests (`GlassTextField`, `GlassSearchBar`, `GlassButton`, `GlassChip`, glass inputs). They fail identically on a pristine `main` at 26551ae on this machine — I checked in a clean worktree — so they look environmental rather than related to this change.

### Tests added

Seven tests in a new `presented routes` group in `glass_navigation_shell_test.dart`: one each for `showCupertinoModalPopup`, `showCupertinoDialog` and `fullscreenDialog` (all three fail on `main`); the chrome pinned again and still popping after dismissal; and a committed back-swipe onto a non-pinned root, where the hand-back meets the commit-exit path.

The other two count copies of the back button every frame — across a presentation and dismissal, and across a push and pop between two pinned routes. The second pins down that `isHoisting` answers for *every* registered route, not only the topmost: the outgoing route must keep its placeholder for the whole transition, or its own buttons slide a second copy out from under the pinned one. An earlier revision of this fix got that wrong, and this is the test that caught it.

`nav_bar_patterns_demo.dart` gains a **Presented Sheets** pattern presenting all four kinds over a pinned screen. The full-height sheet reads clearest: it goes opaque at the `large` detent, so anything still drawn on top is left floating on a solid surface with nothing behind it to refract.
