### PR TITLE
GlassModalSheet: finish the travel at scroll handover; keep `progress` current inside its listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Thanks to [@JakeThomson](https://github.com/JakeThomson) for the fix (#280).
 
 Thanks to [@JakeThomson](https://github.com/JakeThomson) for the fix and on-device integration tests (#281).
 
+- **`GlassModalSheet` finishes its travel when a drag hands over to the content (#284):** An upward content drag hands the pointer to the scroll view once the sheet is within 5% of its top detent, and that pointer's release is a scroll, not a drag — so the sheet parked up to 5% short of the top with no `onStateChanged`, the host still believed it sat at the lower detent, and the next collapse skipped its scroll-to-top. The sheet now snaps the remainder at the moment of handover: it arrives, reports `full` and gives its haptic as the content starts to scroll, not when the finger eventually lifts.
+
+- **`GlassModalSheetController.progress` and `value` are current inside `progressListenable` (#285):** Both reported the position the sheet had last *built* at, and the listener fires before that build — a frame behind, so the final tick of any drag never showed where the sheet stopped. They now refresh on every controller tick, before listeners run.
+
 ---
 
 # 1.3.0

--- a/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_mechanics.dart
@@ -450,11 +450,10 @@ class GlassModalSheetController {
   /// The sheet's live position, straight off its animation controller, or null
   /// while no sheet is attached.
   ///
-  /// [value] reports the position the sheet last *built* at. That is what
-  /// consumers want, but it lags by a frame inside a pointer handler or a
-  /// [progressListenable] callback — both run before the sheet rebuilds — and
-  /// the null case distinguishes "not mounted yet" from a sheet genuinely
-  /// sitting at 0.0.
+  /// [value] reads the same position (it is refreshed on every controller
+  /// tick, before [progressListenable] fires, so a listener sees where the
+  /// sheet is, not where it was a frame ago); the null case distinguishes
+  /// "not mounted yet" from a sheet genuinely sitting at 0.0.
   double? get _livePosition => _state?._animationController.value;
 }
 

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -71,7 +71,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
     _geometry = _buildGeometry();
 
     _animationController = AnimationController.unbounded(vsync: this);
-    _animationController.addListener(_progressNotifier.notify);
+    _animationController.addListener(_onPositionTick);
     _saturationController = AnimationController(
       duration: const Duration(milliseconds: 200),
       vsync: this,
@@ -124,7 +124,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     widget.controller?._detach(this);
-    _animationController.removeListener(_progressNotifier.notify);
+    _animationController.removeListener(_onPositionTick);
     _animationController.dispose();
     _progressNotifier.dispose();
     _saturationController.dispose();
@@ -248,6 +248,17 @@ class _GlassModalSheetState extends State<GlassModalSheet>
         _scrollController.jumpTo(0);
       }
     }
+  }
+
+  /// Every position change, drag and animation alike. Brings
+  /// [_currentPosition] — what the controller's `value` and `progress`
+  /// report — up to date BEFORE the progress listeners run. It used to be
+  /// written only in build, so a listener always read the position of the
+  /// previous frame, and the last tick of a drag never showed where the
+  /// sheet actually stopped.
+  void _onPositionTick() {
+    _currentPosition = _animationController.value;
+    _progressNotifier.notify();
   }
 
   void _jumpTo(double value) {
@@ -390,6 +401,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
       return;
     }
 
+    final phaseBefore = _gestureArena.phase;
     final shouldClaim = _gestureArena.evaluateMove(
       event.position.dy,
       event.position.dx,
@@ -400,6 +412,19 @@ class _GlassModalSheetState extends State<GlassModalSheet>
       canScrollListUp: _canScrollListUp,
       atTopDetent: _contentScrollProgress > _kTopDetentThreshold,
     );
+
+    if (!shouldClaim &&
+        phaseBefore == GesturePhase.contentDrag &&
+        _gestureArena.phase == GesturePhase.scrolling) {
+      // The sheet just handed this drag to its content. That happens at the
+      // top-detent THRESHOLD — up to (1 - _kTopDetentThreshold) of the
+      // travel short of the detent itself — and this pointer's up will see
+      // a scroll, not a drag, so nothing else would ever finish the trip.
+      // Snap the remainder now: the sheet arrives as the content starts to
+      // scroll, with the state callback and haptic an arrival deserves,
+      // instead of parking a few points shy of the top with no callback.
+      _snapToState(_geometry.maxState);
+    }
 
     if (shouldClaim) {
       if (_animationController.isAnimating) {

--- a/test/widgets/overlays/glass_modal_sheet_progress_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_progress_test.dart
@@ -51,6 +51,25 @@ void main() {
       expect(controller.progress, 1.0);
     });
 
+    testWidgets('progress is current inside its own listener', (tester) async {
+      // A listener runs before the sheet rebuilds. It must still read the
+      // position the sheet is moving to, not the one it last built at —
+      // otherwise the final tick of any drag reports a frame too early.
+      final controller = GlassModalSheetController();
+      await tester.pumpWidget(_sheetApp(controller));
+      await tester.pumpAndSettle();
+
+      double? seen;
+      void listener() => seen = controller.progress;
+      controller.progressListenable!.addListener(listener);
+      addTearDown(() => controller.progressListenable?.removeListener(listener));
+
+      controller.snapToState(GlassSheetState.full, animate: false);
+      expect(seen, 1.0, reason: 'the jump to full should read as 1.0 at once');
+      await tester.pumpAndSettle();
+      expect(controller.progress, 1.0);
+    });
+
     testWidgets('snap back to half → progress returns to 0.0', (tester) async {
       final controller = GlassModalSheetController();
       await tester.pumpWidget(_sheetApp(controller));

--- a/test/widgets/overlays/glass_modal_sheet_scroll_handover_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_scroll_handover_test.dart
@@ -48,6 +48,7 @@ void main() {
     bool ownController = false,
     bool withCarousel = false,
     ScrollController? contentController,
+    ValueChanged<GlassSheetState>? onStateChanged,
   }) {
     return createTestApp(
       child: Stack(
@@ -56,6 +57,7 @@ void main() {
             controller: controller,
             detents: detents,
             initialState: initialState,
+            onStateChanged: onStateChanged,
             child: Builder(
               builder: (context) {
                 final scroll = ScrollControllerProvider.of(context);
@@ -112,6 +114,38 @@ void main() {
     await gesture.up();
     await tester.pumpAndSettle();
     expect(controller.currentState, GlassSheetState.full);
+  });
+
+  testWidgets('the handover finishes the sheet\'s travel before the finger lifts',
+      (tester) async {
+    final states = <GlassSheetState>[];
+    final controller = GlassModalSheetController();
+    await tester.pumpWidget(
+      buildSheet(controller: controller, onStateChanged: states.add),
+    );
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(const Offset(400, 450));
+    await tester.pump(const Duration(milliseconds: 16));
+    await dragBy(tester, gesture, -540);
+    expect(contentPixels(tester), greaterThan(0.0),
+        reason: 'the drag should have been handed to the content');
+
+    // The handover happens at the top-detent THRESHOLD, short of the detent
+    // itself, and this pointer's up will see a scroll rather than a drag —
+    // so the sheet must finish the trip on its own, while the finger is
+    // still down: it arrives at full, and says so, as the content starts to
+    // scroll rather than when the finger eventually lifts.
+    await tester.pump(const Duration(milliseconds: 600));
+    expect(controller.progress, 1.0,
+        reason: 'the sheet should complete its travel to the top detent');
+    expect(states, contains(GlassSheetState.full),
+        reason: 'arriving at full via the handover must be reported');
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(controller.currentState, GlassSheetState.full);
+    expect(controller.progress, 1.0);
   });
 
   testWidgets('scrolls content back to its top before collapsing',


### PR DESCRIPTION
Fixes #284, fixes #285.

**Handover (#284).** In `_onPointerMove`, when `evaluateMove` flips the phase from `contentDrag` to `scrolling`, the sheet now calls `_snapToState(_geometry.maxState)` right there. The spring covers whatever travel was left (up to `1 - _kTopDetentThreshold`), and because it goes through the normal snap path the arrival gets its `onStateChanged`, its haptic and the settled-state bookkeeping — so the next collapse's scroll-to-top works too. The reverse handover is unaffected: a downward drag that takes the sheet back stops the animation and re-anchors, as it already did for any in-flight snap.

**Progress (#285).** The animation controller's listener is now `_onPositionTick`, which writes `_currentPosition` before notifying `_progressNotifier`. `build` keeps its ±0.002 detent snap on top. The `_livePosition` doc no longer describes `value` as lagging.

**Tests.** Two new regression tests, both red on `main`:

- `glass_modal_sheet_scroll_handover_test.dart` — "the handover finishes the sheet's travel before the finger lifts": drags the content up without lifting, pumps, and expects `progress == 1.0` and `full` in the `onStateChanged` log before `gesture.up()`.
- `glass_modal_sheet_progress_test.dart` — "progress is current inside its own listener": a non-animated jump to full must read as `1.0` inside the listener.

CHANGELOG entries under 1.3.1.

Verified on device in Hero Dirt (iPhone 16 Pro Max, iOS 26): a hand-dragged sheet now arrives, dims the map and taps as the content starts scrolling; the collapse brings the content back to the top.