### PR TITLE
Scrollable segmented control: selection stability, anchored re-grid morph, and picker behaviors

### DIFF
--- a/example/lib/demos/glass_segmented_regrid_demo.dart
+++ b/example/lib/demos/glass_segmented_regrid_demo.dart
@@ -1,0 +1,189 @@
+// Scrollable segmented control — re-grid morph + selection seating
+//
+// The scrollable control's hard case is a list whose LENGTH changes while a
+// selection is showing: a time picker that re-steps 60 → 30 → 15 minutes
+// re-grids every cell around the value you are looking at.
+//
+// Toggle "Morph" to compare the two candidate defaults for regridDuration:
+//   off (Duration.zero) — the list swaps instantly
+//   on  (180ms)         — entrants grow in, leavers shrink out, and the
+//                         selection stays anchored under your eye
+//
+// "Remount" rebuilds the control from scratch to show the seating beat: a
+// fresh mount lands with the selection already centred rather than sliding
+// in from the first segment.
+
+import 'package:flutter/cupertino.dart';
+
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await LiquidGlassWidgets.initialize();
+  runApp(LiquidGlassWidgets.wrap(child: const SegmentedRegridApp()));
+}
+
+class SegmentedRegridApp extends StatelessWidget {
+  const SegmentedRegridApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const CupertinoApp(
+      title: 'Segmented — Re-grid Morph',
+      theme: CupertinoThemeData(brightness: Brightness.dark),
+      home: SegmentedRegridHome(),
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}
+
+class SegmentedRegridHome extends StatefulWidget {
+  const SegmentedRegridHome({super.key});
+
+  @override
+  State<SegmentedRegridHome> createState() => _SegmentedRegridHomeState();
+}
+
+class _SegmentedRegridHomeState extends State<SegmentedRegridHome> {
+  /// Minutes-per-step, coarse → fine.
+  static const List<int> _steps = [60, 30, 15];
+
+  int _stepMin = 60;
+  int _selectedMin = 9 * 60; // 9:00 AM
+  bool _morph = true;
+  int _mountEpoch = 0; // bump to force a fresh mount
+
+  /// Every step from midnight, plus the current selection if the step no
+  /// longer lands on it — the same insert-if-missing rule a real picker
+  /// needs so stepping coarse can't silently move the user's value.
+  List<int> get _values {
+    final values = [for (var m = 0; m < 24 * 60; m += _stepMin) m];
+    if (!values.contains(_selectedMin)) {
+      values.add(_selectedMin);
+      values.sort();
+    }
+    return values;
+  }
+
+  static String _label(int minutes) {
+    final h24 = minutes ~/ 60;
+    final m = minutes % 60;
+    final h = h24 % 12 == 0 ? 12 : h24 % 12;
+    final digits = m == 0 ? '$h' : '$h:${m.toString().padLeft(2, '0')}';
+    return '$digits ${h24 < 12 ? 'AM' : 'PM'}';
+  }
+
+  void _setStep(int step) => setState(() => _stepMin = step);
+
+
+  @override
+  Widget build(BuildContext context) {
+    final values = _values;
+    final stepIdx = _steps.indexOf(_stepMin);
+
+    return CupertinoPageScaffold(
+      navigationBar: GlassAppBar(
+        title: const Text(
+          'Segmented — Re-grid Morph',
+          style: TextStyle(
+            color: CupertinoColors.label,
+            fontSize: 17,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        actions: [
+          GlassButton(
+            icon: const Icon(CupertinoIcons.refresh),
+            onTap: () => setState(() => _mountEpoch++),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: GlassSegmentedControl.scrollable(
+                  // The key is the demo's remount button, not part of the
+                  // API — it throws the state away so the seating beat runs
+                  // again on a fresh mount.
+                  key: ValueKey(_mountEpoch),
+                  quality: GlassQuality.premium,
+                  selectedIndex: values.indexOf(_selectedMin),
+                  onSegmentSelected: (i) =>
+                      setState(() => _selectedMin = values[i]),
+                  selectionAlignment: SegmentSelectionAlignment.center,
+                  dragBehavior: SegmentDragBehavior.scroll,
+                  regridDuration:
+                      _morph ? const Duration(milliseconds: 180) : Duration.zero,
+                  segments: [
+                    for (final m in values)
+                      // id is what lets a surviving cell keep its element
+                      // across the re-grid; without it the morph has no
+                      // anchor and the list simply redraws.
+                      GlassSegment(label: _label(m), id: 'time-$m'),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 28),
+              // Step control — the re-grid trigger.
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  GlassButton(
+                    icon: const Icon(CupertinoIcons.zoom_in),
+                    onTap: () => _setStep(
+                        _steps[(stepIdx + 1).clamp(0, _steps.length - 1)]),
+                  ),
+                  const SizedBox(width: 12),
+                  GlassButton(
+                    icon: const Icon(CupertinoIcons.zoom_out),
+                    onTap: () => _setStep(
+                        _steps[(stepIdx - 1).clamp(0, _steps.length - 1)]),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'Morph',
+                    style: TextStyle(
+                      color: CupertinoColors.label.resolveFrom(context),
+                      fontSize: 15,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  CupertinoSwitch(
+                    value: _morph,
+                    onChanged: (v) => setState(() => _morph = v),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 20),
+              Text(
+                '$_stepMin-min steps  ·  ${values.length} segments  ·  '
+                '${_label(_selectedMin)}',
+                style: TextStyle(
+                  color: CupertinoColors.secondaryLabel.resolveFrom(context),
+                  fontSize: 15,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Zoom to re-step  ·  toggle Morph to compare  ·  ↻ to remount',
+                style: TextStyle(
+                  color: CupertinoColors.tertiaryLabel.resolveFrom(context),
+                  fontSize: 13,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/interactive/scrollable_segment_content.dart
+++ b/lib/src/widgets/interactive/scrollable_segment_content.dart
@@ -688,7 +688,11 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
                     measuredReady && widget.selectedIndex < _tabOffsets.length
                         ? _tabOffsets[widget.selectedIndex]
                         : 0.0;
-                isMoving = (currentValue - targetOffset).abs() > 2.0;
+                // Only a measured target can say the pill is moving: during
+                // a remeasure gap the stale comparison read as motion and
+                // fired the bloom pulse on every list change.
+                isMoving =
+                    measuredReady && (currentValue - targetOffset).abs() > 2.0;
                 // Width alone: zero only before the very first measure. A
                 // list-length remeasure keeps the previous geometry live,
                 // so the pill stays visible through it instead of blinking.

--- a/lib/src/widgets/interactive/scrollable_segment_content.dart
+++ b/lib/src/widgets/interactive/scrollable_segment_content.dart
@@ -109,6 +109,15 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   /// Specifically tracks if we are dragging the indicator in scrollable mode.
   bool _isDraggingIndicator = false;
 
+  /// Bumped whenever the indicator springs are snapped
+  /// ([SingleSpringController.setValue]) onto freshly measured geometry —
+  /// initial mount and list-length remeasures. Rides into
+  /// [VelocitySpringBuilder.teleportEpoch] so the rendered pill JUMPS with
+  /// the springs; without it the follower animated across the
+  /// discontinuity, which showed as the pill travelling in from the track
+  /// edge on every mount and list change.
+  int _indicatorEpoch = 0;
+
   /// Shadows are suppressed while the indicator is being dragged so they
   /// do not interact with the live BackdropFilter blur, then restored
   /// when the pill is idle.
@@ -126,6 +135,7 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   late Listenable _springListenable;
 
   late List<GlobalKey> _tabKeys;
+  final Map<Object, GlobalKey> _cellKeysById = {};
   List<double> _tabWidths = [];
   List<double> _tabOffsets = [];
 
@@ -172,7 +182,17 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   }
 
   void _initKeys() {
-    _tabKeys = List.generate(widget.tabs.length, (_) => GlobalKey());
+    // Cells keep their key across list changes when their segment carries
+    // the same identity ([GlassSegment.id], falling back to label): a
+    // surviving value keeps its element instead of remounting, so a
+    // reconfigured list redraws only what actually changed. Segments with
+    // no identity, or a duplicated one, get fresh cells.
+    final seen = <Object>{};
+    _tabKeys = List.generate(widget.tabs.length, (i) {
+      final Object? id = widget.tabs[i].id ?? widget.tabs[i].label;
+      if (id == null || !seen.add(id)) return GlobalKey();
+      return _cellKeysById.putIfAbsent(id, GlobalKey.new);
+    });
     WidgetsBinding.instance.addPostFrameCallback((_) => _measureTabs());
   }
 
@@ -202,10 +222,18 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
       setState(() {
         _tabWidths = widths;
         _tabOffsets = offsets;
-        // Snap indicator to selected tab after first measure (no animation).
+        // Snap indicator to the selected tab after (re)measure; the epoch
+        // makes the rendered pill jump with the springs instead of
+        // animating in from stale geometry.
+        _indicatorEpoch++;
         _indOffsetSpring.setValue(offsets[selIdx]);
         _indWidthSpring.setValue(widths[selIdx]);
       });
+      // A selection outside the viewport comes into view without animation:
+      // at first measure there is no prior state the user has seen, and
+      // after a list change the host may have positioned the scroll itself
+      // (ensure-visible no-ops when the selection is already on screen).
+      _scrollToEnsureVisible(selIdx, animated: false);
     } else {
       WidgetsBinding.instance.addPostFrameCallback((_) => _measureTabs());
     }
@@ -281,8 +309,11 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
         _tabWidths = [];
         _tabOffsets = [];
       });
-      _indOffsetSpring.setValue(0);
-      _indWidthSpring.setValue(0);
+      // The springs deliberately KEEP their last geometry: zeroing them
+      // hid the pill for the remeasure gap and then made it travel in
+      // from the track edge. The pill holds its stale position for the
+      // remeasure frame and the epoch-snap in [_measureTabs] lands it on
+      // the new geometry with no travel.
       _initKeys();
     }
   }
@@ -523,7 +554,7 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   ///
   /// Called on tap and on programmatic selection changes. Only fires when
   /// measurements are ready and the controller has an attached position.
-  void _scrollToEnsureVisible(int tabIndex) {
+  void _scrollToEnsureVisible(int tabIndex, {bool animated = true}) {
     if (!widget.scrollController.hasClients) return;
     if (tabIndex >= _tabOffsets.length || tabIndex >= _tabWidths.length) return;
 
@@ -551,11 +582,15 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
     );
 
     if ((targetOffset - currentOffset).abs() > 0.5) {
-      widget.scrollController.animateTo(
-        targetOffset,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeOutCubic,
-      );
+      if (animated) {
+        widget.scrollController.animateTo(
+          targetOffset,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOutCubic,
+        );
+      } else {
+        widget.scrollController.jumpTo(targetOffset);
+      }
     }
   }
 
@@ -621,6 +656,7 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
           final safeTabLabels = stableTabLabels!;
           return VelocitySpringBuilder(
             value: widget.isScrollable ? _indOffsetSpring.value : _xAlign,
+            teleportEpoch: _indicatorEpoch,
             springWhenActive: GlassSpring.interactive(),
             springWhenReleased: GlassSpring.snappy(
               duration: const Duration(milliseconds: 350),
@@ -653,7 +689,10 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
                         ? _tabOffsets[widget.selectedIndex]
                         : 0.0;
                 isMoving = (currentValue - targetOffset).abs() > 2.0;
-                canShowIndicator = measuredReady && _indWidthSpring.value > 0;
+                // Width alone: zero only before the very first measure. A
+                // list-length remeasure keeps the previous geometry live,
+                // so the pill stays visible through it instead of blinking.
+                canShowIndicator = _indWidthSpring.value > 0;
               } else {
                 final double targetAlignment =
                     _computeXAlignmentForTab(widget.selectedIndex);

--- a/lib/src/widgets/interactive/scrollable_segment_content.dart
+++ b/lib/src/widgets/interactive/scrollable_segment_content.dart
@@ -18,7 +18,11 @@ import '../../../widgets/surfaces/shared/tab_bar_types.dart'
 import '../../../widgets/shared/glass_accessibility_scope.dart'
     show GlassAccessibilityData;
 import '../../../widgets/surfaces/glass_tab_bar.dart'
-    show GlassSegment, DividerSettings, SegmentSelectionAlignment;
+    show
+        GlassSegment,
+        DividerSettings,
+        SegmentDragBehavior,
+        SegmentSelectionAlignment;
 
 // =============================================================================
 // ScrollableSegmentContent — draggable indicator + segment layout
@@ -57,6 +61,7 @@ class ScrollableSegmentContent extends StatefulWidget {
     this.tabBarBorderRadius,
     this.selectionAlignment = SegmentSelectionAlignment.minimal,
     this.regridDuration = const Duration(milliseconds: 180),
+    this.dragBehavior = SegmentDragBehavior.selectIndicator,
     super.key,
   });
 
@@ -99,6 +104,9 @@ class ScrollableSegmentContent extends StatefulWidget {
 
   /// See [GlassSegmentedControl.regridDuration].
   final Duration regridDuration;
+
+  /// See [GlassSegmentedControl.dragBehavior].
+  final SegmentDragBehavior dragBehavior;
 
   @override
   State<ScrollableSegmentContent> createState() =>
@@ -624,6 +632,9 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
       setState(() => _isDown = true);
       return;
     }
+    // Picker strips: a drag NAVIGATES — never claim it for the indicator,
+    // so it falls through to the scroll view like any off-pill drag.
+    if (widget.dragBehavior == SegmentDragBehavior.scroll) return;
 
     final scrollOffset = widget.scrollController.hasClients
         ? widget.scrollController.offset

--- a/lib/src/widgets/interactive/scrollable_segment_content.dart
+++ b/lib/src/widgets/interactive/scrollable_segment_content.dart
@@ -6,6 +6,7 @@ library;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/rendering.dart' show RenderPositionedBox;
 import '../../../constants/glass_defaults.dart';
 import '../../renderer/liquid_glass_renderer.dart';
 import '../../../types/glass_quality.dart';
@@ -145,9 +146,18 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   Set<int>? _morphExiting;
   AnimationController? _morphCtrl;
   CurvedAnimation? _morphAnim;
-  double? _morphAnchorGlobalX; // selected cell's global x, held per tick
-  double? _morphAnchorLocalX; // same, in the control's coordinates (pill)
+  double? _morphAnchorLocalX; // anchor in the control's coordinates
   int _morphSelectedIndex = 0; // selected cell's index in _morphTabs
+
+  /// Natural (unfactored) width of every merged cell — survivors and
+  /// leavers from the old list's measurements, entrants measured from
+  /// their INNER boxes at the t=0 frame (the Align sizes the outer box to
+  /// zero, but the child inside it is laid out at full natural width).
+  /// With these, the anchoring scroll offset is computed ANALYTICALLY per
+  /// tick — a correction chasing last frame's boxes lags one frame, which
+  /// is catastrophic when a debug build only paints a handful of morph
+  /// frames.
+  List<double>? _morphNaturalWidths;
 
   bool get _morphing => _morphTabs != null;
 
@@ -213,6 +223,10 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   }
 
   void _onScroll() {
+    // During a morph the pill is drawn at a fixed anchor and the per-tick
+    // correction drives the scroll — rebuilding here would double the
+    // per-frame cost for nothing.
+    if (_morphing) return;
     // Rebuild to update the screen-relative indicator position during scroll.
     if (mounted) setState(() {});
   }
@@ -326,7 +340,16 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
       _initKeys();
     }
 
-    if (oldWidget.selectedIndex != widget.selectedIndex && !_isDragging) {
+    // A length change owns the whole transition (morph or snap): its
+    // measure pass seats both the pill and the scroll. Letting this branch
+    // also run would spring the pill and ensure-visible against STALE
+    // offsets from the outgoing list — the two visibly fight (verified
+    // frame-by-frame: the scroll lunged toward the stale target while the
+    // morph anchor dragged it back).
+    final lengthChanged = oldWidget.tabs.length != widget.tabs.length;
+    if (!lengthChanged &&
+        oldWidget.selectedIndex != widget.selectedIndex &&
+        !_isDragging) {
       setState(() {
         _xAlign = _computeXAlignmentForTab(widget.selectedIndex);
       });
@@ -344,7 +367,7 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
         );
       }
     }
-    if (oldWidget.tabs.length != widget.tabs.length) {
+    if (lengthChanged) {
       if (_morphing) _finishMorph(jumpToEnd: true);
       final reduceMotion = GlassAccessibilityData.of(context).reduceMotion;
       if (widget.isScrollable &&
@@ -421,46 +444,103 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
     // Anchor: where the selected cell sits RIGHT NOW.
     final anchorLocal =
         _tabOffsets[oldSel] - widget.scrollController.offset;
-    final box = context.findRenderObject();
-    if (box is! RenderBox) return false;
-    final anchorGlobal = box.localToGlobal(Offset(anchorLocal, 0)).dx;
+
+    // Natural widths: old-list cells are already measured; entrants are
+    // filled in from their inner boxes once the t=0 frame has laid out.
+    final oldWidthById = <Object, double>{
+      for (var i = 0; i < oldTabs.length; i++)
+        if (oldIds[i] != null) oldIds[i]!: _tabWidths[i],
+    };
+    final naturals = <double>[
+      for (var i = 0; i < merged.length; i++)
+        entering.contains(i)
+            ? 0.0
+            : oldWidthById[_identityOf(merged[i])] ?? 0.0,
+    ];
 
     _morphTabs = merged;
     _morphEntering = entering;
     _morphExiting = exiting;
     _morphSelectedIndex = merged.indexWhere((t) => _identityOf(t) == selId);
     _morphAnchorLocalX = anchorLocal;
-    _morphAnchorGlobalX = anchorGlobal;
+    _morphNaturalWidths = naturals;
     _morphCtrl?.dispose();
     _morphAnim?.dispose();
-    _morphCtrl = AnimationController(
+    final ctrl = AnimationController(
         vsync: this, duration: widget.regridDuration)
       ..addListener(_onMorphTick)
       ..addStatusListener((st) {
         if (st == AnimationStatus.completed) _finishMorph();
       });
-    _morphAnim =
-        CurvedAnimation(parent: _morphCtrl!, curve: Curves.easeOutCubic);
+    _morphCtrl = ctrl;
+    _morphAnim = CurvedAnimation(parent: ctrl, curve: Curves.easeOutCubic);
     setState(_initKeys); // keys for the merged list; survivors keep theirs
-    _morphCtrl!.forward();
+    // The clock starts only after the merged list's FIRST frame has been
+    // built and laid out. At t=0 that frame is pixel-identical to the old
+    // list (entrants at width 0, leavers at full), and it carries the whole
+    // re-parenting cost — on a debug build it can take longer than the
+    // entire morph, which previously let the clock expire inside it.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _morphCtrl != ctrl) return;
+      if (!_measureEnteringNaturals()) {
+        // Can't anchor without real widths — degrade to the snap path.
+        _finishMorph();
+        return;
+      }
+      ctrl.forward();
+    });
     return true;
   }
 
-  /// Per-tick: after this frame lays the animating widths out, correct the
-  /// scroll so the selected cell stays exactly on its anchor.
+  /// Fills [_morphNaturalWidths] for entering cells from the t=0 frame.
+  bool _measureEnteringNaturals() {
+    final naturals = _morphNaturalWidths;
+    if (naturals == null) return false;
+    for (final i in _morphEntering!) {
+      if (i >= _tabKeys.length) return false;
+      var box = _tabKeys[i].currentContext?.findRenderObject();
+      // Descend to the Align's child — the naturally-sized inner cell.
+      RenderBox? inner;
+      void visit(RenderObject o) {
+        if (o is RenderPositionedBox) {
+          final c = o.child;
+          if (c is RenderBox && c.hasSize) inner = c;
+          return;
+        }
+        o.visitChildren(visit);
+      }
+
+      if (box is RenderBox) visit(box);
+      if (inner == null) return false;
+      naturals[i] = inner!.size.width;
+    }
+    return true;
+  }
+
+  /// Per-tick, BEFORE this frame builds: seat the scroll ANALYTICALLY so
+  /// the selected cell's left edge sits exactly on the anchor at this
+  /// frame's t. Computed from the known natural widths — never from boxes,
+  /// which describe last frame's t and lag catastrophically when a slow
+  /// build paints only a handful of morph frames.
   void _onMorphTick() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !_morphing) return;
-      if (_morphSelectedIndex >= _tabKeys.length) return;
-      final cell = _tabKeys[_morphSelectedIndex].currentContext
-          ?.findRenderObject();
-      final ctl = widget.scrollController;
-      if (cell is! RenderBox || !cell.hasSize || !ctl.hasClients) return;
-      final drift = cell.localToGlobal(Offset.zero).dx - _morphAnchorGlobalX!;
-      if (drift.abs() < 0.1) return;
-      ctl.jumpTo((ctl.offset + drift)
-          .clamp(ctl.position.minScrollExtent, ctl.position.maxScrollExtent));
-    });
+    if (!mounted || !_morphing) return;
+    final naturals = _morphNaturalWidths;
+    final ctl = widget.scrollController;
+    if (naturals == null || !ctl.hasClients) return;
+    final t = _morphAnim!.value;
+    final dividerW = widget.dividerSettings?.thickness ?? 0.0;
+    double x = 0;
+    for (var i = 0; i < _morphSelectedIndex; i++) {
+      final w = naturals[i];
+      x += _morphEntering!.contains(i)
+          ? w * t
+          : _morphExiting!.contains(i)
+              ? w * (1 - t)
+              : w;
+      if (dividerW > 0) x += dividerW;
+    }
+    ctl.jumpTo((x - _morphAnchorLocalX!)
+        .clamp(ctl.position.minScrollExtent, ctl.position.maxScrollExtent));
   }
 
   /// Ends the morph: drops the exiting cells, remeasures the final list,
@@ -479,6 +559,7 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
       _morphTabs = null;
       _morphEntering = null;
       _morphExiting = null;
+      _morphNaturalWidths = null;
       _xAlign = _computeXAlignmentForTab(widget.selectedIndex);
       _tabWidths = [];
       _tabOffsets = [];

--- a/lib/src/widgets/interactive/scrollable_segment_content.dart
+++ b/lib/src/widgets/interactive/scrollable_segment_content.dart
@@ -159,6 +159,13 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   /// frames.
   List<double>? _morphNaturalWidths;
 
+  /// True from the morph's end until the post-morph measure has epoch-
+  /// snapped the springs onto the final geometry. The pill keeps drawing
+  /// at the anchor through this gap — without it, one frame rendered from
+  /// the springs' STALE pre-morph coordinates before the snap landed,
+  /// which read as the highlight blinking after the morph.
+  bool _morphSettling = false;
+
   bool get _morphing => _morphTabs != null;
 
   /// The list currently RENDERED — the merged morph list while morphing.
@@ -275,8 +282,11 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
         _tabOffsets = offsets;
         // Snap indicator to the selected tab after (re)measure; the epoch
         // makes the rendered pill jump with the springs instead of
-        // animating in from stale geometry.
+        // animating in from stale geometry. This is also the handoff that
+        // releases a morph's anchor — by now spring-position minus scroll
+        // equals the anchor, so the switch is pixel-invisible.
         _indicatorEpoch++;
+        _morphSettling = false;
         _indOffsetSpring.setValue(offsets[selIdx]);
         _indWidthSpring.setValue(widths[selIdx]);
       });
@@ -560,6 +570,7 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
       _morphEntering = null;
       _morphExiting = null;
       _morphNaturalWidths = null;
+      _morphSettling = true; // anchor holds until the final measure snaps
       _xAlign = _computeXAlignmentForTab(widget.selectedIndex);
       _tabWidths = [];
       _tabOffsets = [];
@@ -927,7 +938,8 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
               final Alignment alignment = widget.isScrollable
                   ? Alignment.center
                   : Alignment(currentValue, 0);
-              final double screenLeft = _morphing
+              final double screenLeft = (_morphing || _morphSettling) &&
+                      _morphAnchorLocalX != null
                   ? _morphAnchorLocalX!
                   : widget.isScrollable &&
                           widget.scrollController.hasClients
@@ -950,6 +962,7 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
                 // a remeasure gap the stale comparison read as motion and
                 // fired the bloom pulse on every list change.
                 isMoving = !_morphing &&
+                    !_morphSettling &&
                     measuredReady &&
                     (currentValue - targetOffset).abs() > 2.0;
                 // Width alone: zero only before the very first measure. A

--- a/lib/src/widgets/interactive/scrollable_segment_content.dart
+++ b/lib/src/widgets/interactive/scrollable_segment_content.dart
@@ -14,8 +14,10 @@ import '../../../utils/glass_spring.dart';
 import '../../../widgets/shared/animated_glass_indicator.dart';
 import '../../../widgets/surfaces/shared/tab_bar_types.dart'
     show MaskingQuality;
+import '../../../widgets/shared/glass_accessibility_scope.dart'
+    show GlassAccessibilityData;
 import '../../../widgets/surfaces/glass_tab_bar.dart'
-    show GlassSegment, DividerSettings;
+    show GlassSegment, DividerSettings, SegmentSelectionAlignment;
 
 // =============================================================================
 // ScrollableSegmentContent — draggable indicator + segment layout
@@ -52,6 +54,8 @@ class ScrollableSegmentContent extends StatefulWidget {
     this.dividerSettings,
     this.indicatorShadow,
     this.tabBarBorderRadius,
+    this.selectionAlignment = SegmentSelectionAlignment.minimal,
+    this.regridDuration = const Duration(milliseconds: 180),
     super.key,
   });
 
@@ -89,6 +93,12 @@ class ScrollableSegmentContent extends StatefulWidget {
   /// (tab labels + background pill) to the same rounded shape.
   final BorderRadius? tabBarBorderRadius;
 
+  /// See [GlassSegmentedControl.selectionAlignment].
+  final SegmentSelectionAlignment selectionAlignment;
+
+  /// See [GlassSegmentedControl.regridDuration].
+  final Duration regridDuration;
+
   @override
   State<ScrollableSegmentContent> createState() =>
       ScrollableSegmentContentState();
@@ -117,6 +127,32 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   /// discontinuity, which showed as the pill travelling in from the track
   /// edge on every mount and list change.
   int _indicatorEpoch = 0;
+
+  // ── Re-grid morph (list-length changes, scrollable mode) ─────────────────
+  //
+  // When the segment list changes around a surviving selection, the old and
+  // new lists are MERGED by identity and rendered together for
+  // [ScrollableSegmentContent.regridDuration]: entering cells grow in
+  // (width 0→natural via Align.widthFactor, with scale 0.8→1 and fade
+  // riding the same curve), leaving cells shrink out, and the survivors
+  // glide as the Row re-flows around them. The SELECTED cell is anchored:
+  // a per-tick scroll correction holds it at the screen position it had
+  // when the morph began, and the pill is drawn at that anchor directly.
+  // Taps and indicator drags are ignored for the (sub-200 ms) morph; a
+  // second list change mid-morph completes the current one instantly.
+  List<GlassSegment>? _morphTabs; // merged render list, null = not morphing
+  Set<int>? _morphEntering; // indices into _morphTabs
+  Set<int>? _morphExiting;
+  AnimationController? _morphCtrl;
+  CurvedAnimation? _morphAnim;
+  double? _morphAnchorGlobalX; // selected cell's global x, held per tick
+  double? _morphAnchorLocalX; // same, in the control's coordinates (pill)
+  int _morphSelectedIndex = 0; // selected cell's index in _morphTabs
+
+  bool get _morphing => _morphTabs != null;
+
+  /// The list currently RENDERED — the merged morph list while morphing.
+  List<GlassSegment> get _renderTabs => _morphTabs ?? widget.tabs;
 
   /// Shadows are suppressed while the indicator is being dragged so they
   /// do not interact with the live BackdropFilter blur, then restored
@@ -187,9 +223,10 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
     // surviving value keeps its element instead of remounting, so a
     // reconfigured list redraws only what actually changed. Segments with
     // no identity, or a duplicated one, get fresh cells.
+    final tabs = _renderTabs;
     final seen = <Object>{};
-    _tabKeys = List.generate(widget.tabs.length, (i) {
-      final Object? id = widget.tabs[i].id ?? widget.tabs[i].label;
+    _tabKeys = List.generate(tabs.length, (i) {
+      final Object? id = tabs[i].id ?? tabs[i].label;
       if (id == null || !seen.add(id)) return GlobalKey();
       return _cellKeysById.putIfAbsent(id, GlobalKey.new);
     });
@@ -197,7 +234,7 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   }
 
   void _measureTabs() {
-    if (!mounted) return;
+    if (!mounted || _morphing) return;
     double offset = 0;
     List<double> widths = [];
     List<double> offsets = [];
@@ -232,7 +269,9 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
       // A selection outside the viewport comes into view without animation:
       // at first measure there is no prior state the user has seen, and
       // after a list change the host may have positioned the scroll itself
-      // (ensure-visible no-ops when the selection is already on screen).
+      // (with [SegmentSelectionAlignment.minimal] this no-ops when the
+      // selection is already on screen; [SegmentSelectionAlignment.center]
+      // seats it centered).
       _scrollToEnsureVisible(selIdx, animated: false);
     } else {
       WidgetsBinding.instance.addPostFrameCallback((_) => _measureTabs());
@@ -241,6 +280,8 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
 
   @override
   void dispose() {
+    _morphAnim?.dispose();
+    _morphCtrl?.dispose();
     _indOffsetSpring.dispose();
     _indWidthSpring.dispose();
     _drag.dispose();
@@ -304,6 +345,14 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
       }
     }
     if (oldWidget.tabs.length != widget.tabs.length) {
+      if (_morphing) _finishMorph(jumpToEnd: true);
+      final reduceMotion = GlassAccessibilityData.of(context).reduceMotion;
+      if (widget.isScrollable &&
+          !reduceMotion &&
+          widget.regridDuration > Duration.zero &&
+          _tryStartMorph(oldWidget.tabs)) {
+        return;
+      }
       setState(() {
         _xAlign = _computeXAlignmentForTab(widget.selectedIndex);
         _tabWidths = [];
@@ -318,6 +367,125 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
     }
   }
 
+  static Object? _identityOf(GlassSegment t) => t.id ?? t.label;
+
+  /// Begins the re-grid morph from [oldTabs] to `widget.tabs`. Returns
+  /// false (caller falls back to the snap path) when there is nothing to
+  /// anchor: no measured geometry yet, or the selected segment's identity
+  /// does not survive the change.
+  bool _tryStartMorph(List<GlassSegment> oldTabs) {
+    if (_tabWidths.length != oldTabs.length) return false;
+    if (!widget.scrollController.hasClients) return false;
+    final selId = _identityOf(widget.tabs[widget.selectedIndex]);
+    if (selId == null) return false;
+    final oldIds = [for (final t in oldTabs) _identityOf(t)];
+    final oldSel = oldIds.indexOf(selId);
+    if (oldSel < 0) return false;
+
+    // Merge: walk the NEW list, interleaving each exiting old segment
+    // after the surviving predecessor it followed in the old order.
+    final newIds = {
+      for (final t in widget.tabs)
+        if (_identityOf(t) != null) _identityOf(t)!,
+    };
+    final exitingAfter = <Object?, List<GlassSegment>>{};
+    Object? lastSurvivor;
+    for (var i = 0; i < oldTabs.length; i++) {
+      final id = oldIds[i];
+      if (id != null && newIds.contains(id)) {
+        lastSurvivor = id;
+      } else {
+        (exitingAfter[lastSurvivor] ??= []).add(oldTabs[i]);
+      }
+    }
+    final merged = <GlassSegment>[];
+    final entering = <int>{};
+    final exiting = <int>{};
+    void addExiting(Object? afterId) {
+      for (final t in exitingAfter[afterId] ?? const <GlassSegment>[]) {
+        exiting.add(merged.length);
+        merged.add(t);
+      }
+    }
+
+    addExiting(null); // old leaders with no surviving predecessor
+    for (final t in widget.tabs) {
+      final id = _identityOf(t);
+      final survives = id != null && oldIds.contains(id);
+      if (!survives) entering.add(merged.length);
+      merged.add(t);
+      if (survives) addExiting(id);
+    }
+    if (entering.isEmpty && exiting.isEmpty) return false;
+
+    // Anchor: where the selected cell sits RIGHT NOW.
+    final anchorLocal =
+        _tabOffsets[oldSel] - widget.scrollController.offset;
+    final box = context.findRenderObject();
+    if (box is! RenderBox) return false;
+    final anchorGlobal = box.localToGlobal(Offset(anchorLocal, 0)).dx;
+
+    _morphTabs = merged;
+    _morphEntering = entering;
+    _morphExiting = exiting;
+    _morphSelectedIndex = merged.indexWhere((t) => _identityOf(t) == selId);
+    _morphAnchorLocalX = anchorLocal;
+    _morphAnchorGlobalX = anchorGlobal;
+    _morphCtrl?.dispose();
+    _morphAnim?.dispose();
+    _morphCtrl = AnimationController(
+        vsync: this, duration: widget.regridDuration)
+      ..addListener(_onMorphTick)
+      ..addStatusListener((st) {
+        if (st == AnimationStatus.completed) _finishMorph();
+      });
+    _morphAnim =
+        CurvedAnimation(parent: _morphCtrl!, curve: Curves.easeOutCubic);
+    setState(_initKeys); // keys for the merged list; survivors keep theirs
+    _morphCtrl!.forward();
+    return true;
+  }
+
+  /// Per-tick: after this frame lays the animating widths out, correct the
+  /// scroll so the selected cell stays exactly on its anchor.
+  void _onMorphTick() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_morphing) return;
+      if (_morphSelectedIndex >= _tabKeys.length) return;
+      final cell = _tabKeys[_morphSelectedIndex].currentContext
+          ?.findRenderObject();
+      final ctl = widget.scrollController;
+      if (cell is! RenderBox || !cell.hasSize || !ctl.hasClients) return;
+      final drift = cell.localToGlobal(Offset.zero).dx - _morphAnchorGlobalX!;
+      if (drift.abs() < 0.1) return;
+      ctl.jumpTo((ctl.offset + drift)
+          .clamp(ctl.position.minScrollExtent, ctl.position.maxScrollExtent));
+    });
+  }
+
+  /// Ends the morph: drops the exiting cells, remeasures the final list,
+  /// epoch-snaps the pill onto it, and re-asserts the selection alignment.
+  void _finishMorph({bool jumpToEnd = false}) {
+    final ctrl = _morphCtrl;
+    _morphCtrl = null;
+    _morphAnim?.dispose();
+    _morphAnim = null;
+    ctrl?.dispose();
+    if (!mounted) {
+      _morphTabs = null;
+      return;
+    }
+    setState(() {
+      _morphTabs = null;
+      _morphEntering = null;
+      _morphExiting = null;
+      _xAlign = _computeXAlignmentForTab(widget.selectedIndex);
+      _tabWidths = [];
+      _tabOffsets = [];
+    });
+    _initKeys(); // final list; _measureTabs epoch-snaps + aligns
+  }
+
   double _computeXAlignmentForTab(int tabIndex) {
     return DraggableIndicatorPhysics.computeAlignment(
       tabIndex,
@@ -330,6 +498,7 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   // ===========================================================================
 
   void _handleTapUp(TapUpDetails details) {
+    if (_morphing) return; // sub-200ms; geometry is in flux
     final box = context.findRenderObject() as RenderBox?;
     if (box == null) return;
 
@@ -358,6 +527,7 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   }
 
   void _handleDragDown(DragDownDetails details) {
+    if (_morphing) return;
     if (!widget.isScrollable) {
       setState(() => _isDown = true);
       return;
@@ -568,7 +738,12 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
 
     double targetOffset = currentOffset;
 
-    if (tabLeft - currentOffset < edgePadding) {
+    if (widget.selectionAlignment == SegmentSelectionAlignment.center) {
+      // Picker behavior: the selection lives at the center, clamped at the
+      // ends of the list.
+      targetOffset =
+          tabLeft - (viewportWidth - _tabWidths[tabIndex]) / 2;
+    } else if (tabLeft - currentOffset < edgePadding) {
       // Tab is partially or fully off-screen to the left.
       targetOffset = tabLeft - edgePadding;
     } else if (tabRight - currentOffset > viewportWidth - edgePadding) {
@@ -671,8 +846,10 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
               final Alignment alignment = widget.isScrollable
                   ? Alignment.center
                   : Alignment(currentValue, 0);
-              final double screenLeft =
-                  widget.isScrollable && widget.scrollController.hasClients
+              final double screenLeft = _morphing
+                  ? _morphAnchorLocalX!
+                  : widget.isScrollable &&
+                          widget.scrollController.hasClients
                       ? currentValue - widget.scrollController.offset
                       : 0.0;
 
@@ -691,8 +868,9 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
                 // Only a measured target can say the pill is moving: during
                 // a remeasure gap the stale comparison read as motion and
                 // fired the bloom pulse on every list change.
-                isMoving =
-                    measuredReady && (currentValue - targetOffset).abs() > 2.0;
+                isMoving = !_morphing &&
+                    measuredReady &&
+                    (currentValue - targetOffset).abs() > 2.0;
                 // Width alone: zero only before the very first measure. A
                 // list-length remeasure keeps the previous geometry live,
                 // so the pill stays visible through it instead of blinking.
@@ -842,32 +1020,57 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
     Color selectedIconColor,
     Color unselectedIconColor,
   ) {
+    final tabs = _renderTabs;
+    final selectedRenderIndex =
+        _morphing ? _morphSelectedIndex : widget.selectedIndex;
     final List<Widget> tabWidgets = List.generate(
-      widget.tabs.length,
+      tabs.length,
       (index) {
-        final tab = widget.tabs[index];
-        final isSelected = index == widget.selectedIndex;
-        return KeyedSubtree(
-          key: _tabKeys[index],
-          child: RepaintBoundary(
-            child: TabBarItem(
-              tab: tab,
-              isSelected: isSelected,
-              onTap: () => _onTabTap(index),
-              onTapDown: () {},
-              labelStyle: isSelected ? selectedStyle : unselectedStyle,
-              iconColor: isSelected ? selectedIconColor : unselectedIconColor,
-              iconSize: widget.iconSize,
-              padding: widget.labelPadding,
-            ),
+        final tab = tabs[index];
+        final isSelected = index == selectedRenderIndex;
+        Widget cell = RepaintBoundary(
+          child: TabBarItem(
+            tab: tab,
+            isSelected: isSelected,
+            onTap: () => _onTabTap(index),
+            onTapDown: () {},
+            labelStyle: isSelected ? selectedStyle : unselectedStyle,
+            iconColor: isSelected ? selectedIconColor : unselectedIconColor,
+            iconSize: widget.iconSize,
+            padding: widget.labelPadding,
           ),
         );
+        if (_morphing &&
+            (_morphEntering!.contains(index) ||
+                _morphExiting!.contains(index))) {
+          final entering = _morphEntering!.contains(index);
+          cell = AnimatedBuilder(
+            animation: _morphAnim!,
+            child: cell,
+            builder: (context, child) {
+              final t =
+                  entering ? _morphAnim!.value : 1.0 - _morphAnim!.value;
+              // Width 0→natural glides the survivors apart as the Row
+              // re-flows; the scale and fade ride the same curve.
+              return ClipRect(
+                child: Align(
+                  widthFactor: t,
+                  child: Transform.scale(
+                    scale: 0.8 + 0.2 * t,
+                    child: Opacity(opacity: t, child: child),
+                  ),
+                ),
+              );
+            },
+          );
+        }
+        return KeyedSubtree(key: _tabKeys[index], child: cell);
       },
     );
 
     if (widget.dividerSettings != null) {
       final d = widget.dividerSettings!;
-      for (int i = widget.tabs.length - 1; i > 0; i--) {
+      for (int i = tabs.length - 1; i > 0; i--) {
         final isVisible = !d.isHideAutomatically ||
             (i - 1 != widget.selectedIndex && i != widget.selectedIndex);
 

--- a/lib/src/widgets/interactive/scrollable_segment_content.dart
+++ b/lib/src/widgets/interactive/scrollable_segment_content.dart
@@ -60,7 +60,7 @@ class ScrollableSegmentContent extends StatefulWidget {
     this.indicatorShadow,
     this.tabBarBorderRadius,
     this.selectionAlignment = SegmentSelectionAlignment.minimal,
-    this.regridDuration = const Duration(milliseconds: 180),
+    this.regridDuration = Duration.zero,
     this.dragBehavior = SegmentDragBehavior.selectIndicator,
     super.key,
   });

--- a/lib/src/widgets/interactive/scrollable_segment_content.dart
+++ b/lib/src/widgets/interactive/scrollable_segment_content.dart
@@ -176,6 +176,36 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
 
   bool get _morphing => _morphTabs != null;
 
+  /// Guards the two-beat centering against rapid re-selection.
+  int _seatGen = 0;
+
+  /// Delay between the pill's travel starting and the centering scroll:
+  /// the pill's released spring visually lands around 300 ms, and starting
+  /// the glide just before keeps the beats connected without mushing them.
+  static const Duration _kCenterAfterSelectDelay = Duration(milliseconds: 250);
+
+  /// Seats a newly selected segment per the alignment policy.
+  ///
+  /// [SegmentSelectionAlignment.minimal] ensure-visibles immediately.
+  /// [SegmentSelectionAlignment.center] plays TWO BEATS, picker-style:
+  /// the pill travels to the chosen segment FIRST while the scroll holds
+  /// (selection feedback happens where the finger is), then the strip
+  /// glides the choice to center with the pill riding its cell. Centering
+  /// simultaneously with the pill's travel made both land in the same
+  /// instant — nothing ever visibly arrived at the tapped spot.
+  void _seatSelection(int index) {
+    if (widget.selectionAlignment != SegmentSelectionAlignment.center) {
+      _scrollToEnsureVisible(index);
+      return;
+    }
+    final gen = ++_seatGen;
+    Future.delayed(_kCenterAfterSelectDelay, () {
+      if (!mounted || gen != _seatGen || _morphing || _isDragging) return;
+      if (widget.selectedIndex != index) return; // superseded
+      _scrollToEnsureVisible(index);
+    });
+  }
+
   /// The list currently RENDERED — the merged morph list while morphing.
   List<GlassSegment> get _renderTabs => _morphTabs ?? widget.tabs;
 
@@ -378,10 +408,11 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
         _indOffsetSpring.setValue(_tabOffsets[widget.selectedIndex]);
         _indWidthSpring.animateTo(_tabWidths[widget.selectedIndex]);
       }
-      // Programmatic selection change — ensure the new tab scrolls into view.
+      // Programmatic selection change — seat the new tab (immediately, or
+      // in the centering second beat).
       if (widget.isScrollable) {
         WidgetsBinding.instance.addPostFrameCallback(
-          (_) => _scrollToEnsureVisible(widget.selectedIndex),
+          (_) => _seatSelection(widget.selectedIndex),
         );
       }
     }
@@ -816,9 +847,9 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
     if (index != widget.selectedIndex) {
       widget.onTabSelected(index);
     }
-    // Scroll the tapped tab fully into view in case it was partially visible.
+    // Seat the tapped tab (immediately, or in the centering second beat).
     if (widget.isScrollable) {
-      _scrollToEnsureVisible(index);
+      _seatSelection(index);
     }
   }
 

--- a/lib/src/widgets/interactive/scrollable_segment_content.dart
+++ b/lib/src/widgets/interactive/scrollable_segment_content.dart
@@ -179,10 +179,12 @@ class ScrollableSegmentContentState extends State<ScrollableSegmentContent>
   /// Guards the two-beat centering against rapid re-selection.
   int _seatGen = 0;
 
-  /// Delay between the pill's travel starting and the centering scroll:
-  /// the pill's released spring visually lands around 300 ms, and starting
-  /// the glide just before keeps the beats connected without mushing them.
-  static const Duration _kCenterAfterSelectDelay = Duration(milliseconds: 250);
+  /// Delay between the pill's travel starting and the centering scroll.
+  /// The pill's snappy spring covers most of its distance by ~150 ms, so
+  /// starting the glide there keeps the select-then-settle ORDER legible
+  /// while the two motions blend (250 ms read as too separated on device
+  /// — Joe, 2026-08-29).
+  static const Duration _kCenterAfterSelectDelay = Duration(milliseconds: 150);
 
   /// Seats a newly selected segment per the alignment policy.
   ///

--- a/lib/utils/glass_spring.dart
+++ b/lib/utils/glass_spring.dart
@@ -414,6 +414,7 @@ class VelocitySpringBuilder extends StatefulWidget {
     required this.springWhenReleased,
     required this.builder,
     this.active = true,
+    this.teleportEpoch = 0,
     this.child,
     super.key,
   });
@@ -429,6 +430,16 @@ class VelocitySpringBuilder extends StatefulWidget {
 
   /// Whether the user is currently dragging (selects [springWhenActive]).
   final bool active;
+
+  /// Monotonic marker for DISCONTINUOUS [value] changes.
+  ///
+  /// When this differs from the previous build's value, the follower snaps
+  /// straight to [value] instead of animating toward it — for corrections
+  /// that must not read as motion (an indicator snapped to freshly measured
+  /// geometry at mount, or after its list was re-measured). Continuous
+  /// changes (taps, drags, spring targets) leave the epoch alone and
+  /// animate exactly as before.
+  final int teleportEpoch;
 
   /// The builder called on every frame with the current value and velocity.
   final VelocitySpringWidgetBuilder builder;
@@ -470,10 +481,13 @@ class _VelocitySpringBuilderState extends State<VelocitySpringBuilder>
     if (springChanged) {
       _ctrl.spring = _currentSpring;
     }
-    if (widget.value != oldWidget.value) {
+    if (widget.value != oldWidget.value ||
+        widget.teleportEpoch != oldWidget.teleportEpoch) {
       // IP1: When Reduce Motion is active, snap instantly instead of animating.
+      // A teleport-epoch change snaps too: the value jumped discontinuously
+      // and travel would render as motion the source never made.
       final reduceMotion = GlassAccessibilityData.of(context).reduceMotion;
-      if (reduceMotion) {
+      if (reduceMotion || widget.teleportEpoch != oldWidget.teleportEpoch) {
         _ctrl.setValue(widget.value);
       } else {
         _ctrl.animateTo(widget.value);

--- a/lib/widgets/interactive/glass_segmented_control.dart
+++ b/lib/widgets/interactive/glass_segmented_control.dart
@@ -202,7 +202,7 @@ class GlassSegmentedControl extends StatefulWidget {
     this.backgroundKey,
     this.scrollController,
     this.selectionAlignment = SegmentSelectionAlignment.minimal,
-    this.regridDuration = const Duration(milliseconds: 180),
+    this.regridDuration = Duration.zero,
     this.dragBehavior = SegmentDragBehavior.selectIndicator,
     this.direction = Axis.horizontal,
     this.segmentExtent,
@@ -276,7 +276,7 @@ class GlassSegmentedControl extends StatefulWidget {
     // Scrollable-specific params
     this.scrollController,
     this.selectionAlignment = SegmentSelectionAlignment.minimal,
-    this.regridDuration = const Duration(milliseconds: 180),
+    this.regridDuration = Duration.zero,
     this.dragBehavior = SegmentDragBehavior.selectIndicator,
     this.iconSize = 24.0,
     this.labelPadding = const EdgeInsets.symmetric(horizontal: 16),
@@ -520,8 +520,13 @@ class GlassSegmentedControl extends StatefulWidget {
   /// surviving selection (scrollable mode only): entering segments grow in
   /// (width, with a slight scale and fade riding it), leaving segments
   /// shrink out, and the survivors glide — anchored so the selected
-  /// segment does not move on screen. [Duration.zero] disables the morph
-  /// (the list snaps); Reduce Motion always snaps.
+  /// segment does not move on screen.
+  ///
+  /// Defaults to [Duration.zero] — the list snaps, and the morph is
+  /// opt-in. There is no platform behavior to mirror here (native
+  /// segmented controls do not scroll), so a host's control should not
+  /// start animating just because the package was upgraded.
+  /// Reduce Motion always snaps.
   final Duration regridDuration;
 
   /// What a horizontal drag means. Scrollable mode only — the fixed

--- a/lib/widgets/interactive/glass_segmented_control.dart
+++ b/lib/widgets/interactive/glass_segmented_control.dart
@@ -9,7 +9,11 @@ import '../../types/glass_quality.dart';
 import '../shared/adaptive_liquid_glass_layer.dart';
 import '../surfaces/shared/tab_bar_types.dart' show MaskingQuality;
 import '../surfaces/glass_tab_bar.dart'
-    show DividerSettings, GlassSegment, SegmentSelectionAlignment;
+    show
+        DividerSettings,
+        GlassSegment,
+        SegmentDragBehavior,
+        SegmentSelectionAlignment;
 import '../../src/widgets/interactive/scrollable_segment_content.dart';
 import '../../src/widgets/interactive/segmented_control_internal.dart';
 
@@ -199,6 +203,7 @@ class GlassSegmentedControl extends StatefulWidget {
     this.scrollController,
     this.selectionAlignment = SegmentSelectionAlignment.minimal,
     this.regridDuration = const Duration(milliseconds: 180),
+    this.dragBehavior = SegmentDragBehavior.selectIndicator,
     this.direction = Axis.horizontal,
     this.segmentExtent,
     // ── iOS 26 interaction ──────────────────────────────────────────────────
@@ -272,6 +277,7 @@ class GlassSegmentedControl extends StatefulWidget {
     this.scrollController,
     this.selectionAlignment = SegmentSelectionAlignment.minimal,
     this.regridDuration = const Duration(milliseconds: 180),
+    this.dragBehavior = SegmentDragBehavior.selectIndicator,
     this.iconSize = 24.0,
     this.labelPadding = const EdgeInsets.symmetric(horizontal: 16),
     this.selectedIconColor,
@@ -518,6 +524,14 @@ class GlassSegmentedControl extends StatefulWidget {
   /// (the list snaps); Reduce Motion always snaps.
   final Duration regridDuration;
 
+  /// What a horizontal drag means. Scrollable mode only — the fixed
+  /// control always drags its indicator (`UISegmentedControl` parity).
+  ///
+  /// Defaults to [SegmentDragBehavior.selectIndicator] (unchanged
+  /// behavior). Use [SegmentDragBehavior.scroll] for picker-style strips
+  /// where a drag should navigate the list and selection is tap-only.
+  final SegmentDragBehavior dragBehavior;
+
   /// Icon size in logical pixels. Used in scrollable mode only.
   /// Defaults to 24.0 — matching [GlassTabBar].
   final double iconSize;
@@ -605,6 +619,7 @@ class _GlassSegmentedControlState extends State<GlassSegmentedControl> {
           scrollController: _scrollController,
           selectionAlignment: widget.selectionAlignment,
           regridDuration: widget.regridDuration,
+          dragBehavior: widget.dragBehavior,
           indicatorColor: widget.indicatorColor,
           selectedLabelStyle: widget.selectedTextStyle,
           unselectedLabelStyle: widget.unselectedTextStyle,

--- a/lib/widgets/interactive/glass_segmented_control.dart
+++ b/lib/widgets/interactive/glass_segmented_control.dart
@@ -195,6 +195,7 @@ class GlassSegmentedControl extends StatefulWidget {
     this.useOwnLayer = false,
     this.quality,
     this.backgroundKey,
+    this.scrollController,
     this.direction = Axis.horizontal,
     this.segmentExtent,
     // ── iOS 26 interaction ──────────────────────────────────────────────────
@@ -265,6 +266,7 @@ class GlassSegmentedControl extends StatefulWidget {
     this.quality,
     this.backgroundKey,
     // Scrollable-specific params
+    this.scrollController,
     this.iconSize = 24.0,
     this.labelPadding = const EdgeInsets.symmetric(horizontal: 16),
     this.selectedIconColor,
@@ -484,6 +486,17 @@ class GlassSegmentedControl extends StatefulWidget {
   // Scrollable-mode params (used only when isScrollable: true)
   // ===========================================================================
 
+  /// External scroll controller for the scrollable variant. Scrollable
+  /// mode only.
+  ///
+  /// Lets the host read and position the viewport — for example, keeping
+  /// the selected segment at an exact screen position while the segment
+  /// list is reconfigured around it (a picker changing its granularity).
+  /// When null the control manages its own. Provide it from the first
+  /// build; swapping between external and internal after mount is not
+  /// supported.
+  final ScrollController? scrollController;
+
   /// Icon size in logical pixels. Used in scrollable mode only.
   /// Defaults to 24.0 — matching [GlassTabBar].
   final double iconSize;
@@ -514,16 +527,18 @@ class GlassSegmentedControl extends StatefulWidget {
 
 class _GlassSegmentedControlState extends State<GlassSegmentedControl> {
   late final ScrollController _scrollController;
+  late final bool _ownsController;
 
   @override
   void initState() {
     super.initState();
-    _scrollController = ScrollController();
+    _scrollController = widget.scrollController ?? ScrollController();
+    _ownsController = widget.scrollController == null;
   }
 
   @override
   void dispose() {
-    _scrollController.dispose();
+    if (_ownsController) _scrollController.dispose();
     super.dispose();
   }
 

--- a/lib/widgets/interactive/glass_segmented_control.dart
+++ b/lib/widgets/interactive/glass_segmented_control.dart
@@ -8,7 +8,8 @@ import '../../theme/glass_theme_helpers.dart';
 import '../../types/glass_quality.dart';
 import '../shared/adaptive_liquid_glass_layer.dart';
 import '../surfaces/shared/tab_bar_types.dart' show MaskingQuality;
-import '../surfaces/glass_tab_bar.dart' show DividerSettings, GlassSegment;
+import '../surfaces/glass_tab_bar.dart'
+    show DividerSettings, GlassSegment, SegmentSelectionAlignment;
 import '../../src/widgets/interactive/scrollable_segment_content.dart';
 import '../../src/widgets/interactive/segmented_control_internal.dart';
 
@@ -196,6 +197,8 @@ class GlassSegmentedControl extends StatefulWidget {
     this.quality,
     this.backgroundKey,
     this.scrollController,
+    this.selectionAlignment = SegmentSelectionAlignment.minimal,
+    this.regridDuration = const Duration(milliseconds: 180),
     this.direction = Axis.horizontal,
     this.segmentExtent,
     // ── iOS 26 interaction ──────────────────────────────────────────────────
@@ -267,6 +270,8 @@ class GlassSegmentedControl extends StatefulWidget {
     this.backgroundKey,
     // Scrollable-specific params
     this.scrollController,
+    this.selectionAlignment = SegmentSelectionAlignment.minimal,
+    this.regridDuration = const Duration(milliseconds: 180),
     this.iconSize = 24.0,
     this.labelPadding = const EdgeInsets.symmetric(horizontal: 16),
     this.selectedIconColor,
@@ -497,6 +502,22 @@ class GlassSegmentedControl extends StatefulWidget {
   /// supported.
   final ScrollController? scrollController;
 
+  /// Where the scrollable variant keeps its selected segment. Scrollable
+  /// mode only.
+  ///
+  /// [SegmentSelectionAlignment.minimal] (default) scrolls just enough for
+  /// the selection to be visible; [SegmentSelectionAlignment.center] keeps
+  /// it centered whenever the list allows — the picker behavior.
+  final SegmentSelectionAlignment selectionAlignment;
+
+  /// Duration of the re-grid morph when the segment LIST changes around a
+  /// surviving selection (scrollable mode only): entering segments grow in
+  /// (width, with a slight scale and fade riding it), leaving segments
+  /// shrink out, and the survivors glide — anchored so the selected
+  /// segment does not move on screen. [Duration.zero] disables the morph
+  /// (the list snaps); Reduce Motion always snaps.
+  final Duration regridDuration;
+
   /// Icon size in logical pixels. Used in scrollable mode only.
   /// Defaults to 24.0 — matching [GlassTabBar].
   final double iconSize;
@@ -582,6 +603,8 @@ class _GlassSegmentedControlState extends State<GlassSegmentedControl> {
           onTabSelected: widget.onSegmentSelected,
           isScrollable: true,
           scrollController: _scrollController,
+          selectionAlignment: widget.selectionAlignment,
+          regridDuration: widget.regridDuration,
           indicatorColor: widget.indicatorColor,
           selectedLabelStyle: widget.selectedTextStyle,
           unselectedLabelStyle: widget.unselectedTextStyle,

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -1516,6 +1516,22 @@ class GlassTabBarTrailingButton {
 // GlassSegment — configuration for a single segment in GlassSegmentedControl
 // =============================================================================
 
+/// What a horizontal drag means on a scrollable segmented control.
+enum SegmentDragBehavior {
+  /// A drag beginning on the selected segment drags the INDICATOR from
+  /// choice to choice (the `UISegmentedControl` gesture); drags elsewhere
+  /// scroll the list. The right feel when every choice is visible.
+  selectIndicator,
+
+  /// Every drag scrolls the list — the selected segment included;
+  /// selection changes by tap only. The picker behavior: with most
+  /// choices off-screen (and especially with
+  /// [SegmentSelectionAlignment.center], which parks the selection exactly
+  /// where a scrolling thumb naturally lands), navigation is what a drag
+  /// means.
+  scroll,
+}
+
 /// Where a scrollable segmented control keeps its selected segment.
 enum SegmentSelectionAlignment {
   /// Scroll only as far as needed for the selection to be fully visible,

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -1516,6 +1516,18 @@ class GlassTabBarTrailingButton {
 // GlassSegment — configuration for a single segment in GlassSegmentedControl
 // =============================================================================
 
+/// Where a scrollable segmented control keeps its selected segment.
+enum SegmentSelectionAlignment {
+  /// Scroll only as far as needed for the selection to be fully visible,
+  /// with a little edge breathing room (the classic tab-bar behavior).
+  minimal,
+
+  /// Keep the selection centered in the viewport whenever possible —
+  /// clamped at the ends of the list. The picker behavior: selection lives
+  /// at the center and the choices arrange themselves around it.
+  center,
+}
+
 /// Configuration for a single segment in [GlassSegmentedControl].
 ///
 /// [GlassSegment] is the item type for [GlassSegmentedControl] — the iOS 26

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -1569,6 +1569,7 @@ class GlassSegment {
   const GlassSegment({
     this.icon,
     this.label,
+    this.id,
     this.tooltip,
     this.semanticLabel,
     this.enabled = true,
@@ -1588,6 +1589,15 @@ class GlassSegment {
   /// If null, [icon] is used alone. If both are provided, the icon is shown
   /// above the label (same layout as iOS `UISegmentedControl` with images).
   final String? label;
+
+  /// Stable identity for this segment across list changes.
+  ///
+  /// When the segment list is replaced (items inserted, removed, or the
+  /// list re-gridded around a surviving value), segments whose identity
+  /// survives keep their underlying elements instead of remounting — only
+  /// genuinely new cells build. Falls back to [label]; segments with
+  /// neither, or with duplicate identities, get fresh cells each time.
+  final Object? id;
 
   /// Tooltip shown on long-press (optional).
   ///

--- a/test/scrollable_selection_stability_test.dart
+++ b/test/scrollable_selection_stability_test.dart
@@ -125,6 +125,9 @@ void main() {
               segs.indexWhere((t) => t.label == 'T$selected'),
           onSegmentSelected: (_) {},
           selectionAlignment: SegmentSelectionAlignment.center,
+          // The morph is opt-in (the default snaps), and this test is
+          // about the morph — so it has to ask for it.
+          regridDuration: const Duration(milliseconds: 180),
         ));
     await tester.pumpWidget(build(coarse()));
     await tester.pumpAndSettle();
@@ -165,6 +168,9 @@ void main() {
           selectedIndex: segs().indexWhere((t) => t.label == 'T4'),
           onSegmentSelected: (_) {},
           selectionAlignment: SegmentSelectionAlignment.center,
+          // Opt in: without a morph there is no handoff to test, and this
+          // would pass vacuously.
+          regridDuration: const Duration(milliseconds: 180),
         ));
     await tester.pumpWidget(build());
     await tester.pumpAndSettle();

--- a/test/scrollable_selection_stability_test.dart
+++ b/test/scrollable_selection_stability_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
-import 'package:liquid_glass_widgets/utils/glass_spring.dart';
 
 /// Selection stability for [GlassSegmentedControl.scrollable]:
 ///  1. the initial selection mounts scrolled into view, with no residual

--- a/test/scrollable_selection_stability_test.dart
+++ b/test/scrollable_selection_stability_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/utils/glass_spring.dart';
+
+/// Selection stability for [GlassSegmentedControl.scrollable]:
+///  1. the initial selection mounts scrolled into view, with no residual
+///     indicator animation (no slide-in from the track edge),
+///  2. a list-length change keeps the indicator mounted through the
+///     remeasure and lands it with no travel,
+///  3. segments with a surviving identity keep their elements across list
+///     changes instead of remounting,
+///  4. [VelocitySpringBuilder.teleportEpoch] snaps discontinuous values.
+void main() {
+  Widget harness(Widget child) => MaterialApp(
+        home: Scaffold(
+          body: Center(child: SizedBox(width: 300, child: child)),
+        ),
+      );
+
+  List<GlassSegment> segments(int n, {String prefix = 'S'}) =>
+      [for (var i = 0; i < n; i++) GlassSegment(label: '$prefix$i')];
+
+  testWidgets('initial selection is in view with no residual animation',
+      (tester) async {
+    final ctl = ScrollController();
+    addTearDown(ctl.dispose);
+    await tester.pumpWidget(harness(GlassSegmentedControl.scrollable(
+      segments: segments(30),
+      selectedIndex: 20,
+      onSegmentSelected: (_) {},
+      scrollController: ctl,
+    )));
+    // Frame 2: post-frame measurement has run and snapped everything.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 32));
+    expect(ctl.offset, greaterThan(0),
+        reason: 'selection 20 of 30 cannot be visible at offset 0');
+    expect(find.text('S20').hitTestable(), findsOneWidget);
+    expect(tester.binding.transientCallbackCount, 0,
+        reason: 'nothing may still be animating after the mount snap');
+  });
+
+  testWidgets('length change keeps the indicator and lands without travel',
+      (tester) async {
+    final ctl = ScrollController();
+    addTearDown(ctl.dispose);
+    Widget build(int n) => harness(GlassSegmentedControl.scrollable(
+          segments: segments(n),
+          selectedIndex: 5,
+          onSegmentSelected: (_) {},
+          scrollController: ctl,
+        ));
+    await tester.pumpWidget(build(10));
+    await tester.pumpAndSettle();
+
+    bool indicatorShown() => find
+        .byWidgetPredicate(
+            (w) => w.runtimeType.toString() == 'AnimatedGlassIndicator')
+        .evaluate()
+        .isNotEmpty;
+    expect(indicatorShown(), isTrue);
+
+    await tester.pumpWidget(build(20));
+    // The remeasure gap: indicator must survive it.
+    expect(indicatorShown(), isTrue,
+        reason: 'indicator blinked out during the remeasure gap');
+    await tester.pump();
+    expect(indicatorShown(), isTrue);
+    await tester.pump(const Duration(milliseconds: 32));
+    expect(tester.binding.transientCallbackCount, 0,
+        reason: 'the indicator must snap to the new geometry, not travel');
+  });
+
+  testWidgets('surviving identities keep their elements across list changes',
+      (tester) async {
+    Widget build(List<String> labels) => harness(
+          GlassSegmentedControl.scrollable(
+            segments: [for (final l in labels) GlassSegment(label: l)],
+            selectedIndex: 0,
+            onSegmentSelected: (_) {},
+          ),
+        );
+    await tester.pumpWidget(build(['A', 'B', 'C']));
+    await tester.pumpAndSettle();
+    final before = tester.element(find.text('B'));
+    await tester.pumpWidget(build(['A0', 'A', 'B', 'C', 'D']));
+    await tester.pumpAndSettle();
+    expect(identical(before, tester.element(find.text('B'))), isTrue,
+        reason: "segment 'B' survived the change and must keep its element");
+  });
+
+  testWidgets('teleportEpoch snaps; unchanged epoch animates', (tester) async {
+    double seen = -1;
+    Widget build(double value, int epoch) => MaterialApp(
+          home: VelocitySpringBuilder(
+            value: value,
+            teleportEpoch: epoch,
+            springWhenActive: GlassSpring.interactive(),
+            springWhenReleased:
+                GlassSpring.snappy(duration: const Duration(milliseconds: 350)),
+            active: false,
+            builder: (context, v, _, __) {
+              seen = v;
+              return const SizedBox();
+            },
+          ),
+        );
+    await tester.pumpWidget(build(0, 0));
+    expect(seen, 0);
+    // Epoch bump: lands instantly, nothing left animating.
+    await tester.pumpWidget(build(100, 1));
+    await tester.pump();
+    expect(seen, 100);
+    expect(tester.binding.transientCallbackCount, 0);
+    // Same epoch: animates through intermediate values.
+    await tester.pumpWidget(build(200, 1));
+    await tester.pump(const Duration(milliseconds: 40));
+    expect(seen, greaterThan(100));
+    expect(seen, lessThan(200), reason: 'must travel, not snap');
+    await tester.pumpAndSettle();
+    expect(seen, moreOrLessEquals(200, epsilon: 0.5));
+  });
+}

--- a/test/scrollable_selection_stability_test.dart
+++ b/test/scrollable_selection_stability_test.dart
@@ -240,6 +240,43 @@ void main() {
         reason: 'an indicator drag must not scroll the list');
   });
 
+  testWidgets('center tap: pill beat first, centering glide second',
+      (tester) async {
+    var selected = 15;
+    final ctl = ScrollController();
+    addTearDown(ctl.dispose);
+    late StateSetter setSel;
+    await tester.pumpWidget(harness(StatefulBuilder(
+      builder: (context, setState) {
+        setSel = setState;
+        return GlassSegmentedControl.scrollable(
+          segments: segments(30),
+          selectedIndex: selected,
+          onSegmentSelected: (i) => setState(() => selected = i),
+          selectionAlignment: SegmentSelectionAlignment.center,
+          dragBehavior: SegmentDragBehavior.scroll,
+          scrollController: ctl,
+        );
+      },
+    )));
+    await tester.pumpAndSettle();
+    final before = ctl.offset;
+
+    await tester.tap(find.text('S16'), warnIfMissed: true);
+    // Beat one: the pill travels, the scroll HOLDS.
+    await tester.pump(const Duration(milliseconds: 120));
+    expect(selected, 16);
+    expect((ctl.offset - before).abs(), lessThan(1),
+        reason: 'the scroll must hold while the pill travels');
+    // Beat two: the centering glide, after the delay.
+    await tester.pumpAndSettle();
+    final viewport = tester.getRect(find.byType(GlassSegmentedControl));
+    final cell = tester.getRect(find.text('S16'));
+    expect((cell.center.dx - viewport.center.dx).abs(), lessThan(2.0),
+        reason: 'the choice ends centered');
+    setSel(() {}); // silence unused warning paths
+  });
+
   testWidgets('teleportEpoch snaps; unchanged epoch animates', (tester) async {
     double seen = -1;
     Widget build(double value, int epoch) => MaterialApp(

--- a/test/scrollable_selection_stability_test.dart
+++ b/test/scrollable_selection_stability_test.dart
@@ -45,11 +45,14 @@ void main() {
       (tester) async {
     final ctl = ScrollController();
     addTearDown(ctl.dispose);
+    // regridDuration zero: this test covers the SNAP path; the morph path
+    // has its own tests below.
     Widget build(int n) => harness(GlassSegmentedControl.scrollable(
           segments: segments(n),
           selectedIndex: 5,
           onSegmentSelected: (_) {},
           scrollController: ctl,
+          regridDuration: Duration.zero,
         ));
     await tester.pumpWidget(build(10));
     await tester.pumpAndSettle();
@@ -88,6 +91,65 @@ void main() {
     await tester.pumpAndSettle();
     expect(identical(before, tester.element(find.text('B'))), isTrue,
         reason: "segment 'B' survived the change and must keep its element");
+  });
+
+  testWidgets('center alignment seats the selection mid-viewport',
+      (tester) async {
+    await tester.pumpWidget(harness(GlassSegmentedControl.scrollable(
+      segments: segments(30),
+      selectedIndex: 15,
+      onSegmentSelected: (_) {},
+      selectionAlignment: SegmentSelectionAlignment.center,
+    )));
+    await tester.pumpAndSettle();
+    final viewport = tester.getRect(find.byType(GlassSegmentedControl));
+    final cell = tester.getRect(find.text('S15'));
+    expect((cell.center.dx - viewport.center.dx).abs(), lessThan(2.0),
+        reason: 'selection must sit at the viewport center');
+  });
+
+  testWidgets('re-grid morph: anchored selection, entrants grow, leavers '
+      'shrink out', (tester) async {
+    var selected = 4;
+    List<GlassSegment> coarse() =>
+        [for (var i = 0; i < 8; i++) GlassSegment(label: 'T$i')];
+    List<GlassSegment> fine() => [
+          for (var i = 0; i < 8; i++) ...[
+            GlassSegment(label: 'T$i'),
+            if (i < 7) GlassSegment(label: 'N$i'),
+          ],
+        ];
+    Widget build(List<GlassSegment> segs) =>
+        harness(GlassSegmentedControl.scrollable(
+          segments: segs,
+          selectedIndex:
+              segs.indexWhere((t) => t.label == 'T$selected'),
+          onSegmentSelected: (_) {},
+          selectionAlignment: SegmentSelectionAlignment.center,
+        ));
+    await tester.pumpWidget(build(coarse()));
+    await tester.pumpAndSettle();
+    final anchor = tester.getTopLeft(find.text('T$selected')).dx;
+
+    await tester.pumpWidget(build(fine()));
+    await tester.pump(const Duration(milliseconds: 90)); // mid-morph
+    expect(find.text('N3'), findsOneWidget,
+        reason: 'entrants must exist mid-morph');
+    expect(
+        (tester.getTopLeft(find.text('T$selected')).dx - anchor).abs(),
+        lessThan(3.0),
+        reason: 'the selection is anchored through the morph');
+    await tester.pumpAndSettle();
+    expect(tester.binding.transientCallbackCount, 0);
+
+    // Coarsen again: leavers must remain visible mid-morph, gone after.
+    await tester.pumpWidget(build(coarse()));
+    await tester.pump(const Duration(milliseconds: 90));
+    expect(find.text('N3'), findsOneWidget,
+        reason: 'leavers shrink out — still present mid-morph');
+    await tester.pumpAndSettle();
+    expect(find.text('N3'), findsNothing);
+    expect(tester.binding.transientCallbackCount, 0);
   });
 
   testWidgets('teleportEpoch snaps; unchanged epoch animates', (tester) async {

--- a/test/scrollable_selection_stability_test.dart
+++ b/test/scrollable_selection_stability_test.dart
@@ -152,6 +152,50 @@ void main() {
     expect(tester.binding.transientCallbackCount, 0);
   });
 
+  testWidgets('pill position hands off seamlessly at morph end',
+      (tester) async {
+    var n = 8;
+    List<GlassSegment> segs() => [
+          for (var i = 0; i < n; i++) ...[
+            GlassSegment(label: 'T$i'),
+            if (n > 8 && i < 7) GlassSegment(label: 'N$i'),
+          ],
+        ];
+    Widget build() => harness(GlassSegmentedControl.scrollable(
+          segments: segs(),
+          selectedIndex: segs().indexWhere((t) => t.label == 'T4'),
+          onSegmentSelected: (_) {},
+          selectionAlignment: SegmentSelectionAlignment.center,
+        ));
+    await tester.pumpWidget(build());
+    await tester.pumpAndSettle();
+
+    double? pillLeft() {
+      final els = find
+          .byWidgetPredicate(
+              (w) => w.runtimeType.toString() == 'AnimatedGlassIndicator')
+          .evaluate();
+      if (els.isEmpty) return null;
+      return (els.first.widget as dynamic).exactOffset as double?;
+    }
+
+    n = 15;
+    await tester.pumpWidget(build());
+    // Pump beyond the 180ms morph in small steps, across the finish
+    // handoff: the rendered pill offset must never move visibly.
+    double? prev = pillLeft();
+    for (var i = 0; i < 24; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+      final now = pillLeft();
+      if (prev != null && now != null) {
+        expect((now - prev).abs(), lessThan(1.5),
+            reason: 'pill jumped between frames (frame $i)');
+      }
+      prev = now;
+    }
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('teleportEpoch snaps; unchanged epoch animates', (tester) async {
     double seen = -1;
     Widget build(double value, int epoch) => MaterialApp(

--- a/test/scrollable_selection_stability_test.dart
+++ b/test/scrollable_selection_stability_test.dart
@@ -196,6 +196,50 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets('dragBehavior.scroll: pill drags scroll the list, tap-only '
+      'selection', (tester) async {
+    int? tapped;
+    final ctl = ScrollController();
+    addTearDown(ctl.dispose);
+    await tester.pumpWidget(harness(GlassSegmentedControl.scrollable(
+      segments: segments(30),
+      selectedIndex: 15,
+      onSegmentSelected: (i) => tapped = i,
+      selectionAlignment: SegmentSelectionAlignment.center,
+      dragBehavior: SegmentDragBehavior.scroll,
+      scrollController: ctl,
+    )));
+    await tester.pumpAndSettle();
+    final before = ctl.offset;
+    await tester.drag(find.text('S15'), const Offset(-120, 0));
+    await tester.pumpAndSettle();
+    expect(tapped, isNull, reason: 'a drag must not change the selection');
+    expect((ctl.offset - before).abs(), greaterThan(60),
+        reason: 'a drag starting on the pill must scroll the list');
+  });
+
+  testWidgets('default dragBehavior keeps the indicator drag', (tester) async {
+    int? dragged;
+    final ctl = ScrollController();
+    addTearDown(ctl.dispose);
+    await tester.pumpWidget(harness(GlassSegmentedControl.scrollable(
+      segments: segments(30),
+      selectedIndex: 15,
+      onSegmentSelected: (i) => dragged = i,
+      selectionAlignment: SegmentSelectionAlignment.center,
+      scrollController: ctl,
+    )));
+    await tester.pumpAndSettle();
+    final before = ctl.offset;
+    await tester.timedDrag(
+        find.text('S15'), const Offset(-120, 0), const Duration(milliseconds: 300));
+    await tester.pumpAndSettle();
+    expect(dragged, isNotNull,
+        reason: 'dragging the pill selects a neighboring segment');
+    expect((ctl.offset - before).abs(), lessThan(1),
+        reason: 'an indicator drag must not scroll the list');
+  });
+
   testWidgets('teleportEpoch snaps; unchanged epoch animates', (tester) async {
     double seen = -1;
     Widget build(double value, int epoch) => MaterialApp(


### PR DESCRIPTION
The scrollable `GlassSegmentedControl` renders its indicator through a spring-follower that animates *every* value change, and its list-length path zeroes the indicator springs. Two visible artifacts follow: on every mount the pill slides in from the track edge to the selection, and on every list change it blinks out and slides back in. This PR fixes those and rounds the control out for picker-style use:

- **`VelocitySpringBuilder.teleportEpoch`** — a monotonic marker for discontinuous corrections (initial measure, list-change re-measure); the follower snaps instead of animating. Taps and drags animate exactly as before.
- **List-length changes keep the springs' geometry and the pill mounted**; the post-measure epoch-snap lands it with no travel.
- **`GlassSegment.id`** — cells are keyed by identity (falling back to label), so values that survive a list change keep their elements instead of remounting.
- **The selection scrolls into view** after initial and post-change measures (jump, not animate), and **`scrollController` is exposed**.
- **Anchored re-grid morph** (`regridDuration`, default 180ms): when the list is reconfigured around a surviving selection, entering segments grow in (width via `Align.widthFactor`, with scale 0.8→1 and fade riding the curve), leaving segments shrink out, and the survivors glide — with the selected cell held to its exact screen position by an analytic per-tick scroll offset computed from natural widths (never chasing last frame's boxes, so it stays correct even when a slow build paints only a few morph frames; the clock starts only after the pixel-identical t=0 frame absorbs the re-parenting cost). `Duration.zero` and Reduce Motion snap.
- **`SegmentSelectionAlignment.center`** — the picker policy: mount, tap, and re-grids all seat the selection mid-viewport (default `minimal`, unchanged).
- **`SegmentDragBehavior.scroll`** — every drag navigates the list and selection is tap-only (default `selectIndicator`, unchanged; fixed mode untouched). With centering, the selection parks exactly where a scrolling thumb naturally lands, so claiming that drag for the indicator was a usability trap on long lists.
- **Two-beat centered seating**: the pill travels to the tapped choice first while the scroll holds, then a 150ms-delayed 300ms glide centers it — selection feedback at the finger, then the world settles.

One default changes: list-length changes now morph (180ms) instead of snapping. If you'd rather keep the old rendering as the default, happy to flip `regridDuration` to `Duration.zero`.

Ten tests in `test/scrollable_selection_stability_test.dart`, including frame-stepped assertions that the rendered pill never moves through a morph and its finish. Full suite green apart from the five pre-existing golden drifts (identical on clean `main`).

Context: we built a time-of-day picker with 24–96 segments and re-griddable granularity (hour / 30-min / 15-min steps) on this control; happy to share screen recordings of before/after.
