### PR TITLE
fix: inline accessory reaches the trailing edge when no trailing pill exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Bug Fixes
+
+- **Inline bottom accessory reaches the trailing edge without a trailing button (#264):** On `GlassTabBar.minimizable`, the inline accessory reserved the trailing capsule's width even when there was no capsule — `_buildMinimizable` sets `showPill: trailingButton != null`, but the inline geometry did not consult it. A minimized bar with a mini-player and no trailing action left a dead `searchBarHeight + bottomAccessorySpacing` gap on that edge, unreachable from the public API: `minimizable` does not expose `searchConfig` (so `collapsedTabWidth` has no trailing counterpart), and `minimizedBarHeight` drives the minimized pill height as well as this width. The accessory now extends to `horizontalPadding` when the pill is absent, and still clears it when present.
+
+---
+
 # 1.2.2
 
 ## New Features

--- a/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
@@ -889,9 +889,19 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
       final inlineAccessoryLeft = widget.horizontalPadding +
           collapsedTabW +
           widget.bottomAccessorySpacing;
-      final inlineAccessoryRight = widget.horizontalPadding +
-          widget.searchBarHeight +
-          widget.bottomAccessorySpacing;
+      // Only reserve the trailing capsule's slot when there is one to reserve.
+      // `GlassTabBar.minimizable` sets `showPill: trailingButton != null`, so a
+      // bar with no trailing action has nothing on that edge — holding its
+      // width back leaves a dead gap the accessory cannot reach, and neither
+      // side is reachable from the public API (`minimizable` does not expose
+      // `searchConfig`, and `minimizedBarHeight` drives the pill height as well
+      // as this width). The leading side is already overridable through
+      // `collapsedTabWidth`; this gives the trailing side the same honesty.
+      final inlineAccessoryRight = widget.searchConfig.showPill
+          ? widget.horizontalPadding +
+              widget.searchBarHeight +
+              widget.bottomAccessorySpacing
+          : widget.horizontalPadding;
 
       // Total height of the combined widget.
       // Jumps instantly with `searching` to match `preferredSize` changes.

--- a/test/widgets/surfaces/tab_bar_accessory_test.dart
+++ b/test/widgets/surfaces/tab_bar_accessory_test.dart
@@ -167,4 +167,60 @@ void main() {
       expect(find.byType(GlassScaffold), findsOneWidget);
     });
   });
+
+  group('minimizable inline accessory trailing slot', () {
+    // Regression for #264. The inline geometry was written against the
+    // searchable placement, where a trailing capsule always exists. On
+    // `minimizable` the capsule is optional (`showPill: trailingButton != null`),
+    // so reserving its width unconditionally left a gap nothing could fill —
+    // and nothing in the public API could recover it.
+    Widget host({GlassTabBarTrailingButton? trailingButton}) => MaterialApp(
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.bottomCenter,
+              child: GlassTabBar.minimizable(
+                tabs: const [GlassTab(label: '1'), GlassTab(label: '2')],
+                selectedIndex: 0,
+                onTabSelected: (_) {},
+                minimized: true,
+                trailingButton: trailingButton,
+                bottomAccessoryPlacement:
+                    GlassTabBarAccessoryPlacement.inline,
+                bottomAccessory:
+                    const SizedBox(key: Key('acc'), height: 50),
+                bottomAccessoryHeight: 50,
+              ),
+            ),
+          ),
+        );
+
+    testWidgets('reaches the trailing edge when there is no trailing button',
+        (tester) async {
+      await tester.pumpWidget(host());
+      await tester.pumpAndSettle();
+
+      final bar = tester.getRect(find.byType(GlassTabBar));
+      final accessory = tester.getRect(find.byKey(const Key('acc')));
+
+      // Symmetric with the leading inset the bar already applies.
+      expect(bar.right - accessory.right, closeTo(20.0, 0.5));
+    });
+
+    testWidgets('still clears the trailing button when one is present',
+        (tester) async {
+      await tester.pumpWidget(host(
+        trailingButton: GlassTabBarTrailingButton(
+          icon: const Icon(Icons.add),
+          onTap: () {},
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      final bar = tester.getRect(find.byType(GlassTabBar));
+      final accessory = tester.getRect(find.byKey(const Key('acc')));
+
+      // horizontalPadding(20) + searchBarHeight(50) + spacing(6)
+      expect(bar.right - accessory.right, closeTo(76.0, 0.5));
+    });
+  });
 }


### PR DESCRIPTION
## Description

`GlassTabBar.minimizable` sets `showPill: trailingButton != null`, but the inline accessory geometry reserved the trailing capsule's width unconditionally. A minimized bar carrying a mini-player and no trailing action left a dead `searchBarHeight + bottomAccessorySpacing` gap (50 + 6 = 56 by default) on that edge.

```dart
// before — lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
final inlineAccessoryRight = widget.horizontalPadding +
    widget.searchBarHeight +        // ← never consulted showPill
    widget.bottomAccessorySpacing;
```

Nothing in the public API could recover it: `minimizable` does not expose `searchConfig`, so the leading side's `collapsedTabWidth` escape hatch has no trailing counterpart, and `minimizedBarHeight` drives the minimized pill height as well as this reserved width, so it cannot be tuned independently.

The accessory now extends to `horizontalPadding` when the pill is absent, matching how iOS 26 lets the minimized Music mini-player fill the width beside the tab circle — and still clears the pill when one is present.

Fixes #264

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Platforms Tested

- [x] Android (Impeller)
- [x] iOS (Impeller)

Verified in a real app (a music practice client) on an Android emulator and the iOS 27 simulator: with a mini-player accessory and no trailing button, the minimized bar's accessory now runs to the same inset as its leading edge.

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (shaders, painting logic)
- [x] I have made corresponding changes to the documentation / CHANGELOG.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/golden tests pass locally (`flutter test`)
- [ ] If this changes shader code, I have verified it compiles on both Metal (macOS) and SkSL/SPIR-V (Windows) — n/a, no shader change
- [x] No dynamic indexing or unsupported GLSL builtins were introduced in shader code

### Notes on the test run

The two new tests in `test/widgets/surfaces/tab_bar_accessory_test.dart` measure the gap between the bar's trailing edge and the accessory; the first fails without the fix (`76.0` vs the expected `20.0`) and passes with it. `flutter test test/widgets/surfaces/` is fully green (765 tests).

The full suite shows 31 failures on my machine (Windows) in `test/renderer/` and `test/golden/` — these reproduce identically on an unmodified checkout of `main`, so they are pre-existing golden/platform mismatches rather than anything this change introduces.
