### PR TITLE
feat: 1.4.0 — GlassBodyMode, decoupled backgroundQuality, and GlassMenu pull-downs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,62 @@
-# 1.3.1
+# 1.4.0
+
+## Features
+
+- **`GlassBodyMode` (`adaptive` vs `clear`) — exact design token color fidelity (#269):**
+  Introduced `GlassBodyMode` enum and `bodyMode` property on `LiquidGlassSettings` (defaulting to `GlassBodyMode.adaptive`), achieving 1:1 parity with Apple iOS 26 Liquid Glass `Glass.regular` vs `Glass.clear`.
+  - `GlassBodyMode.adaptive` (default): Employs iOS 26 dynamic luminosity normalization, ambient tint modulation, and brightness compensation based on underlying backdrop luminance.
+  - `GlassBodyMode.clear`: Bypasses luminosity normalization, white-point lift, and content-adaptive modulation. Directly composites the designer's exact hex color and alpha from `glassColor` over the refracted scene while preserving all 3D optical properties (specular rim reflections, Fresnel edge glow, meniscus edge absorption, and surface refraction).
+  - Perfectly resolves color fidelity when `blur: 0` is combined with custom tinted glass surfaces.
+  - Fully integrated across all shader tiers (Impeller `liquid_glass_final_render.frag`, standard `lightweight_glass.frag`, and Skia `_FrostedFallback`).
+
+- **Decoupled track background quality in `GlassTabBar`:**
+  Added `backgroundQuality: GlassQuality?` across `GlassTabBar.bottom`, `GlassTabBar.inline`, `GlassTabBar.searchable`, and `GlassTabBar.minimizable`.
+  - Directly matches UIKit's `UITabBarAppearance.backgroundEffect` decoupling from the active selection capsule.
+  - Allows tab bar containers to render with lightweight frosted glass (e.g., `backgroundQuality: GlassQuality.minimal` or `.standard`) while the moving selection pill retains full liquid refraction (`quality: GlassQuality.premium`).
+  - Defaults to `null`, which seamlessly inherits from `quality` without any visual regression.
+
+- **`GlassTabBarTrailingButton.menu` and `GlassTabBarExtraButton.menu` — native pull-down menus from tab bars (#275):** Both the trailing pill on `GlassTabBar.minimizable` and the extra action button on `GlassTabBar.bottom` and `GlassTabBar.searchable` now support an optional `GlassMenu` pull-down, using the same `.menu` named-constructor pattern established by `GlassButtonGroupItem.menu` and `GlassBarItem.menu`.
+
+  ```dart
+  // Minimizable trailing pill → opens a menu on tap
+  GlassTabBarTrailingButton.menu(
+    icon: const Icon(CupertinoIcons.ellipsis_circle),
+    label: 'More',
+    menuItems: [
+      GlassMenuItem(label: 'Edit', onTap: _edit),
+      GlassMenuItem(label: 'Share', onTap: _share),
+    ],
+  )
+
+  // Bottom-bar extra button → opens a menu on tap
+  GlassTabBarExtraButton.menu(
+    icon: const Icon(CupertinoIcons.plus),
+    label: 'New',
+    menuItems: [
+      GlassMenuItem(label: 'New Note', onTap: _newNote),
+      GlassMenuDivider(),
+      GlassMenuItem(label: 'Import', onTap: _import),
+    ],
+  )
+  ```
+
+  - **Liquid spring origin:** The menu expansion spring originates from the button's actual render coordinates — identical behaviour to `GlassBarItem.menu` and `UIBarButtonItem(image:menu:)` in SwiftUI.
+  - **Auto-upward expansion:** `autoAdjustToScreen: true` is always applied, so menus anchored inside a bottom bar always expand upward, matching the iOS 26 Liquid Glass `UIMenu` behaviour on toolbar items.
+  - **`enabled` toggle:** Setting `enabled: false` on either constructor dims the button and suppresses the menu — consistent with the existing tap-callback variant.
+  - **Accessibility:** Both triggers are wrapped in a `Semantics` node using the required `label` so screen readers announce the control correctly.
+  - **API surface:**
+    - `GlassTabBarTrailingButton` gains: `menuItems`, `menuAlignment`, `menuWidth`, `label`, `enabled`.
+    - `GlassTabBarExtraButton` gains: `menuItems`, `menuAlignment`, `menuWidth`. The `label` and `enabled` fields were already present.
+    - The `isMenu` getter on both classes returns true when the menu variant is active.
+  - **No scope creep:** Direct pass-through of arbitrary widget trees to the trigger position is explicitly deferred; use `GlassMenu.triggerBuilder` directly for fully custom triggers.
+
+  Thanks to [@JoetineY](https://github.com/JoetineY) for the feature request (#275).
 
 ## Bug Fixes
+
+- **Color configuration is uncertain when blur=0 (#269):** When developers configured custom tint colors with `blur: 0`, the surface previously suffered from unexpected luminance and saturation drift because the shader applied adaptive ambient and light calculations intended for blurred glass. Developers can now set `bodyMode: GlassBodyMode.clear` on `LiquidGlassSettings` to bypass adaptive tinting and composite the exact designer hex color while maintaining specular highlights, Fresnel sheen, and 3D meniscus edge refraction.
+
+Thanks to [@JoetineY](https://github.com/JoetineY) for the bug report (#269).
 
 - **Minimized bar keeps the selected tab's icon colour (#279):** On `GlassTabBar.minimizable`, the minimized pill drew the selected tab's icon in `unselectedIconColor`, so a custom `selectedIconColor` dropped out on minimize and returned on expand. The pill now uses `selectedIconColor`, as the native bar does — the tab is still selected, only the bar has shrunk. `GlassTabBar.searchable` is unchanged: its collapsed pill shows the tab search was opened from, which is no longer the selected one.
 
@@ -9,6 +65,14 @@ Thanks to [@JakeThomson](https://github.com/JakeThomson) for the fix (#280).
 - **`GlassScrollEdgeStyle.blur` stays on its own route (#278):** The progressive blur is a backdrop filter, and left unclipped a backdrop filter frosts everything beneath it up to the nearest ancestor clip — under a Cupertino pop that included the route being revealed, which showed the outgoing screen's top and bottom bands until the transition settled. The shader path lost its `ClipRect` when the region moved to paint time in 0.30.1; it is back, so a `ProgressiveBlur` now frosts nothing outside its own rectangle wherever it sits.
 
 Thanks to [@JakeThomson](https://github.com/JakeThomson) for the fix and on-device integration tests (#281).
+
+- **`GlassAppBar` title alignment (#282):** Left-aligned titles (`centerTitle: false`) no longer add an unintended 8 px start gap when no leading widget is present, correctly aligning with content padding.
+
+Thanks to [@Vincen-dev](https://github.com/Vincen-dev) for the bug report and reproduction test (#282).
+
+- **Menu and popover dismiss instantly on route navigation (#274):** When an item or action navigates to another page, `GlassMenu` and `GlassPopover` dismiss immediately instead of playing the close spring across the destination route transition.
+
+Thanks to [@Vincen-dev](https://github.com/Vincen-dev) for the bug report (#274).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -991,6 +991,7 @@ Focused, self-contained demos — one widget, one file, runnable standalone:
 | `nav_bar_patterns_demo.dart` — GlassScaffold layout patterns | `cd example && flutter run -t lib/demos/nav_bar_patterns_demo.dart` |
 | `content_aware_brightness_demo.dart` — light/dark bar adaptation | `cd example && flutter run -t lib/demos/content_aware_brightness_demo.dart` |
 | `indicator_parity_demo.dart` — all four pill widgets side-by-side | `cd example && flutter run -t lib/demos/indicator_parity_demo.dart` |
+| `color_fidelity_demo.dart` — `Glass.clear` vs `Glass.regular` + decoupled track quality | `cd example && flutter run -t lib/demos/color_fidelity_demo.dart` |
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Bring Apple's iOS 26 Liquid Glass to your Flutter app — real shader-based blur
 
 ```yaml
 dependencies:
-  liquid_glass_widgets: ^1.3.1
+  liquid_glass_widgets: ^1.4.0
 ```
 
 ```bash
@@ -992,6 +992,7 @@ Focused, self-contained demos — one widget, one file, runnable standalone:
 | `content_aware_brightness_demo.dart` — light/dark bar adaptation | `cd example && flutter run -t lib/demos/content_aware_brightness_demo.dart` |
 | `indicator_parity_demo.dart` — all four pill widgets side-by-side | `cd example && flutter run -t lib/demos/indicator_parity_demo.dart` |
 | `color_fidelity_demo.dart` — `Glass.clear` vs `Glass.regular` + decoupled track quality | `cd example && flutter run -t lib/demos/color_fidelity_demo.dart` |
+| `tab_bar_menu_demo.dart` — native pull-down menus on tab bars (`.menu`) | `cd example && flutter run -t lib/demos/tab_bar_menu_demo.dart` |
 
 
 ## Documentation

--- a/example/lib/demos/color_fidelity_demo.dart
+++ b/example/lib/demos/color_fidelity_demo.dart
@@ -1,0 +1,676 @@
+// Copyright 2026, Sebastian Degenaar for pixel-innovations.com (liquid_glass_widgets)
+//
+// SPDX-License-Identifier: MIT
+
+/// Color Fidelity & Decoupled Quality Showcase (Issue #269).
+///
+/// Demonstrates:
+///   1. [GlassBodyMode.clear] vs [GlassBodyMode.adaptive] (Apple `Glass.clear` vs `Glass.regular`).
+///      Addresses GitHub Issue #269: when blur=0, clear mode composites the exact hex tint
+///      without ambient luminance shift, while retaining specular highlights, Fresnel sheen,
+///      and 3D meniscus edge refraction.
+///   2. Decoupled [GlassTabBar.backgroundQuality]: tab bar containers can render with lightweight
+///      frosted glass (e.g. GlassQuality.minimal) while the selection indicator retains full
+///      liquid glass refraction (GlassQuality.premium).
+///
+/// To run standalone:
+///   flutter run -t example/lib/demos/color_fidelity_demo.dart
+library;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await LiquidGlassWidgets.initialize();
+  runApp(LiquidGlassWidgets.wrap(child: const ColorFidelityDemoApp()));
+}
+
+class ColorFidelityDemoApp extends StatelessWidget {
+  const ColorFidelityDemoApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      title: 'Color Fidelity & Decoupled Quality',
+      debugShowCheckedModeBanner: false,
+      theme: const CupertinoThemeData(brightness: Brightness.dark),
+      builder: (context, child) => Theme(
+        data: ThemeData.dark(useMaterial3: true),
+        child: child!,
+      ),
+      home: const ColorFidelityDemoPage(),
+    );
+  }
+}
+
+class ColorFidelityDemoPage extends StatefulWidget {
+  const ColorFidelityDemoPage({super.key});
+
+  @override
+  State<ColorFidelityDemoPage> createState() => _ColorFidelityDemoPageState();
+}
+
+class _ColorFidelityDemoPageState extends State<ColorFidelityDemoPage> {
+  // ── Color fidelity state (Issue #269) ──────────────────────────────────────
+  GlassBodyMode _bodyMode = GlassBodyMode.clear;
+  double _blur = 0.0;
+  double _thickness = 22.0;
+  double _lightIntensity = 0.8;
+  Color _selectedColor = const Color(0xD9C3E0F5); // Exact color from Issue #269
+  GlassQuality _selectedQuality = GlassQuality.premium;
+
+  // ── Tab bar decoupled quality state ────────────────────────────────────────
+  int _selectedTab = 0;
+  int _trackQualityIndex = 1; // 0: null (inherit), 1: minimal, 2: standard, 3: premium
+
+  GlassQuality? get _trackQuality => switch (_trackQualityIndex) {
+        0 => null,
+        1 => GlassQuality.minimal,
+        2 => GlassQuality.standard,
+        3 => GlassQuality.premium,
+        _ => null,
+      };
+
+  String get _trackQualityName => switch (_trackQualityIndex) {
+        0 => 'Inherit (Premium)',
+        1 => 'Minimal (Frosted)',
+        2 => 'Standard (2D)',
+        3 => 'Premium (3D Liquid)',
+        _ => 'Unknown',
+      };
+
+  static const List<(String, Color)> _swatches = [
+    ('Issue #269 Blue', Color(0xD9C3E0F5)),
+    ('Pure Frost White', Color(0xD9FFFFFF)),
+    ('Electric Cyan', Color(0xD900F5D4)),
+    ('Neon Magenta', Color(0xD9F72585)),
+    ('Sunset Amber', Color(0xD9FF9E00)),
+    ('Obsidian Noir', Color(0xD91E1E24)),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final adaptiveSettings = LiquidGlassSettings(
+      bodyMode: GlassBodyMode.adaptive,
+      blur: _blur,
+      thickness: _thickness,
+      lightIntensity: _lightIntensity,
+      glassColor: _selectedColor,
+    );
+
+    final clearSettings = LiquidGlassSettings(
+      bodyMode: GlassBodyMode.clear,
+      blur: _blur,
+      thickness: _thickness,
+      lightIntensity: _lightIntensity,
+      glassColor: _selectedColor,
+    );
+
+    final activeSettings = _bodyMode == GlassBodyMode.clear
+        ? clearSettings
+        : adaptiveSettings;
+
+    return GlassPage(
+      background: Stack(
+        fit: StackFit.expand,
+        children: [
+          // High-contrast background pattern to reveal refraction & color fidelity
+          Container(
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  Color(0xFF0F2027),
+                  Color(0xFF203A43),
+                  Color(0xFF2C5364),
+                ],
+              ),
+            ),
+          ),
+          CustomPaint(
+            painter: _HighContrastPatternPainter(),
+            child: const SizedBox.expand(),
+          ),
+        ],
+      ),
+      child: GlassScaffold(
+        extendBody: true,
+        appBar: const GlassAppBar.pinned(
+          title: Text('Color Fidelity & Quality'),
+        ),
+        body: SafeArea(
+          bottom: false,
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 140),
+            children: [
+              // ── Header Banner ───────────────────────────────────────────────
+              _buildHeaderBanner(),
+              const SizedBox(height: 16),
+
+              // ── 1. Side-by-Side Comparison (Issue #269) ────────────────────
+              _buildSectionTitle('ISSUE #269: BLUR = 0 COLOR FIDELITY'),
+              const SizedBox(height: 8),
+              _buildComparisonCards(adaptiveSettings, clearSettings),
+              const SizedBox(height: 20),
+
+              // ── 2. Live Interactive Tuner ──────────────────────────────────
+              _buildSectionTitle('SURFACE PARAMETERS & BODY MODE'),
+              const SizedBox(height: 8),
+              _buildTunerCard(activeSettings),
+              const SizedBox(height: 20),
+
+              // ── 3. Decoupled Track Quality in GlassTabBar ──────────────────
+              _buildSectionTitle('DECOUPLED TRACK QUALITY IN GLASSTABBAR'),
+              const SizedBox(height: 8),
+              _buildDecoupledTrackExplainer(),
+              const SizedBox(height: 12),
+            ],
+          ),
+        ),
+        bottomBar: GlassTabBar.bottom(
+          selectedIndex: _selectedTab,
+          onTabSelected: (i) => setState(() => _selectedTab = i),
+          quality: GlassQuality.premium,
+          backgroundQuality: _trackQuality,
+          selectedIconColor: CupertinoColors.white,
+          unselectedIconColor: CupertinoColors.white.withValues(alpha: 0.4),
+          indicatorColor: CupertinoColors.activeBlue.withValues(alpha: 0.25),
+          tabs: const [
+            GlassTab(icon: Icon(CupertinoIcons.sparkles), label: 'Fidelity'),
+            GlassTab(icon: Icon(CupertinoIcons.slider_horizontal_3), label: 'Tuner'),
+            GlassTab(icon: Icon(CupertinoIcons.layers_alt), label: 'Decoupled'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeaderBanner() {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: CupertinoColors.black.withValues(alpha: 0.45),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: CupertinoColors.white.withValues(alpha: 0.12),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: CupertinoColors.activeBlue.withValues(alpha: 0.2),
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  CupertinoIcons.checkmark_shield_fill,
+                  color: CupertinoColors.activeBlue,
+                  size: 20,
+                ),
+              ),
+              const SizedBox(width: 10),
+              const Expanded(
+                child: Text(
+                  'iOS 26 Liquid Glass Color Fidelity',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: CupertinoColors.white,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'With GlassBodyMode.clear (Apple Glass.clear), glassColor compositing bypasses adaptive luminance and saturation drift when blur=0, matching the exact designer hex while preserving 3D meniscus refraction and specular sheen.',
+            style: TextStyle(
+              fontSize: 13,
+              height: 1.4,
+              color: CupertinoColors.white.withValues(alpha: 0.75),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildComparisonCards(
+    LiquidGlassSettings adaptiveSettings,
+    LiquidGlassSettings clearSettings,
+  ) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            // Left: Adaptive (Glass.regular)
+            Expanded(
+              child: _buildGlassCard(
+                title: 'Adaptive (Glass.regular)',
+                subtitle: 'Ambient & light scaled',
+                badgeColor: CupertinoColors.systemOrange,
+                settings: adaptiveSettings,
+              ),
+            ),
+            const SizedBox(width: 12),
+            // Right: Clear (Glass.clear)
+            Expanded(
+              child: _buildGlassCard(
+                title: 'Clear (Glass.clear)',
+                subtitle: 'Exact hex fidelity',
+                badgeColor: CupertinoColors.activeGreen,
+                settings: clearSettings,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        // Reference Swatch: raw Flutter Container with exact color
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          decoration: BoxDecoration(
+            color: CupertinoColors.black.withValues(alpha: 0.4),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: CupertinoColors.white.withValues(alpha: 0.1)),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  color: _selectedColor,
+                  borderRadius: BorderRadius.circular(6),
+                  border: Border.all(color: CupertinoColors.white.withValues(alpha: 0.3)),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Reference Raw Overlay (100% Target Hex)',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: CupertinoColors.white,
+                      ),
+                    ),
+                    Text(
+                      'Clear mode matches this color exactly; adaptive applies optical luminance shift.',
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: CupertinoColors.white.withValues(alpha: 0.6),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildGlassCard({
+    required String title,
+    required String subtitle,
+    required Color badgeColor,
+    required LiquidGlassSettings settings,
+  }) {
+    return AdaptiveGlass(
+      quality: _selectedQuality,
+      settings: settings,
+      shape: const LiquidRoundedSuperellipse(borderRadius: 16),
+      child: Container(
+        height: 150,
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              decoration: BoxDecoration(
+                color: badgeColor.withValues(alpha: 0.25),
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(color: badgeColor.withValues(alpha: 0.6)),
+              ),
+              child: Text(
+                settings.bodyMode.name.toUpperCase(),
+                style: TextStyle(
+                  color: badgeColor,
+                  fontSize: 10,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    color: CupertinoColors.white,
+                    fontSize: 13,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: TextStyle(
+                    color: CupertinoColors.white.withValues(alpha: 0.65),
+                    fontSize: 11,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTunerCard(LiquidGlassSettings currentSettings) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: CupertinoColors.black.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: CupertinoColors.white.withValues(alpha: 0.15)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Body Mode Toggle
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                'Body Mode',
+                style: TextStyle(
+                  color: CupertinoColors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              CupertinoSlidingSegmentedControl<GlassBodyMode>(
+                groupValue: _bodyMode,
+                children: const {
+                  GlassBodyMode.adaptive: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                    child: Text('Adaptive', style: TextStyle(fontSize: 12)),
+                  ),
+                  GlassBodyMode.clear: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                    child: Text('Clear', style: TextStyle(fontSize: 12)),
+                  ),
+                },
+                onValueChanged: (m) {
+                  if (m != null) setState(() => _bodyMode = m);
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+
+          // Quality Tier Toggle
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                'Quality Tier',
+                style: TextStyle(
+                  color: CupertinoColors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              CupertinoSlidingSegmentedControl<GlassQuality>(
+                groupValue: _selectedQuality,
+                children: const {
+                  GlassQuality.premium: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                    child: Text('Premium', style: TextStyle(fontSize: 12)),
+                  ),
+                  GlassQuality.standard: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                    child: Text('Standard', style: TextStyle(fontSize: 12)),
+                  ),
+                  GlassQuality.minimal: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                    child: Text('Minimal', style: TextStyle(fontSize: 12)),
+                  ),
+                },
+                onValueChanged: (q) {
+                  if (q != null) setState(() => _selectedQuality = q);
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+
+          // Blur slider
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Backdrop Blur: ${_blur.toStringAsFixed(1)}px',
+                style: const TextStyle(color: CupertinoColors.white, fontSize: 13),
+              ),
+              if (_blur == 0.0)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: CupertinoColors.activeBlue.withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: const Text(
+                    'ISSUE #269 USE CASE',
+                    style: TextStyle(
+                      color: CupertinoColors.activeBlue,
+                      fontSize: 9,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          CupertinoSlider(
+            value: _blur,
+            min: 0.0,
+            max: 20.0,
+            onChanged: (v) => setState(() => _blur = v),
+          ),
+          const SizedBox(height: 8),
+
+          // Thickness slider
+          Text(
+            'Thickness (Refraction): ${_thickness.toStringAsFixed(0)}px',
+            style: const TextStyle(color: CupertinoColors.white, fontSize: 13),
+          ),
+          CupertinoSlider(
+            value: _thickness,
+            min: 0.0,
+            max: 50.0,
+            onChanged: (v) => setState(() => _thickness = v),
+          ),
+          const SizedBox(height: 8),
+
+          // Light intensity slider
+          Text(
+            'Light Intensity (Specular): ${_lightIntensity.toStringAsFixed(2)}',
+            style: const TextStyle(color: CupertinoColors.white, fontSize: 13),
+          ),
+          CupertinoSlider(
+            value: _lightIntensity,
+            min: 0.0,
+            max: 2.0,
+            onChanged: (v) => setState(() => _lightIntensity = v),
+          ),
+          const SizedBox(height: 12),
+
+          // Swatches
+          const Text(
+            'Color Tint Swatches',
+            style: TextStyle(
+              color: CupertinoColors.white,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: _swatches.map((swatch) {
+              final isSelected = _selectedColor == swatch.$2;
+              return GestureDetector(
+                onTap: () => setState(() => _selectedColor = swatch.$2),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: swatch.$2.withValues(alpha: 0.8),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
+                      color: isSelected
+                          ? CupertinoColors.white
+                          : CupertinoColors.white.withValues(alpha: 0.2),
+                      width: isSelected ? 2 : 1,
+                    ),
+                  ),
+                  child: Text(
+                    swatch.$1,
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                      color: swatch.$2.computeLuminance() > 0.5
+                          ? CupertinoColors.black
+                          : CupertinoColors.white,
+                    ),
+                  ),
+                ),
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDecoupledTrackExplainer() {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: CupertinoColors.black.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: CupertinoColors.white.withValues(alpha: 0.15)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(CupertinoIcons.layers, color: CupertinoColors.systemTeal, size: 20),
+              const SizedBox(width: 8),
+              const Text(
+                'GlassTabBar.backgroundQuality',
+                style: TextStyle(
+                  color: CupertinoColors.white,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Decouples the tab bar\'s container track from the animated selection indicator. You can set the track to lightweight minimal frosted glass while the sliding indicator maintains full 3D liquid refraction.',
+            style: TextStyle(
+              fontSize: 12,
+              height: 1.4,
+              color: CupertinoColors.white.withValues(alpha: 0.7),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Active Track Quality: $_trackQualityName',
+            style: const TextStyle(
+              color: CupertinoColors.systemTeal,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          CupertinoSlidingSegmentedControl<int>(
+            groupValue: _trackQualityIndex,
+            children: const {
+              0: Padding(
+                padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                child: Text('Inherit', style: TextStyle(fontSize: 11)),
+              ),
+              1: Padding(
+                padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                child: Text('Minimal', style: TextStyle(fontSize: 11)),
+              ),
+              2: Padding(
+                padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                child: Text('Standard', style: TextStyle(fontSize: 11)),
+              ),
+              3: Padding(
+                padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                child: Text('Premium', style: TextStyle(fontSize: 11)),
+              ),
+            },
+            onValueChanged: (v) {
+              if (v != null) setState(() => _trackQualityIndex = v);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSectionTitle(String title) {
+    return Text(
+      title,
+      style: TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w700,
+        letterSpacing: 0.8,
+        color: CupertinoColors.white.withValues(alpha: 0.6),
+      ),
+    );
+  }
+}
+
+/// Grid/checker painter to reveal refraction, transparency, and color fidelity.
+class _HighContrastPatternPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = CupertinoColors.white.withValues(alpha: 0.04)
+      ..strokeWidth = 1;
+
+    const step = 28.0;
+    for (double x = 0; x < size.width; x += step) {
+      canvas.drawLine(Offset(x, 0), Offset(x, size.height), paint);
+    }
+    for (double y = 0; y < size.height; y += step) {
+      canvas.drawLine(Offset(0, y), Offset(size.width, y), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/example/lib/demos/color_fidelity_demo.dart
+++ b/example/lib/demos/color_fidelity_demo.dart
@@ -63,7 +63,8 @@ class _ColorFidelityDemoPageState extends State<ColorFidelityDemoPage> {
 
   // ── Tab bar decoupled quality state ────────────────────────────────────────
   int _selectedTab = 0;
-  int _trackQualityIndex = 1; // 0: null (inherit), 1: minimal, 2: standard, 3: premium
+  int _trackQualityIndex =
+      1; // 0: null (inherit), 1: minimal, 2: standard, 3: premium
 
   GlassQuality? get _trackQuality => switch (_trackQualityIndex) {
         0 => null,
@@ -108,9 +109,8 @@ class _ColorFidelityDemoPageState extends State<ColorFidelityDemoPage> {
       glassColor: _selectedColor,
     );
 
-    final activeSettings = _bodyMode == GlassBodyMode.clear
-        ? clearSettings
-        : adaptiveSettings;
+    final activeSettings =
+        _bodyMode == GlassBodyMode.clear ? clearSettings : adaptiveSettings;
 
     return GlassPage(
       background: Stack(
@@ -180,7 +180,8 @@ class _ColorFidelityDemoPageState extends State<ColorFidelityDemoPage> {
           indicatorColor: CupertinoColors.activeBlue.withValues(alpha: 0.25),
           tabs: const [
             GlassTab(icon: Icon(CupertinoIcons.sparkles), label: 'Fidelity'),
-            GlassTab(icon: Icon(CupertinoIcons.slider_horizontal_3), label: 'Tuner'),
+            GlassTab(
+                icon: Icon(CupertinoIcons.slider_horizontal_3), label: 'Tuner'),
             GlassTab(icon: Icon(CupertinoIcons.layers_alt), label: 'Decoupled'),
           ],
         ),
@@ -278,7 +279,8 @@ class _ColorFidelityDemoPageState extends State<ColorFidelityDemoPage> {
           decoration: BoxDecoration(
             color: CupertinoColors.black.withValues(alpha: 0.4),
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: CupertinoColors.white.withValues(alpha: 0.1)),
+            border:
+                Border.all(color: CupertinoColors.white.withValues(alpha: 0.1)),
           ),
           child: Row(
             children: [
@@ -288,7 +290,8 @@ class _ColorFidelityDemoPageState extends State<ColorFidelityDemoPage> {
                 decoration: BoxDecoration(
                   color: _selectedColor,
                   borderRadius: BorderRadius.circular(6),
-                  border: Border.all(color: CupertinoColors.white.withValues(alpha: 0.3)),
+                  border: Border.all(
+                      color: CupertinoColors.white.withValues(alpha: 0.3)),
                 ),
               ),
               const SizedBox(width: 12),
@@ -387,7 +390,8 @@ class _ColorFidelityDemoPageState extends State<ColorFidelityDemoPage> {
       decoration: BoxDecoration(
         color: CupertinoColors.black.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: CupertinoColors.white.withValues(alpha: 0.15)),
+        border:
+            Border.all(color: CupertinoColors.white.withValues(alpha: 0.15)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -466,11 +470,13 @@ class _ColorFidelityDemoPageState extends State<ColorFidelityDemoPage> {
             children: [
               Text(
                 'Backdrop Blur: ${_blur.toStringAsFixed(1)}px',
-                style: const TextStyle(color: CupertinoColors.white, fontSize: 13),
+                style:
+                    const TextStyle(color: CupertinoColors.white, fontSize: 13),
               ),
               if (_blur == 0.0)
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                   decoration: BoxDecoration(
                     color: CupertinoColors.activeBlue.withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(4),
@@ -538,7 +544,8 @@ class _ColorFidelityDemoPageState extends State<ColorFidelityDemoPage> {
               return GestureDetector(
                 onTap: () => setState(() => _selectedColor = swatch.$2),
                 child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
                   decoration: BoxDecoration(
                     color: swatch.$2.withValues(alpha: 0.8),
                     borderRadius: BorderRadius.circular(8),
@@ -553,7 +560,8 @@ class _ColorFidelityDemoPageState extends State<ColorFidelityDemoPage> {
                     swatch.$1,
                     style: TextStyle(
                       fontSize: 11,
-                      fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                      fontWeight:
+                          isSelected ? FontWeight.bold : FontWeight.normal,
                       color: swatch.$2.computeLuminance() > 0.5
                           ? CupertinoColors.black
                           : CupertinoColors.white,
@@ -574,14 +582,16 @@ class _ColorFidelityDemoPageState extends State<ColorFidelityDemoPage> {
       decoration: BoxDecoration(
         color: CupertinoColors.black.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: CupertinoColors.white.withValues(alpha: 0.15)),
+        border:
+            Border.all(color: CupertinoColors.white.withValues(alpha: 0.15)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             children: [
-              const Icon(CupertinoIcons.layers, color: CupertinoColors.systemTeal, size: 20),
+              const Icon(CupertinoIcons.layers,
+                  color: CupertinoColors.systemTeal, size: 20),
               const SizedBox(width: 8),
               const Text(
                 'GlassTabBar.backgroundQuality',

--- a/example/lib/demos/glass_menu_demo.dart
+++ b/example/lib/demos/glass_menu_demo.dart
@@ -110,6 +110,17 @@ class _MenuDemoPageState extends State<MenuDemoPage> {
   List<Widget> get _items => [
         // Section label — tests theme color inheritance
         const GlassMenuLabel(title: 'Actions'),
+        GlassMenuItem(
+          title: 'Navigate to Page',
+          icon: const Icon(CupertinoIcons.arrow_right_circle_fill),
+          onTap: () {
+            Navigator.of(context).push(
+              CupertinoPageRoute<void>(
+                builder: (_) => const _SampleDestinationPage(),
+              ),
+            );
+          },
+        ),
         ...List.generate(
           _itemCount,
           (i) => GlassMenuItem(
@@ -422,6 +433,52 @@ class _Trigger extends StatelessWidget {
                 letterSpacing: -0.2,
               ),
             ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SampleDestinationPage extends StatelessWidget {
+  const _SampleDestinationPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: const CupertinoNavigationBar(
+        middle: Text('Destination Page'),
+      ),
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                CupertinoIcons.checkmark_seal_fill,
+                color: CupertinoColors.activeGreen,
+                size: 56,
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                'Route Transition Test',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'The menu dismissed instantly on frame 0 of the transition without overlapping this page.',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: CupertinoTheme.of(context)
+                      .textTheme
+                      .textStyle
+                      .color
+                      ?.withValues(alpha: 0.7),
+                  fontSize: 14,
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/example/lib/demos/glass_tab_bar_bottom_demo.dart
+++ b/example/lib/demos/glass_tab_bar_bottom_demo.dart
@@ -44,6 +44,23 @@ class GlassBottomBarDemoPage extends StatefulWidget {
 
 class _GlassBottomBarDemoPageState extends State<GlassBottomBarDemoPage> {
   int _selectedIndex = 0;
+  int _bgQualityIndex = 1; // Default to minimal to showcase decoupled track
+
+  GlassQuality? get _backgroundQuality => switch (_bgQualityIndex) {
+        0 => null, // Inherits quality (premium)
+        1 => GlassQuality.minimal,
+        2 => GlassQuality.standard,
+        3 => GlassQuality.premium,
+        _ => null,
+      };
+
+  String get _bgQualityLabel => switch (_bgQualityIndex) {
+        0 => 'Inherit (Premium)',
+        1 => 'Minimal (Frosted)',
+        2 => 'Standard (2D)',
+        3 => 'Premium (3D)',
+        _ => 'Unknown',
+      };
 
   @override
   Widget build(BuildContext context) {
@@ -56,16 +73,82 @@ class _GlassBottomBarDemoPageState extends State<GlassBottomBarDemoPage> {
       child: GlassScaffold(
         extendBody: true,
         body: Center(
-          child: Text(
-            'Tab $_selectedIndex Selected',
-            style: TextStyle(
-              color: CupertinoColors.white,
-              fontSize: 24,
-              fontWeight: FontWeight.bold,
-              shadows: [
-                Shadow(
-                  blurRadius: 10,
-                  color: CupertinoColors.black,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Tab $_selectedIndex Selected',
+                  style: const TextStyle(
+                    color: CupertinoColors.white,
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    shadows: [
+                      Shadow(
+                        blurRadius: 10,
+                        color: CupertinoColors.black,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 24),
+                // ── Decoupled Track Quality Selector ───────────────────
+                Container(
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: CupertinoColors.black.withValues(alpha: 0.55),
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(
+                      color: CupertinoColors.white.withValues(alpha: 0.15),
+                    ),
+                  ),
+                  child: Column(
+                    children: [
+                      const Text(
+                        'Decoupled Track Quality',
+                        style: TextStyle(
+                          color: CupertinoColors.white,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        'Track: $_bgQualityLabel  ·  Pill: Premium',
+                        style: TextStyle(
+                          color: CupertinoColors.systemTeal,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      CupertinoSlidingSegmentedControl<int>(
+                        groupValue: _bgQualityIndex,
+                        children: const {
+                          0: Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 6),
+                            child: Text('Inherit', style: TextStyle(fontSize: 12)),
+                          ),
+                          1: Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 6),
+                            child: Text('Minimal', style: TextStyle(fontSize: 12)),
+                          ),
+                          2: Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 6),
+                            child: Text('Standard', style: TextStyle(fontSize: 12)),
+                          ),
+                          3: Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 6),
+                            child: Text('Premium', style: TextStyle(fontSize: 12)),
+                          ),
+                        },
+                        onValueChanged: (v) {
+                          if (v != null) setState(() => _bgQualityIndex = v);
+                        },
+                      ),
+                    ],
+                  ),
                 ),
               ],
             ),
@@ -74,15 +157,33 @@ class _GlassBottomBarDemoPageState extends State<GlassBottomBarDemoPage> {
         bottomBar: GlassTabBar.bottom(
           selectedIndex: _selectedIndex,
           onTabSelected: (index) => setState(() => _selectedIndex = index),
+          backgroundQuality: _backgroundQuality,
           // Use distinct colors to verify masking
           selectedIconColor: CupertinoColors.white,
           unselectedIconColor: CupertinoColors.white.withValues(alpha: 0.4),
           indicatorColor: CupertinoColors.activeBlue.withValues(alpha: 0.2),
           maskingQuality: MaskingQuality.high,
-          extraButton: GlassTabBarExtraButton(
-            icon: Icon(CupertinoIcons.info),
-            label: 'something',
-            onTap: () {},
+          extraButton: GlassTabBarExtraButton.menu(
+            icon: const Icon(CupertinoIcons.ellipsis),
+            label: 'Options',
+            menuItems: [
+              GlassMenuItem(
+                icon: const Icon(CupertinoIcons.share),
+                title: 'Share',
+                onTap: () {},
+              ),
+              GlassMenuItem(
+                icon: const Icon(CupertinoIcons.bookmark),
+                title: 'Bookmark',
+                onTap: () {},
+              ),
+              const GlassMenuDivider(),
+              GlassMenuItem(
+                icon: const Icon(CupertinoIcons.gear),
+                title: 'Settings',
+                onTap: () {},
+              ),
+            ],
           ),
           tabs: [
             GlassTab(

--- a/example/lib/demos/glass_tab_bar_bottom_demo.dart
+++ b/example/lib/demos/glass_tab_bar_bottom_demo.dart
@@ -128,19 +128,23 @@ class _GlassBottomBarDemoPageState extends State<GlassBottomBarDemoPage> {
                         children: const {
                           0: Padding(
                             padding: EdgeInsets.symmetric(horizontal: 6),
-                            child: Text('Inherit', style: TextStyle(fontSize: 12)),
+                            child:
+                                Text('Inherit', style: TextStyle(fontSize: 12)),
                           ),
                           1: Padding(
                             padding: EdgeInsets.symmetric(horizontal: 6),
-                            child: Text('Minimal', style: TextStyle(fontSize: 12)),
+                            child:
+                                Text('Minimal', style: TextStyle(fontSize: 12)),
                           ),
                           2: Padding(
                             padding: EdgeInsets.symmetric(horizontal: 6),
-                            child: Text('Standard', style: TextStyle(fontSize: 12)),
+                            child: Text('Standard',
+                                style: TextStyle(fontSize: 12)),
                           ),
                           3: Padding(
                             padding: EdgeInsets.symmetric(horizontal: 6),
-                            child: Text('Premium', style: TextStyle(fontSize: 12)),
+                            child:
+                                Text('Premium', style: TextStyle(fontSize: 12)),
                           ),
                         },
                         onValueChanged: (v) {

--- a/example/lib/demos/minimizable_bar_demo.dart
+++ b/example/lib/demos/minimizable_bar_demo.dart
@@ -64,7 +64,8 @@ enum _ScrollSource {
 
 enum _TrailingMode {
   none('None'),
-  always('Always');
+  always('Always'),
+  menu('Menu');
 
   const _TrailingMode(this.label);
   final String label;
@@ -121,6 +122,7 @@ class _DemoHomeState extends State<_DemoHome> {
   _TrailingMode _trailingMode = _TrailingMode.always;
   _ScrollSource _scrollSource = _ScrollSource.controller;
   int _composerTaps = 0;
+  String? _lastMenuAction;
   bool _showAccessory = false;
   bool _extendBody = true;
 
@@ -166,13 +168,36 @@ class _DemoHomeState extends State<_DemoHome> {
   }
 
   GlassTabBarTrailingButton? get _trailingButton {
-    final button = GlassTabBarTrailingButton(
-      icon: const Icon(CupertinoIcons.square_pencil),
-      onTap: () => setState(() => _composerTaps++),
-    );
     return switch (_trailingMode) {
       _TrailingMode.none => null,
-      _TrailingMode.always => button,
+      _TrailingMode.always => GlassTabBarTrailingButton(
+          icon: const Icon(CupertinoIcons.square_pencil),
+          label: 'Compose',
+          onTap: () => setState(() => _composerTaps++),
+        ),
+      _TrailingMode.menu => GlassTabBarTrailingButton.menu(
+          icon: const Icon(CupertinoIcons.ellipsis),
+          label: 'More actions',
+          menuItems: [
+            GlassMenuItem(
+              icon: const Icon(CupertinoIcons.square_arrow_up),
+              title: 'Share',
+              onTap: () => setState(() => _lastMenuAction = 'Share'),
+            ),
+            GlassMenuItem(
+              icon: const Icon(CupertinoIcons.pencil),
+              title: 'Edit',
+              onTap: () => setState(() => _lastMenuAction = 'Edit'),
+            ),
+            const GlassMenuDivider(),
+            GlassMenuItem(
+              icon: const Icon(CupertinoIcons.trash),
+              title: 'Delete',
+              isDestructive: true,
+              onTap: () => setState(() => _lastMenuAction = 'Delete'),
+            ),
+          ],
+        ),
     };
   }
 
@@ -340,7 +365,8 @@ class _DemoHomeState extends State<_DemoHome> {
             'minimized: ${_minimize.minimized}   ·   '
             'resolved: ${_minimize.resolvedBehavior.name}   ·   '
             'source: ${_scrollSource.label}   ·   '
-            'composer taps: $_composerTaps',
+            'composer taps: $_composerTaps'
+            '${_lastMenuAction != null ? "   ·   menu: $_lastMenuAction" : ""}',
             style: TextStyle(
               fontSize: 12,
               fontFeatures: const [FontFeature.tabularFigures()],

--- a/example/lib/demos/tab_bar_menu_demo.dart
+++ b/example/lib/demos/tab_bar_menu_demo.dart
@@ -1,0 +1,986 @@
+// Copyright 2026, Sebastian Degenaar for pixel-innovations.com (liquid_glass_widgets)
+//
+// SPDX-License-Identifier: MIT
+
+/// Tab Bar Menus Showcase (Issue #275).
+///
+/// Demonstrates native iOS 26 Liquid Glass pull-down menus anchored inside tab bars:
+///   1. [GlassTabBarExtraButton.menu] on [GlassTabBar.bottom] (left & right placement).
+///   2. [GlassTabBarTrailingButton.menu] on [GlassTabBar.minimizable] (springs from trailing pill).
+///   3. [GlassTabBarExtraButton.menu] on [GlassTabBar.searchable] (alongside search pill).
+///
+/// Run standalone:
+///   flutter run -t example/lib/demos/tab_bar_menu_demo.dart
+library;
+
+import 'dart:async';
+import 'dart:ui';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await LiquidGlassWidgets.initialize();
+  runApp(LiquidGlassWidgets.wrap(child: const TabBarMenuDemoApp()));
+}
+
+class TabBarMenuDemoApp extends StatelessWidget {
+  const TabBarMenuDemoApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      title: 'Tab Bar Menus Demo',
+      debugShowCheckedModeBanner: false,
+      theme: const CupertinoThemeData(brightness: Brightness.dark),
+      builder: (context, child) => Theme(
+        data: ThemeData.dark(useMaterial3: true),
+        child: child!,
+      ),
+      home: const TabBarMenuDemoPage(),
+    );
+  }
+}
+
+enum _TabBarVariant {
+  bottom('Bottom Bar'),
+  minimizable('Minimizable'),
+  searchable('Searchable');
+
+  const _TabBarVariant(this.label);
+  final String label;
+}
+
+class TabBarMenuDemoPage extends StatefulWidget {
+  const TabBarMenuDemoPage({super.key});
+
+  @override
+  State<TabBarMenuDemoPage> createState() => _TabBarMenuDemoPageState();
+}
+
+class _TabBarMenuDemoPageState extends State<TabBarMenuDemoPage> {
+  _TabBarVariant _variant = _TabBarVariant.bottom;
+  int _selectedTab = 0;
+  bool _menuEnabled = true;
+  bool _isSearchActive = false;
+  String _searchQuery = '';
+  GlassExtraButtonPlacement _placement = GlassExtraButtonPlacement.right;
+  double _menuWidth = 220;
+  String? _lastAction;
+  Timer? _actionTimer;
+  bool _controlsExpanded = true;
+
+  late final GlassTabBarMinimizeController _minimizeController;
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _minimizeController = GlassTabBarMinimizeController(
+      behavior: GlassBarMinimizeBehavior.onScrollDown,
+    );
+  }
+
+  @override
+  void dispose() {
+    _actionTimer?.cancel();
+    _minimizeController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onAction(String action) {
+    _actionTimer?.cancel();
+    setState(() => _lastAction = action);
+    _actionTimer = Timer(const Duration(milliseconds: 2600), () {
+      if (mounted) setState(() => _lastAction = null);
+    });
+  }
+
+  List<Widget> _buildMenuItems() {
+    return [
+      const GlassMenuLabel(title: 'Quick Actions'),
+      GlassMenuItem(
+        icon: const Icon(CupertinoIcons.square_pencil),
+        title: 'New Note',
+        onTap: () => _onAction('New Note'),
+      ),
+      GlassMenuItem(
+        icon: const Icon(CupertinoIcons.folder_badge_plus),
+        title: 'New Folder',
+        onTap: () => _onAction('New Folder'),
+      ),
+      GlassMenuItem(
+        icon: const Icon(CupertinoIcons.share),
+        title: 'Share Feed',
+        onTap: () => _onAction('Share Feed'),
+      ),
+      const GlassMenuDivider(),
+      GlassMenuItem(
+        icon: const Icon(CupertinoIcons.slider_horizontal_3),
+        title: 'Preferences',
+        onTap: () => _onAction('Preferences'),
+      ),
+      GlassMenuItem(
+        icon: const Icon(CupertinoIcons.trash),
+        title: 'Clear History',
+        isDestructive: true,
+        onTap: () => _onAction('Clear History'),
+      ),
+    ];
+  }
+
+  Widget _buildControlPanel() {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(24),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 16),
+          padding: const EdgeInsets.all(18),
+          decoration: BoxDecoration(
+            color: CupertinoColors.black.withValues(alpha: 0.38),
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(
+              color: CupertinoColors.white.withValues(alpha: 0.16),
+              width: 0.5,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: CupertinoColors.black.withValues(alpha: 0.3),
+                blurRadius: 28,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Header with collapsible toggle
+              GestureDetector(
+                onTap: () =>
+                    setState(() => _controlsExpanded = !_controlsExpanded),
+                behavior: HitTestBehavior.opaque,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Row(
+                      children: [
+                        Container(
+                          width: 28,
+                          height: 28,
+                          decoration: BoxDecoration(
+                            color: CupertinoColors.activeBlue
+                                .withValues(alpha: 0.22),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: const Icon(
+                            CupertinoIcons.slider_horizontal_3,
+                            size: 15,
+                            color: CupertinoColors.activeBlue,
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        Text(
+                          'TAB BAR VARIANT',
+                          style: TextStyle(
+                            color:
+                                CupertinoColors.white.withValues(alpha: 0.70),
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 0.8,
+                          ),
+                        ),
+                      ],
+                    ),
+                    Icon(
+                      _controlsExpanded
+                          ? CupertinoIcons.chevron_up
+                          : CupertinoIcons.chevron_down,
+                      size: 14,
+                      color: CupertinoColors.white.withValues(alpha: 0.70),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+
+              // Bar Variant Selector
+              SizedBox(
+                width: double.infinity,
+                child: CupertinoSlidingSegmentedControl<_TabBarVariant>(
+                  groupValue: _variant,
+                  children: {
+                    for (final v in _TabBarVariant.values)
+                      v: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 7),
+                        child: Text(
+                          v.label,
+                          style: const TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ),
+                  },
+                  onValueChanged: (v) {
+                    if (v != null) {
+                      setState(() {
+                        _variant = v;
+                        _isSearchActive = false;
+                        _searchQuery = '';
+                        _minimizeController.expand();
+                      });
+                    }
+                  },
+                ),
+              ),
+
+              if (_controlsExpanded) ...[
+                const SizedBox(height: 16),
+                Container(
+                  height: 0.5,
+                  color: CupertinoColors.white.withValues(alpha: 0.10),
+                ),
+                const SizedBox(height: 14),
+
+                // Menu Enabled Switch
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text(
+                      'Menu Enabled',
+                      style: TextStyle(
+                        color: CupertinoColors.white,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    CupertinoSwitch(
+                      value: _menuEnabled,
+                      activeTrackColor: CupertinoColors.activeBlue,
+                      onChanged: (val) => setState(() => _menuEnabled = val),
+                    ),
+                  ],
+                ),
+
+                if (_variant == _TabBarVariant.bottom) ...[
+                  const SizedBox(height: 12),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      const Text(
+                        'Button Placement',
+                        style: TextStyle(
+                          color: CupertinoColors.white,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      CupertinoSlidingSegmentedControl<
+                          GlassExtraButtonPlacement>(
+                        groupValue: _placement,
+                        children: const {
+                          GlassExtraButtonPlacement.left: Padding(
+                            padding: EdgeInsets.symmetric(
+                                horizontal: 10, vertical: 4),
+                            child: Text('Left', style: TextStyle(fontSize: 12)),
+                          ),
+                          GlassExtraButtonPlacement.right: Padding(
+                            padding: EdgeInsets.symmetric(
+                                horizontal: 10, vertical: 4),
+                            child:
+                                Text('Right', style: TextStyle(fontSize: 12)),
+                          ),
+                        },
+                        onValueChanged: (p) {
+                          if (p != null) setState(() => _placement = p);
+                        },
+                      ),
+                    ],
+                  ),
+                ],
+
+                const SizedBox(height: 12),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text(
+                      'Menu Width',
+                      style: TextStyle(
+                        color: CupertinoColors.white,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    CupertinoSlidingSegmentedControl<double>(
+                      groupValue: _menuWidth,
+                      children: {
+                        180.0: const Padding(
+                          padding:
+                              EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                          child: Text('180', style: TextStyle(fontSize: 12)),
+                        ),
+                        220.0: const Padding(
+                          padding:
+                              EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                          child: Text('220', style: TextStyle(fontSize: 12)),
+                        ),
+                        260.0: const Padding(
+                          padding:
+                              EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                          child: Text('260', style: TextStyle(fontSize: 12)),
+                        ),
+                      },
+                      onValueChanged: (w) {
+                        if (w != null) setState(() => _menuWidth = w);
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<_DemoFeedItem> _getAllFeedItems() {
+    return const [
+      _DemoFeedItem(
+        category: 'SPATIAL REFRACTION',
+        title: 'Impeller Liquid Shaders',
+        subtitle: 'Real-time backdrop refraction with chromatic aberration.',
+        icon: CupertinoIcons.sparkles,
+        gradient: [Color(0xFF6A11CB), Color(0xFF2575FC)],
+        tag: 'Metal 3D',
+      ),
+      _DemoFeedItem(
+        category: 'METABALL MORPHING',
+        title: 'Dual-Blob Teardrop Physics',
+        subtitle: 'Button morphs smoothly into the pull-down menu shape.',
+        icon: CupertinoIcons.arrow_2_circlepath_circle,
+        gradient: [Color(0xFFF857A6), Color(0xFFFF5858)],
+        tag: 'Spring J-Curve',
+      ),
+      _DemoFeedItem(
+        category: 'MINIMIZABLE BAR',
+        title: 'Scroll-Driven Compact Pill',
+        subtitle: 'Bar shrinks to a compact trailing pill on scroll down.',
+        icon: CupertinoIcons.arrow_down_right_arrow_up_left,
+        gradient: [Color(0xFF00C6FF), Color(0xFF0072FF)],
+        tag: 'Interactive',
+      ),
+      _DemoFeedItem(
+        category: 'SEARCH INTEGRATION',
+        title: 'Elastic Search Pill',
+        subtitle: 'Extra action button stays pinned alongside the search bar.',
+        icon: CupertinoIcons.search,
+        gradient: [Color(0xFFFF9900), Color(0xFFFF5E62)],
+        tag: 'Auto-Collapse',
+      ),
+      _DemoFeedItem(
+        category: 'ADAPTIVE BRIGHTNESS',
+        title: 'Dynamic Lighting & Glow',
+        subtitle: 'Subtle specular glow illuminates borders on tap & drag.',
+        icon: CupertinoIcons.lightbulb_fill,
+        gradient: [Color(0xFF43E97B), Color(0xFF38F9D7)],
+        tag: 'Color Fidelity',
+      ),
+      _DemoFeedItem(
+        category: 'GESTURE ARENA',
+        title: 'Haptic Friction & Snap',
+        subtitle: 'Spring physics dynamically adjust to swipe velocity.',
+        icon: CupertinoIcons.hand_draw_fill,
+        gradient: [Color(0xFFFA709A), Color(0xFFFEE140)],
+        tag: '60/120 Hz',
+      ),
+      _DemoFeedItem(
+        category: 'PERFORMANCE',
+        title: 'Zero-Overhead Compositing',
+        subtitle: 'Stationary surfaces skip full GPU raster passes.',
+        icon: CupertinoIcons.gauge,
+        gradient: [Color(0xFF30CFD0), Color(0xFF330867)],
+        tag: 'Optimized',
+      ),
+    ];
+  }
+
+  Widget _buildContent() {
+    final allItems = _getAllFeedItems();
+    final items = _searchQuery.isEmpty
+        ? allItems
+        : allItems.where((it) {
+            final q = _searchQuery.toLowerCase();
+            return it.title.toLowerCase().contains(q) ||
+                it.subtitle.toLowerCase().contains(q) ||
+                it.category.toLowerCase().contains(q);
+          }).toList();
+
+    return ListView(
+      controller: _scrollController,
+      padding: EdgeInsets.fromLTRB(
+        0,
+        MediaQuery.paddingOf(context).top + 58,
+        0,
+        140,
+      ),
+      children: [
+        // Hero Header
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Badge
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                decoration: BoxDecoration(
+                  color: CupertinoColors.activeBlue.withValues(alpha: 0.18),
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color: CupertinoColors.activeBlue.withValues(alpha: 0.35),
+                    width: 0.5,
+                  ),
+                ),
+                child: const Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      CupertinoIcons.sparkles,
+                      size: 12,
+                      color: CupertinoColors.activeBlue,
+                    ),
+                    SizedBox(width: 5),
+                    Text(
+                      'iOS 26 LIQUID GLASS',
+                      style: TextStyle(
+                        color: CupertinoColors.activeBlue,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                        letterSpacing: 0.8,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 10),
+              const Text(
+                'Tab Bar Menus',
+                style: TextStyle(
+                  fontSize: 32,
+                  fontWeight: FontWeight.w800,
+                  color: CupertinoColors.white,
+                  letterSpacing: -0.6,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                _variant == _TabBarVariant.minimizable
+                    ? 'Scroll down to test the pull-down menu while minimized into the trailing pill.'
+                    : _variant == _TabBarVariant.searchable
+                        ? 'Tap search to expand the input, or tap the ellipsis menu button.'
+                        : 'Tap the ellipsis button on the bar to morph into the liquid menu.',
+                style: TextStyle(
+                  fontSize: 14,
+                  height: 1.35,
+                  color: CupertinoColors.white.withValues(alpha: 0.70),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 18),
+
+        // Controls
+        _buildControlPanel(),
+        const SizedBox(height: 20),
+
+        // Section Title
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                _selectedTab == 0
+                    ? 'EXPLORE FEED'
+                    : _selectedTab == 1
+                        ? 'SAVED LIBRARY'
+                        : 'PROFILE ITEMS',
+                style: TextStyle(
+                  color: CupertinoColors.white.withValues(alpha: 0.75),
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.8,
+                ),
+              ),
+              Text(
+                '${items.length} items',
+                style: TextStyle(
+                  color: CupertinoColors.white.withValues(alpha: 0.5),
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 10),
+
+        // Rich Content Feed Cards
+        for (var i = 0; i < items.length; i++)
+          _FeedCardWidget(
+            item: items[i],
+            index: i + 1,
+            onTap: () => _onAction(items[i].title),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildTabBar() {
+    final menuItems = _buildMenuItems();
+
+    switch (_variant) {
+      case _TabBarVariant.bottom:
+        return GlassTabBar.bottom(
+          selectedIndex: _selectedTab,
+          onTabSelected: (i) => setState(() => _selectedTab = i),
+          extraButton: GlassTabBarExtraButton.menu(
+            icon: const Icon(CupertinoIcons.ellipsis),
+            label: 'More Actions',
+            enabled: _menuEnabled,
+            placement: _placement,
+            menuWidth: _menuWidth,
+            menuItems: menuItems,
+          ),
+          tabs: const [
+            GlassTab(
+              label: 'Explore',
+              icon: Icon(CupertinoIcons.compass),
+              activeIcon: Icon(CupertinoIcons.compass_fill),
+            ),
+            GlassTab(
+              label: 'Library',
+              icon: Icon(CupertinoIcons.book),
+              activeIcon: Icon(CupertinoIcons.book_fill),
+            ),
+            GlassTab(
+              label: 'Account',
+              icon: Icon(CupertinoIcons.person),
+              activeIcon: Icon(CupertinoIcons.person_fill),
+            ),
+          ],
+        );
+
+      case _TabBarVariant.minimizable:
+        return GlassTabBar.minimizable(
+          selectedIndex: _selectedTab,
+          onTabSelected: (i) => setState(() => _selectedTab = i),
+          minimizeController: _minimizeController,
+          scrollController: _scrollController,
+          trailingButton: GlassTabBarTrailingButton.menu(
+            icon: const Icon(CupertinoIcons.ellipsis),
+            label: 'Trailing Actions',
+            enabled: _menuEnabled,
+            menuWidth: _menuWidth,
+            menuItems: menuItems,
+          ),
+          tabs: const [
+            GlassTab(
+              label: 'Explore',
+              icon: Icon(CupertinoIcons.compass),
+              activeIcon: Icon(CupertinoIcons.compass_fill),
+            ),
+            GlassTab(
+              label: 'Library',
+              icon: Icon(CupertinoIcons.book),
+              activeIcon: Icon(CupertinoIcons.book_fill),
+            ),
+            GlassTab(
+              label: 'Profile',
+              icon: Icon(CupertinoIcons.person),
+              activeIcon: Icon(CupertinoIcons.person_fill),
+            ),
+          ],
+        );
+
+      case _TabBarVariant.searchable:
+        return GlassTabBar.searchable(
+          selectedIndex: _selectedTab,
+          onTabSelected: (i) => setState(() => _selectedTab = i),
+          isSearchActive: _isSearchActive,
+          searchConfig: GlassSearchBarConfig(
+            onSearchToggle: (active) =>
+                setState(() => _isSearchActive = active),
+            onChanged: (q) => setState(() => _searchQuery = q),
+            hintText: 'Search feed...',
+          ),
+          extraButton: GlassTabBarExtraButton.menu(
+            icon: const Icon(CupertinoIcons.ellipsis),
+            label: 'Search Actions',
+            enabled: _menuEnabled,
+            menuWidth: _menuWidth,
+            menuItems: menuItems,
+          ),
+          tabs: const [
+            GlassTab(
+              label: 'Explore',
+              icon: Icon(CupertinoIcons.compass),
+              activeIcon: Icon(CupertinoIcons.compass_fill),
+            ),
+            GlassTab(
+              label: 'Library',
+              icon: Icon(CupertinoIcons.book),
+              activeIcon: Icon(CupertinoIcons.book_fill),
+            ),
+          ],
+        );
+    }
+  }
+
+  Widget _buildActionToast() {
+    final action = _lastAction;
+    final isShowing = action != null;
+
+    return AnimatedPositioned(
+      duration: const Duration(milliseconds: 320),
+      curve: Curves.easeOutBack,
+      top: isShowing ? MediaQuery.paddingOf(context).top + 56 : -80,
+      left: 20,
+      right: 20,
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 250),
+        opacity: isShowing ? 1.0 : 0.0,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(18),
+          child: BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              decoration: BoxDecoration(
+                color: CupertinoColors.black.withValues(alpha: 0.55),
+                borderRadius: BorderRadius.circular(18),
+                border: Border.all(
+                  color: CupertinoColors.activeBlue.withValues(alpha: 0.45),
+                  width: 0.8,
+                ),
+                boxShadow: const [
+                  BoxShadow(
+                    color: Color(0x66000000),
+                    blurRadius: 20,
+                    offset: Offset(0, 6),
+                  ),
+                ],
+              ),
+              child: Row(
+                children: [
+                  Container(
+                    width: 28,
+                    height: 28,
+                    decoration: BoxDecoration(
+                      color: CupertinoColors.activeBlue.withValues(alpha: 0.25),
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Icon(
+                      CupertinoIcons.checkmark_alt,
+                      color: CupertinoColors.activeBlue,
+                      size: 16,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Text(
+                          'ACTION EXECUTED',
+                          style: TextStyle(
+                            color: CupertinoColors.secondaryLabel,
+                            fontSize: 10,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 0.6,
+                          ),
+                        ),
+                        const SizedBox(height: 1),
+                        Text(
+                          action ?? '',
+                          style: const TextStyle(
+                            color: CupertinoColors.white,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      backgroundColor: CupertinoColors.black,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          // Background wallpaper - full edge to edge from (0,0)
+          Image.asset(
+            'assets/wallpaper.jpg',
+            fit: BoxFit.cover,
+            errorBuilder: (_, __, ___) => Container(
+              decoration: const BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [Color(0xFF1B1B2F), Color(0xFF162447)],
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                ),
+              ),
+            ),
+          ),
+
+          // Content List
+          _buildContent(),
+
+          // Frosted Glass Top Navigation Bar
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: ClipRect(
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+                child: Container(
+                  color: CupertinoColors.black.withValues(alpha: 0.22),
+                  padding: EdgeInsets.only(
+                    top: MediaQuery.paddingOf(context).top + 4,
+                    left: 6,
+                    right: 16,
+                    bottom: 10,
+                  ),
+                  child: Row(
+                    children: [
+                      CupertinoButton(
+                        padding: const EdgeInsets.all(8),
+                        minimumSize: const Size(32, 32),
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Icon(
+                          CupertinoIcons.chevron_back,
+                          color: CupertinoColors.white,
+                          size: 24,
+                        ),
+                      ),
+                      const Expanded(
+                        child: Text(
+                          'Tab Bar Menus',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: CupertinoColors.white,
+                            fontWeight: FontWeight.w600,
+                            fontSize: 17,
+                            letterSpacing: -0.3,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 40),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+
+          // Floating Action Toast
+          _buildActionToast(),
+
+          // Pinned Tab Bar at Bottom
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: SafeArea(
+              top: false,
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: _buildTabBar(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DemoFeedItem {
+  final String category;
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final List<Color> gradient;
+  final String tag;
+
+  const _DemoFeedItem({
+    required this.category,
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.gradient,
+    required this.tag,
+  });
+}
+
+class _FeedCardWidget extends StatelessWidget {
+  final _DemoFeedItem item;
+  final int index;
+  final VoidCallback onTap;
+
+  const _FeedCardWidget({
+    required this.item,
+    required this.index,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(20),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
+          child: CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: onTap,
+            child: Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: CupertinoColors.black.withValues(alpha: 0.28),
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(
+                  color: CupertinoColors.white.withValues(alpha: 0.12),
+                  width: 0.5,
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: CupertinoColors.black.withValues(alpha: 0.2),
+                    blurRadius: 16,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Gradient Icon Squircle
+                  Container(
+                    width: 44,
+                    height: 44,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        colors: item.gradient,
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                      ),
+                      borderRadius: BorderRadius.circular(12),
+                      boxShadow: [
+                        BoxShadow(
+                          color: item.gradient.first.withValues(alpha: 0.35),
+                          blurRadius: 10,
+                          offset: const Offset(0, 4),
+                        ),
+                      ],
+                    ),
+                    child: Center(
+                      child: Icon(
+                        item.icon,
+                        color: CupertinoColors.white,
+                        size: 22,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 14),
+
+                  // Text Info
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              item.category,
+                              style: TextStyle(
+                                color: item.gradient.first,
+                                fontSize: 10,
+                                fontWeight: FontWeight.w700,
+                                letterSpacing: 0.6,
+                              ),
+                            ),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 6,
+                                vertical: 2,
+                              ),
+                              decoration: BoxDecoration(
+                                color: CupertinoColors.white
+                                    .withValues(alpha: 0.08),
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                              child: Text(
+                                item.tag,
+                                style: TextStyle(
+                                  color: CupertinoColors.white
+                                      .withValues(alpha: 0.65),
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          item.title,
+                          style: const TextStyle(
+                            color: CupertinoColors.white,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                            letterSpacing: -0.2,
+                          ),
+                        ),
+                        const SizedBox(height: 3),
+                        Text(
+                          item.subtitle,
+                          style: TextStyle(
+                            color:
+                                CupertinoColors.white.withValues(alpha: 0.65),
+                            fontSize: 13,
+                            height: 1.25,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,6 +27,8 @@ import 'package:liquid_glass_widgets_example/demos/google_maps_demo.dart'
     show PlatformViewDemo;
 import 'package:liquid_glass_widgets_example/demos/quality_comparison_demo.dart'
     show GlassQualityComparisonDemo;
+import 'package:liquid_glass_widgets_example/demos/color_fidelity_demo.dart'
+    show ColorFidelityDemoPage;
 import 'package:liquid_glass_widgets_example/pages/containers_page.dart';
 import 'package:liquid_glass_widgets_example/pages/feedback_page.dart';
 import 'package:liquid_glass_widgets_example/pages/input_page.dart';
@@ -796,7 +798,7 @@ class _ExamplesTab extends StatelessWidget {
                   ),
                   SizedBox(height: 14),
 
-                  // Row 4: Quality Tiers (full width — Collapse Bar removed in v1.0.0)
+                  // Row 4: Quality Tiers & Color Fidelity
                   Row(
                     children: [
                       Expanded(
@@ -805,6 +807,15 @@ class _ExamplesTab extends StatelessWidget {
                           icon: CupertinoIcons.sparkles,
                           color: const Color(0xFFFFB340),
                           destination: const GlassQualityComparisonDemo(),
+                        ),
+                      ),
+                      SizedBox(width: 14),
+                      Expanded(
+                        child: _SmallDemoCard(
+                          title: 'Color Fidelity',
+                          icon: CupertinoIcons.color_filter,
+                          color: const Color(0xFF00F5D4),
+                          destination: const ColorFidelityDemoPage(),
                         ),
                       ),
                     ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,6 +29,8 @@ import 'package:liquid_glass_widgets_example/demos/quality_comparison_demo.dart'
     show GlassQualityComparisonDemo;
 import 'package:liquid_glass_widgets_example/demos/color_fidelity_demo.dart'
     show ColorFidelityDemoPage;
+import 'package:liquid_glass_widgets_example/demos/tab_bar_menu_demo.dart'
+    show TabBarMenuDemoPage;
 import 'package:liquid_glass_widgets_example/pages/containers_page.dart';
 import 'package:liquid_glass_widgets_example/pages/feedback_page.dart';
 import 'package:liquid_glass_widgets_example/pages/input_page.dart';
@@ -733,6 +735,20 @@ class _ExamplesTab extends StatelessWidget {
                         ),
                       ),
                     ],
+                  ),
+                  SizedBox(height: 14),
+
+                  // Large card: Tab Bar Menus
+                  _LargeDemoCard(
+                    title: 'Tab Bar Menus',
+                    subtitle:
+                        'Pull-down menus on bottom, minimizable & searchable bars (#275)',
+                    icon: CupertinoIcons.ellipsis_vertical_circle_fill,
+                    gradient: const [
+                      Color(0xFF2E0854),
+                      Color(0xFF8E2DE2),
+                    ],
+                    destination: const TabBarMenuDemoPage(),
                   ),
                   SizedBox(height: 14),
 

--- a/lib/liquid_glass_widgets.dart
+++ b/lib/liquid_glass_widgets.dart
@@ -8,6 +8,7 @@ library;
 export 'src/renderer/liquid_glass_renderer.dart'
     show
         AnchorStretchSettings,
+        GlassBodyMode,
         LiquidGlassSettings,
         PlatformViewGlassMode,
         LiquidGlassLayer,

--- a/lib/src/renderer/liquid_glass_renderer.dart
+++ b/lib/src/renderer/liquid_glass_renderer.dart
@@ -16,7 +16,7 @@ export 'glass_glow.dart' show GlassGlow, GlassGlowLayer;
 export 'liquid_glass.dart' show LiquidGlass;
 export 'liquid_glass_blend_group.dart' show LiquidGlassBlendGroup;
 export 'liquid_glass_settings.dart'
-    show LiquidGlassSettings, PlatformViewGlassMode;
+    show GlassBodyMode, LiquidGlassSettings, PlatformViewGlassMode;
 export 'liquid_shape.dart';
 export 'internal/liquid_glass_self_scale_scope.dart'
     show LiquidGlassSelfScaleScope;

--- a/lib/src/renderer/liquid_glass_settings.dart
+++ b/lib/src/renderer/liquid_glass_settings.dart
@@ -38,6 +38,23 @@ enum PlatformViewGlassMode {
   passthrough,
 }
 
+/// Controls how the glass body blends color over the background.
+///
+/// Matches Apple's iOS 26 Liquid Glass material styling in Swift / UIKit:
+/// - [adaptive]: matches `Glass.regular` — adaptive luminance-preserving tint
+///   that takes the color's hue while holding the background's perceived brightness.
+/// - [clear]: matches `Glass.clear` — direct alpha-composited tint with no
+///   luminance normalization, preserving exact design token hex values while
+///   retaining specular, Fresnel, and rim physics.
+enum GlassBodyMode {
+  /// Adaptive luminance-preserving tint (default, matches Apple's Glass.regular).
+  adaptive,
+
+  /// Direct alpha-composite tint with no luminance normalization (matches Apple's Glass.clear).
+  /// Preserves exact design token hex values while retaining specular, Fresnel, and rim physics.
+  clear,
+}
+
 /// Represents the settings for a liquid glass effect.
 class LiquidGlassSettings {
   /// Creates a new [LiquidGlassSettings] with the given settings.
@@ -71,6 +88,7 @@ class LiquidGlassSettings {
     this.backerColor,
     this.platformViewFallbackColor,
     this.platformViewMode = PlatformViewGlassMode.fallbackColor,
+    this.bodyMode = GlassBodyMode.adaptive,
   }) : pinchStrength = 0.0;
 
   /// Private constructor used exclusively by [copyWithPinch].
@@ -102,6 +120,7 @@ class LiquidGlassSettings {
     this.backerColor,
     this.platformViewFallbackColor,
     this.platformViewMode = PlatformViewGlassMode.fallbackColor,
+    this.bodyMode = GlassBodyMode.adaptive,
     required this.pinchStrength,
   });
 
@@ -171,20 +190,19 @@ class LiquidGlassSettings {
   /// intentional optical glass behaviour, not a bug.
   ///
   /// **If you need a pixel-accurate, unmodified color overlay** with no luminance
-  /// normalization or shader processing, use [GlassQuality.minimal] with [blur]
-  /// set to `0`. That tier renders a plain [DecoratedBox] clipped to the glass
-  /// shape — exactly the color you pass, with no optical adjustments:
+  /// normalization or chromatic drift across any quality tier (including [GlassQuality.premium]
+  /// and [GlassQuality.standard]), set [bodyMode] to [GlassBodyMode.clear]:
   ///
   /// ```dart
-  /// AdaptiveGlass(
-  ///   quality: GlassQuality.minimal,
-  ///   settings: LiquidGlassSettings(
-  ///     blur: 0,
-  ///     glassColor: Color(0xD9C3E0F5),
-  ///   ),
-  ///   child: ...,
+  /// LiquidGlassSettings(
+  ///   bodyMode: GlassBodyMode.clear,
+  ///   blur: 0,
+  ///   glassColor: Color(0xD9C3E0F5),
   /// )
   /// ```
+  ///
+  /// In clear mode, the body tint is composited with exact alpha blending while
+  /// still preserving specular highlights, Fresnel sheen, and 3D meniscus edge refraction.
   final Color glassColor;
 
   /// The effective glass color taking visibility into account.
@@ -474,6 +492,7 @@ class LiquidGlassSettings {
         backerColor: backerColor,
         platformViewFallbackColor: platformViewFallbackColor,
         platformViewMode: platformViewMode,
+        bodyMode: bodyMode,
         pinchStrength: value,
       );
 
@@ -526,6 +545,13 @@ class LiquidGlassSettings {
   /// Defaults to [PlatformViewGlassMode.fallbackColor], which is the existing
   /// behaviour, so this changes nothing unless it is asked for.
   final PlatformViewGlassMode platformViewMode;
+
+  /// How the glass body blends color over the background.
+  ///
+  /// Defaults to [GlassBodyMode.adaptive], which matches Apple's `Glass.regular`
+  /// (luminance-preserving tint). Set to [GlassBodyMode.clear] to match Apple's
+  /// `Glass.clear` (direct alpha-composite tint without luminance normalization).
+  final GlassBodyMode bodyMode;
 
   /// The effective saturation taking visibility into account.
   double get effectiveSaturation => 1 + (saturation - 1) * visibility;
@@ -580,6 +606,7 @@ class LiquidGlassSettings {
         // A mode is not interpolable: it switches at the midpoint like any
         // other enum in this class.
         platformViewMode: t < 0.5 ? a.platformViewMode : b.platformViewMode,
+        bodyMode: t < 0.5 ? a.bodyMode : b.bodyMode,
         // pinchStrength is interaction state — lerp it so transitions are smooth
         // when the indicator fades between active/resting states.
         pinchStrength: lerpDouble(a.pinchStrength, b.pinchStrength, t)!);
@@ -619,6 +646,7 @@ class LiquidGlassSettings {
     Color? backerColor,
     Color? platformViewFallbackColor,
     PlatformViewGlassMode? platformViewMode,
+    GlassBodyMode? bodyMode,
   }) =>
       LiquidGlassSettings._withPinch(
         visibility: visibility ?? this.visibility,
@@ -646,6 +674,7 @@ class LiquidGlassSettings {
         platformViewFallbackColor:
             platformViewFallbackColor ?? this.platformViewFallbackColor,
         platformViewMode: platformViewMode ?? this.platformViewMode,
+        bodyMode: bodyMode ?? this.bodyMode,
         pinchStrength: pinchStrength,
       );
 
@@ -677,6 +706,7 @@ class LiquidGlassSettings {
         other.backerColor == backerColor &&
         other.platformViewFallbackColor == platformViewFallbackColor &&
         other.platformViewMode == platformViewMode &&
+        other.bodyMode == bodyMode &&
         other.pinchStrength == pinchStrength;
   }
 
@@ -705,6 +735,7 @@ class LiquidGlassSettings {
         backerColor,
         platformViewFallbackColor,
         platformViewMode,
+        bodyMode,
         pinchStrength,
       ]);
 }

--- a/lib/src/renderer/rendering/liquid_glass_render_object.dart
+++ b/lib/src/renderer/rendering/liquid_glass_render_object.dart
@@ -337,13 +337,17 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
               settings.effectiveEdgeAbsorption,
             ]);
           })
-          // Slot 32: uPlatformViewMode.
+          // Slot 32: uPlatformViewMode; Slot 33: uBodyMode.
           ..setFloatUniforms(initialIndex: 32, (value) {
-            value.setFloat(
-              settings.platformViewMode == PlatformViewGlassMode.passthrough
-                  ? 1.0
-                  : 0.0,
-            );
+            value
+              ..setFloat(
+                settings.platformViewMode == PlatformViewGlassMode.passthrough
+                    ? 1.0
+                    : 0.0,
+              )
+              ..setFloat(
+                settings.bodyMode == GlassBodyMode.clear ? 1.0 : 0.0,
+              );
           })
           ..setImageSampler(
             1,
@@ -484,13 +488,17 @@ abstract class LiquidGlassRenderObject extends RenderProxyBox {
           settings.effectiveEdgeAbsorption,
         ]);
       })
-      // Slot 32: uPlatformViewMode.
+      // Slot 32: uPlatformViewMode; Slot 33: uBodyMode.
       ..setFloatUniforms(initialIndex: 32, (value) {
-        value.setFloat(
-          settings.platformViewMode == PlatformViewGlassMode.passthrough
-              ? 1.0
-              : 0.0,
-        );
+        value
+          ..setFloat(
+            settings.platformViewMode == PlatformViewGlassMode.passthrough
+                ? 1.0
+                : 0.0,
+          )
+          ..setFloat(
+            settings.bodyMode == GlassBodyMode.clear ? 1.0 : 0.0,
+          );
       })
       // Slot 0: captured background image (replaces the BackdropFilter read).
       ..setImageSampler(0, capture)

--- a/lib/src/widgets/surfaces/tab_bar_bottom_internal.dart
+++ b/lib/src/widgets/surfaces/tab_bar_bottom_internal.dart
@@ -18,6 +18,7 @@ import '../../../utils/draggable_indicator_physics.dart';
 import 'tab_bar_drag_gesture_mixin.dart';
 import '../../../utils/glass_spring.dart';
 import '../../../widgets/interactive/glass_button.dart';
+import '../../../widgets/overlays/glass_menu.dart' show GlassMenu;
 import '../../../widgets/shared/adaptive_glass.dart';
 import '../../../widgets/shared/animated_glass_indicator.dart';
 import '../../../widgets/shared/inherited_liquid_glass.dart';
@@ -381,27 +382,40 @@ class BottomBarExtraBtn extends StatelessWidget {
             ? LiquidRoundedRectangle(borderRadius: config.size / 2)
             : const LiquidOval());
 
-    final button = GlassButton(
-      icon: config.icon,
-      onTap: config.onTap,
-      label: config.label,
-      width: config.size,
-      height: config.size,
-      quality: quality,
-      iconColor: iconColor,
-      useOwnLayer: !enableBlend, // When blending, share the parent's layer
-      shape: effectiveShape,
-      platformViewBackdrop: platformViewBackdrop,
-      stretch: platformViewBackdrop ? 0.0 : 0.5,
-      // The extra button is anchored inside the compound bar and does not
-      // animate its layout bounds at rest. Marking it stationary lets
-      // AdaptiveGlass retain the BackdropFilter blur in GlassQuality.minimal,
-      // so it matches the frosted appearance of the main tab bar surface.
-      // See: https://github.com/sdegenaar/liquid_glass_widgets/issues/203
-      isStationary: true,
-    );
+    Widget buildButton(VoidCallback onTap) {
+      return GlassButton(
+        icon: config.icon,
+        onTap: onTap,
+        label: config.label,
+        width: config.size,
+        height: config.size,
+        quality: quality,
+        iconColor: iconColor,
+        useOwnLayer: !enableBlend, // When blending, share the parent's layer
+        shape: effectiveShape,
+        platformViewBackdrop: platformViewBackdrop,
+        stretch: platformViewBackdrop ? 0.0 : 0.5,
+        // The extra button is anchored inside the compound bar and does not
+        // animate its layout bounds at rest. Marking it stationary lets
+        // AdaptiveGlass retain the BackdropFilter blur in GlassQuality.minimal,
+        // so it matches the frosted appearance of the main tab bar surface.
+        // See: https://github.com/sdegenaar/liquid_glass_widgets/issues/203
+        isStationary: true,
+        enabled: config.enabled,
+      );
+    }
 
-    return button;
+    if (config.isMenu) {
+      return GlassMenu(
+        menuAlignment: config.menuAlignment,
+        menuWidth: config.menuWidth,
+        autoAdjustToScreen: true,
+        items: config.menuItems!,
+        triggerBuilder: (context, toggleMenu) => buildButton(toggleMenu),
+      );
+    }
+
+    return buildButton(config.onTap);
   }
 }
 
@@ -430,6 +444,7 @@ class TabIndicator extends StatefulWidget {
     required this.visible,
     required this.indicatorColor,
     required this.quality,
+    this.backgroundQuality,
     required this.barHeight,
     required this.barBorderRadius,
     this.indicatorBorderRadius,
@@ -461,6 +476,7 @@ class TabIndicator extends StatefulWidget {
   final LiquidGlassSettings? indicatorSettings;
   final ValueChanged<int> onTabChanged;
   final GlassQuality quality;
+  final GlassQuality? backgroundQuality;
   final double barHeight;
   final double barBorderRadius;
   final double? indicatorBorderRadius;
@@ -641,7 +657,8 @@ class TabIndicatorState extends State<TabIndicator>
                               shape: _barShape,
                             ),
                             child: AdaptiveGlass.grouped(
-                              quality: widget.quality,
+                              quality:
+                                  widget.backgroundQuality ?? widget.quality,
                               platformViewBackdrop: widget.platformViewBackdrop,
                               shape: _barShape,
                               child: Container(
@@ -769,7 +786,7 @@ class TabIndicatorState extends State<TabIndicator>
                   Positioned.fill(
                     child: RepaintBoundary(
                       child: AdaptiveGlass.grouped(
-                        quality: widget.quality,
+                        quality: widget.backgroundQuality ?? widget.quality,
                         platformViewBackdrop: widget.platformViewBackdrop,
                         shape: _barShape,
                         child: const SizedBox.expand(),
@@ -860,7 +877,7 @@ class TabIndicatorState extends State<TabIndicator>
                   Positioned.fill(
                     child: RepaintBoundary(
                       child: AdaptiveGlass.grouped(
-                        quality: widget.quality,
+                        quality: widget.backgroundQuality ?? widget.quality,
                         platformViewBackdrop: widget.platformViewBackdrop,
                         shape: _barShape,
                         child: const SizedBox.expand(),

--- a/lib/src/widgets/surfaces/tab_bar_bottom_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_bottom_layout.dart
@@ -72,6 +72,7 @@ class TabBarBottomLayout extends StatefulWidget {
     this.glowSpreadRadius = 8,
     this.glowOpacity = 0.6,
     this.quality,
+    this.backgroundQuality,
     this.magnification = 1.15,
     this.innerBlur = 0.0,
     this.maskingQuality = MaskingQuality.high,
@@ -129,6 +130,7 @@ class TabBarBottomLayout extends StatefulWidget {
   final double glowSpreadRadius;
   final double glowOpacity;
   final GlassQuality? quality;
+  final GlassQuality? backgroundQuality;
   final double magnification;
   final double innerBlur;
   final MaskingQuality maskingQuality;
@@ -207,6 +209,11 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout>
     final effectiveQuality = GlassThemeHelpers.resolveQuality(
       context,
       widgetQuality: widget.quality,
+      fallback: GlassQuality.premium,
+    );
+    final effectiveBackgroundQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.backgroundQuality ?? widget.quality,
       fallback: GlassQuality.premium,
     );
 
@@ -337,6 +344,7 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout>
                       height: widget.barHeight,
                       child: TabIndicator(
                         quality: effectiveQuality,
+                        backgroundQuality: effectiveBackgroundQuality,
                         springDescription: widget.springDescription,
                         visible: widget.showIndicator,
                         tabIndex: selectedIndex,

--- a/lib/src/widgets/surfaces/tab_bar_bottom_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_bottom_layout.dart
@@ -317,7 +317,9 @@ class _TabBarBottomLayoutState extends State<TabBarBottomLayout>
                             height: widget.barHeight,
                             child: BottomBarExtraBtn(
                               config: resolvedExtraButton,
-                              quality: effectiveQuality,
+                              // Chrome-plane peer: matches the track background,
+                              // not the indicator pill (effectiveQuality).
+                              quality: effectiveBackgroundQuality,
                               iconColor: resolvedExtraButton.iconColor ??
                                   resolvedUnselectedIconColor,
                               enableBlend: widget.enableBlend,

--- a/lib/src/widgets/surfaces/tab_bar_searchable_internal.dart
+++ b/lib/src/widgets/surfaces/tab_bar_searchable_internal.dart
@@ -110,6 +110,7 @@ class SearchableTabIndicator extends StatefulWidget {
     required this.onTabChanged,
     required this.visible,
     required this.quality,
+    this.backgroundQuality,
     required this.barHeight,
     required this.barBorderRadius,
     this.indicatorBorderRadius,
@@ -150,6 +151,7 @@ class SearchableTabIndicator extends StatefulWidget {
   final double indicatorPinchStrength;
   final ValueChanged<int> onTabChanged;
   final GlassQuality quality;
+  final GlassQuality? backgroundQuality;
   final double barHeight;
   final double barBorderRadius;
   final double? indicatorBorderRadius;
@@ -256,7 +258,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
               behavior: HitTestBehavior.opaque,
               onTap: widget.onDismissSearch,
               child: AdaptiveGlass.grouped(
-                quality: widget.quality,
+                quality: widget.backgroundQuality ?? widget.quality,
                 platformViewBackdrop: widget.platformViewBackdrop,
                 shape: currentShape,
                 child: _wrapWithGlow(
@@ -361,7 +363,8 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                             height: widget.barHeight,
                             decoration: ShapeDecoration(shape: _barShape),
                             child: AdaptiveGlass.grouped(
-                              quality: widget.quality,
+                              quality:
+                                  widget.backgroundQuality ?? widget.quality,
                               platformViewBackdrop: widget.platformViewBackdrop,
                               shape: _barShape,
                               child: Container(
@@ -479,7 +482,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                   Positioned.fill(
                     child: RepaintBoundary(
                       child: AdaptiveGlass.grouped(
-                        quality: widget.quality,
+                        quality: widget.backgroundQuality ?? widget.quality,
                         platformViewBackdrop: widget.platformViewBackdrop,
                         shape: _barShape,
                         child: const SizedBox.expand(),
@@ -563,7 +566,7 @@ class SearchableTabIndicatorState extends State<SearchableTabIndicator>
                   Positioned.fill(
                     child: RepaintBoundary(
                       child: AdaptiveGlass.grouped(
-                        quality: widget.quality,
+                        quality: widget.backgroundQuality ?? widget.quality,
                         platformViewBackdrop: widget.platformViewBackdrop,
                         shape: _barShape,
                         child: const SizedBox.expand(),
@@ -1234,10 +1237,12 @@ class MinimizableTrailingPill extends StatelessWidget {
     this.interactionGlowOpacity = 1,
     this.platformViewBackdrop = false,
     this.iconColor,
+    this.label,
   });
 
   final Widget? icon;
   final VoidCallback? onTap;
+  final String? label;
   final double barBorderRadius;
   final GlassQuality quality;
   final bool enableBackgroundAnimation;
@@ -1310,13 +1315,18 @@ class MinimizableTrailingPill extends StatelessWidget {
             key: const ValueKey('pill-collapsed'),
             behavior: HitTestBehavior.opaque,
             onTap: onTap,
-            child: AdaptiveGlass.grouped(
-              shape: currentShape,
-              quality: quality,
-              platformViewBackdrop: platformViewBackdrop,
-              child: nativePress && nativePressHighlight
-                  ? PressAmbientLift(child: content)
-                  : _wrapWithGlow(child: content),
+            child: Semantics(
+              button: true,
+              label: label,
+              enabled: onTap != null,
+              child: AdaptiveGlass.grouped(
+                shape: currentShape,
+                quality: quality,
+                platformViewBackdrop: platformViewBackdrop,
+                child: nativePress && nativePressHighlight
+                    ? PressAmbientLift(child: content)
+                    : _wrapWithGlow(child: content),
+              ),
             ),
           ),
         );

--- a/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
@@ -23,6 +23,7 @@ import '../../../widgets/surfaces/shared/tab_bar_types.dart'
     show GlassTabPillAnchor, MaskingQuality;
 import '../../../widgets/surfaces/glass_tab_bar.dart'
     show GlassTab, GlassTabBarTrailingButton;
+import '../../../widgets/overlays/glass_menu.dart' show GlassMenu;
 import 'tab_bar_bottom_internal.dart'
     show
         BottomBarExtraBtn,
@@ -94,6 +95,7 @@ class TabBarSearchableLayout extends StatefulWidget {
     this.interactionGlowColor,
     this.interactionGlowRadius = 1.5,
     this.quality,
+    this.backgroundQuality,
     this.magnification = 1.15,
     this.innerBlur = 0.0,
     this.platformViewBackdrop = false,
@@ -184,6 +186,7 @@ class TabBarSearchableLayout extends StatefulWidget {
   final Color? interactionGlowColor;
   final double interactionGlowRadius;
   final GlassQuality? quality;
+  final GlassQuality? backgroundQuality;
   final double magnification;
   final double innerBlur;
   final bool platformViewBackdrop;
@@ -445,6 +448,11 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
       widgetQuality: widget.quality,
       fallback: GlassQuality.premium,
     );
+    final effectiveBackgroundQuality = GlassThemeHelpers.resolveQuality(
+      context,
+      widgetQuality: widget.backgroundQuality ?? widget.quality,
+      fallback: GlassQuality.premium,
+    );
 
     final resolvedGlowColors =
         GlassThemeData.of(context).glowColorsFor(context);
@@ -694,29 +702,55 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                           } else {
                             final renderedTrailing =
                                 widget.trailingButton ?? _lastTrailingButton;
-                            pillChild = MinimizableTrailingPill(
-                              icon: renderedTrailing?.icon,
-                              nativePressHighlight: nativePressHighlight,
-                              onTap: widget.trailingButton?.onTap,
-                              barBorderRadius: widget.barBorderRadius,
-                              quality: effectiveQuality,
-                              platformViewBackdrop: widget.platformViewBackdrop,
-                              enableBackgroundAnimation:
-                                  widget.interactionBehavior.hasScale,
-                              backgroundPressScale: widget.pressScale,
-                              iconColor: resolvedUnselectedIconColor,
-                              interactionGlowColor:
-                                  widget.interactionBehavior.hasGlow
-                                      ? effectiveInteractionGlowColor
-                                      : const Color(0x00000000),
-                              interactionGlowRadius:
-                                  widget.interactionGlowRadius,
-                              interactionGlowBlurRadius:
-                                  effectiveGlowBlurRadius,
-                              interactionGlowSpreadRadius:
-                                  effectiveGlowSpreadRadius,
-                              interactionGlowOpacity: effectiveGlowOpacity,
-                            );
+
+                            Widget buildTrailingPill({VoidCallback? onTap}) {
+                              return MinimizableTrailingPill(
+                                icon: renderedTrailing?.icon,
+                                nativePressHighlight: nativePressHighlight,
+                                onTap: onTap,
+                                label: renderedTrailing?.label,
+                                barBorderRadius: widget.barBorderRadius,
+                                quality: effectiveQuality,
+                                platformViewBackdrop:
+                                    widget.platformViewBackdrop,
+                                enableBackgroundAnimation:
+                                    widget.interactionBehavior.hasScale,
+                                backgroundPressScale: widget.pressScale,
+                                iconColor: resolvedUnselectedIconColor,
+                                interactionGlowColor:
+                                    widget.interactionBehavior.hasGlow
+                                        ? effectiveInteractionGlowColor
+                                        : const Color(0x00000000),
+                                interactionGlowRadius:
+                                    widget.interactionGlowRadius,
+                                interactionGlowBlurRadius:
+                                    effectiveGlowBlurRadius,
+                                interactionGlowSpreadRadius:
+                                    effectiveGlowSpreadRadius,
+                                interactionGlowOpacity: effectiveGlowOpacity,
+                              );
+                            }
+
+                            if (renderedTrailing?.isMenu == true) {
+                              pillChild = GlassMenu(
+                                menuAlignment: renderedTrailing!.menuAlignment,
+                                menuWidth: renderedTrailing.menuWidth,
+                                autoAdjustToScreen: true,
+                                items: renderedTrailing.menuItems!,
+                                triggerBuilder: (context, toggleMenu) =>
+                                    buildTrailingPill(
+                                  onTap: renderedTrailing.enabled
+                                      ? toggleMenu
+                                      : null,
+                                ),
+                              );
+                            } else {
+                              pillChild = buildTrailingPill(
+                                onTap: (renderedTrailing?.enabled == true)
+                                    ? widget.trailingButton?.onTap
+                                    : null,
+                              );
+                            }
                           }
 
                           return Positioned(
@@ -820,6 +854,7 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                             child: SearchableTabIndicator(
                               key: _indicatorKey,
                               quality: effectiveQuality,
+                              backgroundQuality: effectiveBackgroundQuality,
                               visible: widget.showIndicator && !searching,
                               tabIndex: widget.selectedIndex,
                               tabCount: widget.tabs.length,

--- a/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
+++ b/lib/src/widgets/surfaces/tab_bar_searchable_layout.dart
@@ -672,7 +672,9 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                               nativePressHighlight: nativePressHighlight,
                               isActive: searching,
                               barBorderRadius: widget.barBorderRadius,
-                              quality: effectiveQuality,
+                              // Chrome-plane peer: matches the track background,
+                              // not the indicator pill (effectiveQuality).
+                              quality: effectiveBackgroundQuality,
                               platformViewBackdrop: widget.platformViewBackdrop,
                               enableBackgroundAnimation:
                                   widget.interactionBehavior.hasScale,
@@ -710,7 +712,9 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                                 onTap: onTap,
                                 label: renderedTrailing?.label,
                                 barBorderRadius: widget.barBorderRadius,
-                                quality: effectiveQuality,
+                                // Chrome-plane peer: matches the track background,
+                                // not the indicator pill (effectiveQuality).
+                                quality: effectiveBackgroundQuality,
                                 platformViewBackdrop:
                                     widget.platformViewBackdrop,
                                 enableBackgroundAnimation:
@@ -807,7 +811,9 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                                     alignment: Alignment.center,
                                     child: BottomBarExtraBtn(
                                       config: widget.extraButton!,
-                                      quality: effectiveQuality,
+                                      // Chrome-plane peer: matches the track background,
+                                      // not the indicator pill (effectiveQuality).
+                                      quality: effectiveBackgroundQuality,
                                       iconColor:
                                           widget.extraButton!.iconColor ??
                                               resolvedUnselectedIconColor,
@@ -947,7 +953,9 @@ class _TabBarSearchableLayoutState extends State<TabBarSearchableLayout>
                             },
                             pillSize: animH,
                             barBorderRadius: widget.barBorderRadius,
-                            quality: effectiveQuality,
+                            // Chrome-plane peer: matches the track background,
+                            // not the indicator pill (effectiveQuality).
+                            quality: effectiveBackgroundQuality,
                             indicatorColor: widget.indicatorColor,
                             settings: widget.settings,
                             cancelButtonColor:

--- a/lib/utils/glass_morph_controller.dart
+++ b/lib/utils/glass_morph_controller.dart
@@ -225,6 +225,16 @@ class GlassMorphController extends ChangeNotifier {
     _runSpring(0.0, velocityHint: LiquidMorphPhysics.closeVelocityHint);
   }
 
+  /// Immediately resets the controller to its resting closed state (value = 0.0,
+  /// velocity = 0.0) without running an animation.
+  void reset() {
+    _animationController.stop();
+    _isClosing = false;
+    _hasHandedOff = false;
+    _animationController.value = 0.0;
+    notifyListeners();
+  }
+
   // ─── Physics computation ──────────────────────────────────────────────────
 
   /// Computes the current [LiquidMorphState] for the given layout geometry.

--- a/lib/widgets/overlays/glass_menu.dart
+++ b/lib/widgets/overlays/glass_menu.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 import 'dart:ui';
 import 'package:flutter/cupertino.dart';
 import '../../utils/glass_morph_controller.dart';
+import '../../src/renderer/internal/glass_materialize_scope.dart';
 import '../../src/renderer/liquid_glass_renderer.dart';
 
 import '../../constants/glass_defaults.dart';

--- a/lib/widgets/overlays/glass_popover.dart
+++ b/lib/widgets/overlays/glass_popover.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 import 'dart:ui';
 import 'package:flutter/cupertino.dart';
 import '../../utils/glass_morph_controller.dart';
+import '../../src/renderer/internal/glass_materialize_scope.dart';
 import '../../src/renderer/liquid_glass_renderer.dart';
 
 import '../../constants/glass_defaults.dart';

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -109,8 +109,12 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     widget.controller?._attach(this);
   }
 
+  ModalRoute<dynamic>? _route;
+
   @override
   void dispose() {
+    _removeRouteListeners();
+    _route = null;
     widget.controller?._detach(this);
     _morphController.dispose();
     _scrollController.dispose();
@@ -128,6 +132,81 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     _morphController.setDisableAnimations(
       MediaQuery.of(context).disableAnimations,
     );
+    _updateRouteListener();
+  }
+
+  void _updateRouteListener() {
+    final currentRoute = ModalRoute.of(context);
+    if (_route != currentRoute) {
+      _removeRouteListeners();
+      _route = currentRoute;
+      _addRouteListeners();
+    }
+  }
+
+  void _addRouteListeners() {
+    final route = _route;
+    if (route == null) return;
+    route.secondaryAnimation?.addListener(_handleSecondaryAnimation);
+    route.secondaryAnimation?.addStatusListener(_handleSecondaryAnimationStatus);
+    route.animation?.addStatusListener(_handlePrimaryAnimationStatus);
+  }
+
+  void _removeRouteListeners() {
+    final route = _route;
+    if (route == null) return;
+    route.secondaryAnimation?.removeListener(_handleSecondaryAnimation);
+    route.secondaryAnimation?.removeStatusListener(_handleSecondaryAnimationStatus);
+    route.animation?.removeStatusListener(_handlePrimaryAnimationStatus);
+  }
+
+  void _handleSecondaryAnimation() {
+    if (!_overlayController.isShowing) return;
+    final anim = _route?.secondaryAnimation;
+    if (anim == null) return;
+    if (anim.status == AnimationStatus.forward ||
+        anim.status == AnimationStatus.completed ||
+        (anim.value > 0.0 && anim.status != AnimationStatus.reverse)) {
+      _dismissImmediately();
+    }
+  }
+
+  void _handleSecondaryAnimationStatus(AnimationStatus status) {
+    if (!_overlayController.isShowing) return;
+    if (status == AnimationStatus.forward ||
+        status == AnimationStatus.completed) {
+      _dismissImmediately();
+    }
+  }
+
+  void _handlePrimaryAnimationStatus(AnimationStatus status) {
+    if (!_overlayController.isShowing) return;
+    if (status == AnimationStatus.reverse) {
+      _dismissImmediately();
+    }
+  }
+
+  void _dismissImmediately() {
+    if (!_overlayController.isShowing && _morphController.value == 0.0) {
+      return;
+    }
+    final wasClosing = _morphController.isClosing;
+    _overlayController.hide();
+    _morphController.reset();
+    _horizontalOffset = 0.0;
+    _verticalOffset = 0.0;
+    _hoveredIndex = null;
+    _hoveredIndexNotifier.value = null;
+    _isDragging = false;
+    _isDraggingNotifier.value = false;
+    _hasStretched = false;
+    _followOffset = Offset.zero;
+    if (!wasClosing) {
+      widget.onClose?.call();
+    }
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   @override
@@ -330,6 +409,7 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
   }
 
   void _closeMenu() {
+    if (!_overlayController.isShowing) return;
     setState(() {
       _hoveredIndex = null;
       _isDragging = false;

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -147,7 +147,6 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
   void _addRouteListeners() {
     final route = _route;
     if (route == null) return;
-    route.secondaryAnimation?.addListener(_handleSecondaryAnimation);
     route.secondaryAnimation
         ?.addStatusListener(_handleSecondaryAnimationStatus);
     route.animation?.addStatusListener(_handlePrimaryAnimationStatus);
@@ -156,27 +155,14 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
   void _removeRouteListeners() {
     final route = _route;
     if (route == null) return;
-    route.secondaryAnimation?.removeListener(_handleSecondaryAnimation);
     route.secondaryAnimation
         ?.removeStatusListener(_handleSecondaryAnimationStatus);
     route.animation?.removeStatusListener(_handlePrimaryAnimationStatus);
   }
 
-  void _handleSecondaryAnimation() {
-    if (!_overlayController.isShowing) return;
-    final anim = _route?.secondaryAnimation;
-    if (anim == null) return;
-    if (anim.status == AnimationStatus.forward ||
-        anim.status == AnimationStatus.completed ||
-        (anim.value > 0.0 && anim.status != AnimationStatus.reverse)) {
-      _dismissImmediately();
-    }
-  }
-
   void _handleSecondaryAnimationStatus(AnimationStatus status) {
     if (!_overlayController.isShowing) return;
-    if (status == AnimationStatus.forward ||
-        status == AnimationStatus.completed) {
+    if (status == AnimationStatus.forward) {
       _dismissImmediately();
     }
   }

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -148,7 +148,8 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     final route = _route;
     if (route == null) return;
     route.secondaryAnimation?.addListener(_handleSecondaryAnimation);
-    route.secondaryAnimation?.addStatusListener(_handleSecondaryAnimationStatus);
+    route.secondaryAnimation
+        ?.addStatusListener(_handleSecondaryAnimationStatus);
     route.animation?.addStatusListener(_handlePrimaryAnimationStatus);
   }
 
@@ -156,7 +157,8 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
     final route = _route;
     if (route == null) return;
     route.secondaryAnimation?.removeListener(_handleSecondaryAnimation);
-    route.secondaryAnimation?.removeStatusListener(_handleSecondaryAnimationStatus);
+    route.secondaryAnimation
+        ?.removeStatusListener(_handleSecondaryAnimationStatus);
     route.animation?.removeStatusListener(_handlePrimaryAnimationStatus);
   }
 
@@ -219,11 +221,6 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
         // Block trigger taps while menu is significantly open.
         final isMenuBlocking = _overlayController.isShowing && rawValue > 0.8;
 
-        // Early handoff during close:
-        // When closing and the liquid morph is almost finished, we latch the handoff.
-        // We instantly hide the empty glass overlay and reveal the REAL trigger.
-        // The latch ensures that even if the underdamped spring bounces back up
-        // past 0.15, we don't hide the icon again!
         final isHandoff =
             _morphController.isClosing && _morphController.hasHandedOff;
         final triggerOpacity =
@@ -247,6 +244,13 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
         final double pushDy =
             isHandoff ? (finalDy + _verticalOffset) * rawValue : 0.0;
 
+        final Widget triggerChild = widget.triggerBuilder != null
+            ? widget.triggerBuilder!(context, _toggleMenu)
+            : GestureDetector(
+                onTap: _toggleMenu,
+                child: widget.trigger,
+              );
+
         return Stack(
           clipBehavior: Clip.none,
           children: [
@@ -255,14 +259,14 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
               offset: Offset(pushDx, pushDy),
               child: Opacity(
                 opacity: triggerOpacity,
-                child: IgnorePointer(
-                  ignoring: isMenuBlocking,
-                  child: widget.triggerBuilder != null
-                      ? widget.triggerBuilder!(context, _toggleMenu)
-                      : GestureDetector(
-                          onTap: _toggleMenu,
-                          child: widget.trigger,
-                        ),
+                child: GlassMaterializeScope(
+                  glassProgress: triggerOpacity,
+                  contentOpacity: triggerOpacity,
+                  contentSigma: 0.0,
+                  child: IgnorePointer(
+                    ignoring: isMenuBlocking,
+                    child: triggerChild,
+                  ),
                 ),
               ),
             ),

--- a/lib/widgets/overlays/shared/glass_popover_internal.dart
+++ b/lib/widgets/overlays/shared/glass_popover_internal.dart
@@ -143,8 +143,12 @@ class _GlassPopoverState extends State<GlassPopover>
     });
   }
 
+  ModalRoute<dynamic>? _route;
+
   @override
   void dispose() {
+    _removeRouteListeners();
+    _route = null;
     _blurRamp.dispose();
     _morphController.dispose();
     super.dispose();
@@ -157,6 +161,80 @@ class _GlassPopoverState extends State<GlassPopover>
     _morphController.setDisableAnimations(
       MediaQuery.of(context).disableAnimations,
     );
+    _updateRouteListener();
+  }
+
+  void _updateRouteListener() {
+    final currentRoute = ModalRoute.of(context);
+    if (_route != currentRoute) {
+      _removeRouteListeners();
+      _route = currentRoute;
+      _addRouteListeners();
+    }
+  }
+
+  void _addRouteListeners() {
+    final route = _route;
+    if (route == null) return;
+    route.secondaryAnimation?.addListener(_handleSecondaryAnimation);
+    route.secondaryAnimation?.addStatusListener(_handleSecondaryAnimationStatus);
+    route.animation?.addStatusListener(_handlePrimaryAnimationStatus);
+  }
+
+  void _removeRouteListeners() {
+    final route = _route;
+    if (route == null) return;
+    route.secondaryAnimation?.removeListener(_handleSecondaryAnimation);
+    route.secondaryAnimation?.removeStatusListener(_handleSecondaryAnimationStatus);
+    route.animation?.removeStatusListener(_handlePrimaryAnimationStatus);
+  }
+
+  void _handleSecondaryAnimation() {
+    if (!_overlayController.isShowing) return;
+    final anim = _route?.secondaryAnimation;
+    if (anim == null) return;
+    if (anim.status == AnimationStatus.forward ||
+        anim.status == AnimationStatus.completed ||
+        (anim.value > 0.0 && anim.status != AnimationStatus.reverse)) {
+      _dismissImmediately();
+    }
+  }
+
+  void _handleSecondaryAnimationStatus(AnimationStatus status) {
+    if (!_overlayController.isShowing) return;
+    if (status == AnimationStatus.forward ||
+        status == AnimationStatus.completed) {
+      _dismissImmediately();
+    }
+  }
+
+  void _handlePrimaryAnimationStatus(AnimationStatus status) {
+    if (!_overlayController.isShowing) return;
+    if (status == AnimationStatus.reverse) {
+      _dismissImmediately();
+    }
+  }
+
+  void _dismissImmediately() {
+    if (!_overlayController.isShowing && _morphController.value == 0.0) {
+      return;
+    }
+    final wasClosing = _morphController.isClosing;
+    _overlayController.hide();
+    _morphController.reset();
+    _blurRamp.stop();
+    _blurRamp.value = 0.0;
+    _horizontalOffset = 0.0;
+    _verticalOffset = 0.0;
+    _measuredContentHeight = null;
+    _contentMeasured = false;
+    _cachedContent = null;
+    if (!wasClosing) {
+      widget.onClose?.call();
+    }
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   @override
@@ -354,7 +432,7 @@ class _GlassPopoverState extends State<GlassPopover>
   }
 
   void _closePopover() {
-    if (!mounted) return;
+    if (!mounted || !_overlayController.isShowing) return;
     // Freeze the blur where it is for the collapse. Ramping it back down here
     // would race the morph and read as the blur "popping off" while the blob is
     // still visibly shrinking; holding it keeps the close visually coherent.

--- a/lib/widgets/overlays/shared/glass_popover_internal.dart
+++ b/lib/widgets/overlays/shared/glass_popover_internal.dart
@@ -176,7 +176,6 @@ class _GlassPopoverState extends State<GlassPopover>
   void _addRouteListeners() {
     final route = _route;
     if (route == null) return;
-    route.secondaryAnimation?.addListener(_handleSecondaryAnimation);
     route.secondaryAnimation
         ?.addStatusListener(_handleSecondaryAnimationStatus);
     route.animation?.addStatusListener(_handlePrimaryAnimationStatus);
@@ -185,27 +184,14 @@ class _GlassPopoverState extends State<GlassPopover>
   void _removeRouteListeners() {
     final route = _route;
     if (route == null) return;
-    route.secondaryAnimation?.removeListener(_handleSecondaryAnimation);
     route.secondaryAnimation
         ?.removeStatusListener(_handleSecondaryAnimationStatus);
     route.animation?.removeStatusListener(_handlePrimaryAnimationStatus);
   }
 
-  void _handleSecondaryAnimation() {
-    if (!_overlayController.isShowing) return;
-    final anim = _route?.secondaryAnimation;
-    if (anim == null) return;
-    if (anim.status == AnimationStatus.forward ||
-        anim.status == AnimationStatus.completed ||
-        (anim.value > 0.0 && anim.status != AnimationStatus.reverse)) {
-      _dismissImmediately();
-    }
-  }
-
   void _handleSecondaryAnimationStatus(AnimationStatus status) {
     if (!_overlayController.isShowing) return;
-    if (status == AnimationStatus.forward ||
-        status == AnimationStatus.completed) {
+    if (status == AnimationStatus.forward) {
       _dismissImmediately();
     }
   }

--- a/lib/widgets/overlays/shared/glass_popover_internal.dart
+++ b/lib/widgets/overlays/shared/glass_popover_internal.dart
@@ -177,7 +177,8 @@ class _GlassPopoverState extends State<GlassPopover>
     final route = _route;
     if (route == null) return;
     route.secondaryAnimation?.addListener(_handleSecondaryAnimation);
-    route.secondaryAnimation?.addStatusListener(_handleSecondaryAnimationStatus);
+    route.secondaryAnimation
+        ?.addStatusListener(_handleSecondaryAnimationStatus);
     route.animation?.addStatusListener(_handlePrimaryAnimationStatus);
   }
 
@@ -185,7 +186,8 @@ class _GlassPopoverState extends State<GlassPopover>
     final route = _route;
     if (route == null) return;
     route.secondaryAnimation?.removeListener(_handleSecondaryAnimation);
-    route.secondaryAnimation?.removeStatusListener(_handleSecondaryAnimationStatus);
+    route.secondaryAnimation
+        ?.removeStatusListener(_handleSecondaryAnimationStatus);
     route.animation?.removeStatusListener(_handlePrimaryAnimationStatus);
   }
 
@@ -337,18 +339,28 @@ class _GlassPopoverState extends State<GlassPopover>
                     offset: Offset(pushDx, pushDy),
                     child: Opacity(
                       opacity: triggerOpacity,
-                      child: IgnorePointer(
-                        ignoring: isPopoverBlocking,
-                        child: child, // triggerContent
+                      child: GlassMaterializeScope(
+                        glassProgress: triggerOpacity,
+                        contentOpacity: triggerOpacity,
+                        contentSigma: 0.0,
+                        child: IgnorePointer(
+                          ignoring: isPopoverBlocking,
+                          child: child, // triggerContent
+                        ),
                       ),
                     ),
                   )
                 : triggerOpacity < 1.0
                     ? Opacity(
                         opacity: triggerOpacity,
-                        child: IgnorePointer(
-                          ignoring: isPopoverBlocking,
-                          child: child,
+                        child: GlassMaterializeScope(
+                          glassProgress: triggerOpacity,
+                          contentOpacity: triggerOpacity,
+                          contentSigma: 0.0,
+                          child: IgnorePointer(
+                            ignoring: isPopoverBlocking,
+                            child: child,
+                          ),
                         ),
                       )
                     : isPopoverBlocking

--- a/lib/widgets/shared/adaptive_glass.dart
+++ b/lib/widgets/shared/adaptive_glass.dart
@@ -332,6 +332,7 @@ class AdaptiveGlass extends StatelessWidget {
               // surfaces such as bars.
               whitenStrength: normalizedSettings.whitenStrength,
               whitenGated: normalizedSettings.whitenGated,
+              bodyMode: normalizedSettings.bodyMode,
             )
           : normalizedSettings;
 
@@ -745,9 +746,11 @@ class _FrostedFallback extends StatelessWidget {
         // Accessibility: boost opacity so content remains legible
         // even when Reduce Transparency removes blur on older hardware.
         ? (tint.a * 0.5 + 0.40).clamp(0.40, 0.80)
-        // Minimal (developer choice): honour the specified glass color alpha,
-        // allowing it to go up to 1.0 for solid color modes.
-        : tint.a.clamp(0.05, 1.0);
+        // Minimal (developer choice): honour the specified glass color alpha.
+        // In clear mode (GlassBodyMode.clear), allow exact alpha down to 0.0 without clamping.
+        : settings.bodyMode == GlassBodyMode.clear
+            ? tint.a.clamp(0.0, 1.0)
+            : tint.a.clamp(0.05, 1.0);
     final frostedColor = tint.withValues(alpha: frostedAlpha);
 
     final sat = settings.effectiveSaturation;

--- a/lib/widgets/shared/lightweight_liquid_glass.dart
+++ b/lib/widgets/shared/lightweight_liquid_glass.dart
@@ -1072,5 +1072,9 @@ class _RenderLightweightGlass extends RenderProxyBox
     // Matches the uniform wired in liquid_glass_final_render.frag via uEdgeConfig.y.
     // Default 1.0 = calibrated iOS 26 baseline (0.10 * adaptiveStrength in shader).
     shader.setFloat(index++, _settings.fresnelStrength.clamp(0.0, 4.0));
+
+    // 34: uBodyMode — 0.0 = adaptive, 1.0 = clear.
+    shader.setFloat(
+        index++, _settings.bodyMode == GlassBodyMode.clear ? 1.0 : 0.0);
   }
 }

--- a/lib/widgets/surfaces/glass_app_bar.dart
+++ b/lib/widgets/surfaces/glass_app_bar.dart
@@ -578,15 +578,18 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
       );
     } else {
       // Leading-aligned: title occupies the space between the two side widgets
-      // with an 8 px logical-start gap.
+      // with an 8 px gap when adjacent to a leading or action widget.
       //
-      // Logical-start side = leadingWidth (LTR) or actionsWidth (RTL).
-      // Logical-end side   = actionsWidth (LTR) or leadingWidth (RTL).
-      final double startOccupied = _isLTR ? leadingWidth : actionsWidth;
-      final double endOccupied = _isLTR ? actionsWidth : leadingWidth;
+      // In both LTR and RTL:
+      //   - leading is positioned at the logical-start edge (0 in LTR, width - leadingWidth in RTL).
+      //   - actions is positioned at the logical-end edge (width - actionsWidth in LTR, 0 in RTL).
+      final double startOccupied = leadingWidth;
+      final double endOccupied = actionsWidth;
+      final double startGap = startOccupied > 0 ? _titleGap : 0.0;
+      final double endGap = endOccupied > 0 ? _titleGap : 0.0;
       final double maxWidth = math.max(
         0.0,
-        size.width - startOccupied - _titleGap - endOccupied,
+        size.width - startOccupied - startGap - endOccupied - endGap,
       );
 
       final Size ts = layoutChild(
@@ -596,8 +599,8 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
 
       // Pin to logical-start edge (left in LTR, right in RTL).
       final double titleX = _isLTR
-          ? startOccupied + _titleGap
-          : size.width - startOccupied - _titleGap - ts.width;
+          ? startOccupied + startGap
+          : size.width - startOccupied - startGap - ts.width;
 
       positionChild(
         _ToolbarSlot.title,

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -6,6 +6,7 @@ import '../../src/renderer/liquid_glass_renderer.dart';
 
 import '../../src/types/glass_interaction_behavior.dart';
 import '../../types/glass_quality.dart';
+import '../overlays/glass_menu.dart' show GlassMenuAlignment;
 import '../shared/inherited_liquid_glass.dart';
 import 'shared/glass_search_bar_config.dart';
 import 'shared/tab_bar_accessory_placement.dart';
@@ -218,6 +219,7 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
     double glowSpreadRadius = 8,
     double glowOpacity = 0.6,
     GlassQuality? quality,
+    GlassQuality? backgroundQuality,
     double magnification = 1.15,
     double innerBlur = 0.0,
     MaskingQuality maskingQuality = MaskingQuality.high,
@@ -275,6 +277,7 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
           glowSpreadRadius: glowSpreadRadius,
           glowOpacity: glowOpacity,
           quality: quality,
+          backgroundQuality: backgroundQuality,
           magnification: magnification,
           innerBlur: innerBlur,
           maskingQuality: maskingQuality,
@@ -356,6 +359,7 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
     double? tabWidth,
     LiquidGlassSettings? settings,
     GlassQuality? quality,
+    GlassQuality? backgroundQuality,
     MaskingQuality maskingQuality = MaskingQuality.high,
     GlobalKey? backgroundKey,
     double iconLabelSpacing = 4,
@@ -411,6 +415,7 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
           tabWidth: tabWidth,
           settings: settings,
           quality: quality,
+          backgroundQuality: backgroundQuality,
           maskingQuality: maskingQuality,
           backgroundKey: backgroundKey,
           iconLabelSpacing: iconLabelSpacing,
@@ -483,6 +488,7 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
     Color? interactionGlowColor,
     double interactionGlowRadius = 1.5,
     GlassQuality? quality,
+    GlassQuality? backgroundQuality,
     double magnification = 1.15,
     double innerBlur = 0.0,
     bool platformViewBackdrop = false,
@@ -550,6 +556,7 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
           interactionGlowColor: interactionGlowColor,
           interactionGlowRadius: interactionGlowRadius,
           quality: quality,
+          backgroundQuality: backgroundQuality,
           magnification: magnification,
           innerBlur: innerBlur,
           platformViewBackdrop: platformViewBackdrop,
@@ -641,6 +648,7 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
     GlassTabBarMinimizeController? minimizeController,
     VoidCallback? onMinimizedTabTap,
     GlassTabBarTrailingButton? trailingButton,
+    GlassTabBarExtraButton? extraButton,
     Widget? bottomAccessory,
     GlassTabBarAccessoryPlacement? bottomAccessoryPlacement,
     bool bottomAccessoryEnabled = true,
@@ -680,6 +688,7 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
     Color? interactionGlowColor,
     double interactionGlowRadius = 1.5,
     GlassQuality? quality,
+    GlassQuality? backgroundQuality,
     double magnification = 1.15,
     double innerBlur = 0.0,
     bool platformViewBackdrop = false,
@@ -708,6 +717,7 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
           isSearchActive: minimized,
           onMinimizedTabTap: onMinimizedTabTap,
           trailingButton: trailingButton,
+          extraButton: extraButton,
           minimizeController: minimizeController,
           bottomAccessoryPlacement: bottomAccessoryPlacement,
           bottomAccessory: bottomAccessory,
@@ -747,6 +757,7 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
           interactionGlowColor: interactionGlowColor,
           interactionGlowRadius: interactionGlowRadius,
           quality: quality,
+          backgroundQuality: backgroundQuality,
           magnification: magnification,
           innerBlur: innerBlur,
           platformViewBackdrop: platformViewBackdrop,
@@ -786,6 +797,7 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
       this.iconSize = 24.0,
       this.settings,
       this.quality,
+      this.backgroundQuality,
       this.indicatorSettings,
       this.indicatorPinchStrength = 0.4,
       this.indicatorExpansion =
@@ -905,6 +917,18 @@ class GlassTabBar extends StatefulWidget with GlassDynamicPreferredSize {
   /// If null, inherits from parent [InheritedLiquidGlass] or defaults to
   /// [GlassQuality.standard].
   final GlassQuality? quality;
+
+  /// Rendering quality for the tab bar track/background container.
+  ///
+  /// Matches UIKit's separation of `UITabBarAppearance.backgroundEffect` from
+  /// the system selection indicator pill:
+  /// - When null (default), inherits from [quality] (backward-compatible).
+  /// - When set, controls the quality tier of the track surface independently of
+  ///   the indicator pill. For example, setting [backgroundQuality] to
+  ///   [GlassQuality.minimal] or [GlassQuality.standard] while keeping [quality]
+  ///   at [GlassQuality.premium] delivers full Impeller chromatic refraction and
+  ///   jelly morphing on the indicator while saving GPU overhead on the static track.
+  final GlassQuality? backgroundQuality;
 
   /// Controls indicator clipping quality.
   ///
@@ -1290,6 +1314,7 @@ class _GlassTabBarState extends State<GlassTabBar> {
       glowSpreadRadius: widget.glowSpreadRadius,
       glowOpacity: widget.glowOpacity,
       quality: widget.quality,
+      backgroundQuality: widget.backgroundQuality,
       magnification: widget.magnification,
       innerBlur: widget.innerBlur,
       maskingQuality: widget.maskingQuality,
@@ -1348,6 +1373,7 @@ class _GlassTabBarState extends State<GlassTabBar> {
       glowSpreadRadius: widget.glowSpreadRadius,
       glowOpacity: widget.glowOpacity,
       quality: widget.quality,
+      backgroundQuality: widget.backgroundQuality,
       magnification: widget.magnification,
       innerBlur: widget.innerBlur,
       maskingQuality: widget.maskingQuality,
@@ -1438,6 +1464,7 @@ class _GlassTabBarState extends State<GlassTabBar> {
       interactionGlowColor: widget.interactionGlowColor,
       interactionGlowRadius: widget.interactionGlowRadius,
       quality: widget.quality,
+      backgroundQuality: widget.backgroundQuality,
       magnification: widget.magnification,
       innerBlur: widget.innerBlur,
       platformViewBackdrop: widget.platformViewBackdrop,
@@ -1477,17 +1504,62 @@ class _GlassTabBarState extends State<GlassTabBar> {
 /// states; pass it conditionally (see [GlassTabBar.minimizable]) for
 /// app-defined policies such as a button that exists only while minimized.
 class GlassTabBarTrailingButton {
+  static void _noOp() {}
+
   /// Creates the trailing button.
   const GlassTabBarTrailingButton({
     required this.icon,
     required this.onTap,
-  });
+    this.label,
+    this.enabled = true,
+  })  : menuItems = null,
+        menuAlignment = null,
+        menuWidth = 200;
+
+  /// Opens a [GlassMenu] pull-down when the trailing pill is tapped.
+  ///
+  /// The whole pill morphs into the menu — the same liquid-spring behavior
+  /// as [GlassButtonGroupItem.menu] and [GlassBarItem.menu]. Equivalent to
+  /// a `UIBarButtonItem(image:menu:)` placed in the tab bar's trailing slot.
+  ///
+  /// [menuItems] accepts [GlassMenuItem] and [GlassMenuDivider] widgets —
+  /// the same contract as [GlassMenu.items].
+  ///
+  /// [menuAlignment] defaults to auto-detection, which for a bottom-of-screen
+  /// button always expands upward — pass [GlassMenuAlignment.topLeft] or
+  /// [GlassMenuAlignment.topRight] to pin the direction explicitly.
+  const GlassTabBarTrailingButton.menu({
+    required this.icon,
+    required List<Widget> this.menuItems,
+    this.label,
+    this.enabled = true,
+    this.menuAlignment,
+    this.menuWidth = 200,
+  })  : onTap = _noOp;
 
   /// The glyph centered on the pill.
   final Widget icon;
 
   /// Called when the pill is tapped.
   final VoidCallback onTap;
+
+  /// Optional accessibility label for the button.
+  final String? label;
+
+  /// Whether the button is interactive. Defaults to true.
+  final bool enabled;
+
+  /// When non-null, tapping this button opens a [GlassMenu] pull-down.
+  final List<Widget>? menuItems;
+
+  /// Controls where the menu expands relative to the trigger button.
+  final GlassMenuAlignment? menuAlignment;
+
+  /// Width of the expanded menu panel in logical pixels. Defaults to 200.
+  final double menuWidth;
+
+  /// Whether this button opens a menu rather than firing a tap callback.
+  bool get isMenu => menuItems != null;
 }
 
 // =============================================================================

--- a/lib/widgets/surfaces/glass_tab_bar.dart
+++ b/lib/widgets/surfaces/glass_tab_bar.dart
@@ -1535,7 +1535,7 @@ class GlassTabBarTrailingButton {
     this.enabled = true,
     this.menuAlignment,
     this.menuWidth = 200,
-  })  : onTap = _noOp;
+  }) : onTap = _noOp;
 
   /// The glyph centered on the pill.
   final Widget icon;

--- a/lib/widgets/surfaces/shared/tab_bar_extra_button.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_extra_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../../interactive/glass_button.dart';
+import '../../overlays/glass_menu.dart' show GlassMenuAlignment;
 
 // =============================================================================
 // Extra Button Configuration
@@ -43,6 +44,8 @@ enum GlassExtraButtonPlacement {
 /// The extra button is rendered as a [GlassButton] and typically used for
 /// primary actions like creating new content.
 class GlassTabBarExtraButton {
+  static void _noOp() {}
+
   /// Creates an extra button configuration.
   const GlassTabBarExtraButton({
     required this.icon,
@@ -53,7 +56,35 @@ class GlassTabBarExtraButton {
     this.placement = GlassExtraButtonPlacement.right,
     this.position = GlassExtraButtonPosition.beforeSearch,
     this.collapseOnSearchFocus = true,
-  });
+    this.enabled = true,
+  })  : menuItems = null,
+        menuAlignment = null,
+        menuWidth = 200;
+
+  /// Opens a [GlassMenu] pull-down when the extra button is tapped.
+  ///
+  /// The button morphs into the menu — the same liquid-spring behavior
+  /// as [GlassButtonGroupItem.menu] and [GlassBarItem.menu]. Equivalent to
+  /// a `UIBarButtonItem(image:menu:)` placed in a toolbar or tab bar.
+  ///
+  /// [menuItems] accepts [GlassMenuItem] and [GlassMenuDivider] widgets —
+  /// the same contract as [GlassMenu.items].
+  ///
+  /// [menuAlignment] defaults to auto-detection, which for a bottom-of-screen
+  /// button always expands upward.
+  const GlassTabBarExtraButton.menu({
+    required this.icon,
+    required List<Widget> this.menuItems,
+    required this.label,
+    this.iconColor,
+    this.size = 64,
+    this.placement = GlassExtraButtonPlacement.right,
+    this.position = GlassExtraButtonPosition.beforeSearch,
+    this.collapseOnSearchFocus = true,
+    this.enabled = true,
+    this.menuAlignment,
+    this.menuWidth = 200,
+  })  : onTap = _noOp;
 
   /// Icon widget displayed in the button.
   final Widget icon;
@@ -104,4 +135,30 @@ class GlassTabBarExtraButton {
   /// the search input. Use this for buttons with contextual relevance during
   /// active search (e.g. a "Filter" action that applies to search results).
   final bool collapseOnSearchFocus;
+
+  /// Whether the button is interactive.
+  ///
+  /// When false, the button does not respond to taps. Defaults to true.
+  final bool enabled;
+
+  /// When non-null, tapping this button opens a [GlassMenu] pull-down.
+  ///
+  /// Accepts [GlassMenuItem] and [GlassMenuDivider] widgets. Set via
+  /// [GlassTabBarExtraButton.menu].
+  final List<Widget>? menuItems;
+
+  /// Controls where the menu expands relative to the trigger button.
+  ///
+  /// Defaults to auto-detection (upward for bottom-bar placement). Set via
+  /// [GlassTabBarExtraButton.menu].
+  final GlassMenuAlignment? menuAlignment;
+
+  /// Width of the expanded menu panel in logical pixels.
+  ///
+  /// Defaults to 200. Set via [GlassTabBarExtraButton.menu].
+  final double menuWidth;
+
+  /// Whether this button opens a menu rather than firing a tap callback.
+  bool get isMenu => menuItems != null;
 }
+

--- a/lib/widgets/surfaces/shared/tab_bar_extra_button.dart
+++ b/lib/widgets/surfaces/shared/tab_bar_extra_button.dart
@@ -84,7 +84,7 @@ class GlassTabBarExtraButton {
     this.enabled = true,
     this.menuAlignment,
     this.menuWidth = 200,
-  })  : onTap = _noOp;
+  }) : onTap = _noOp;
 
   /// Icon widget displayed in the button.
   final Widget icon;
@@ -161,4 +161,3 @@ class GlassTabBarExtraButton {
   /// Whether this button opens a menu rather than firing a tap callback.
   bool get isMenu => menuItems != null;
 }
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: liquid_glass_widgets
 description: "iOS 26-style liquid glass widgets for Flutter. Built on a custom fragment shader for real blur, liquid interactions, specular highlights, and chromatic aberration."
-version: 1.3.1
+version: 1.4.0
 
 homepage: https://github.com/sdegenaar/liquid_glass_widgets
 repository: https://github.com/sdegenaar/liquid_glass_widgets

--- a/shaders/lightweight_glass.frag
+++ b/shaders/lightweight_glass.frag
@@ -35,6 +35,9 @@ uniform float uEdgeAbsorption;
 // 33: uFresnelStrength — scales the grazing-angle Fresnel rim brightening [0..∞].
 // Default 1.0 = calibrated iOS 26 baseline. 0.0 = no rim highlight.
 uniform float uFresnelStrength;
+// 34: uBodyMode — 0.0 = adaptive (default, iOS 26 Glass.regular), 1.0 = clear (iOS 26 Glass.clear).
+// In clear mode, luminance normalization is bypassed for direct alpha compositing.
+uniform float uBodyMode;
 
 uniform sampler2D uBackground; // The captured background texture
 // Slot 22 (uData5.z): specular sharpness level — passed as float 0.0/1.0/2.0, cast to int.
@@ -434,8 +437,15 @@ void main() {
       float ambientDarken = clamp((uAmbientStrength * 0.25 + 0.08) * (1.0 + densityFactor * 0.5) + bottomDarken, 0.0, 0.8);
       vec3 darkenedBg = saturatedBg * (1.0 - ambientDarken);
 
-      // PATH A body: use luminosity-preserving glass tint (applyGlassColorLW).
-      vec3 bodyColor = applyGlassColorLW(darkenedBg, uGlassColor);
+      // PATH A body: use luminosity-preserving glass tint (applyGlassColorLW) in adaptive mode.
+      // In clear mode (uBodyMode > 0.5, iOS 26 Glass.clear), bypass luminosity normalization
+      // and directly alpha composite the glass color over the background.
+      vec3 bodyColor;
+      if (uBodyMode > 0.5) {
+        bodyColor = mix(saturatedBg, uGlassColor.rgb, uGlassColor.a);
+      } else {
+        bodyColor = applyGlassColorLW(darkenedBg, uGlassColor);
+      }
 
       // Adaptive rim color: brighten the background at the edge (Premium's getHighlightColor).
       vec3 adaptiveRimColor = mix(bgRgb, vec3(1.0), 0.7);
@@ -464,22 +474,25 @@ void main() {
     // PATH B: All Standard widgets use this path.
     // Flutter SrcOver composites us over the BackdropFilter(blur+saturation) background.
     float isLight = step(0.5, uBackdropLuma);
+    float isClear = step(0.5, uBodyMode);
     
-    // 8% frost floor ensures minimum material visibility
-    // In light mode, add more frost for a cleaner white look
-    float simulatedFrost = 0.08 + densityFactor * 0.05 + isLight * 0.04;
-    float pmA = max(glassAlpha, simulatedFrost);
+    // 8% frost floor ensures minimum material visibility in adaptive mode.
+    // In clear mode, simulated frost floor is zeroed out for exact color reproduction.
+    float simulatedFrost = mix(0.08 + densityFactor * 0.05 + isLight * 0.04, 0.0, isClear);
+    float pmA = mix(max(glassAlpha, simulatedFrost), glassAlpha, isClear);
     
     // In light mode, transparent glass becomes white frost. In dark mode, it remains black (ambient darken).
     vec3 frostRgb = vec3(isLight);
-    vec3 baseRgb = mix(frostRgb, uGlassColor.rgb, min(glassAlpha / (simulatedFrost + 0.01), 1.0));
+    vec3 adaptiveBaseRgb = mix(frostRgb, uGlassColor.rgb, min(glassAlpha / (simulatedFrost + 0.01), 1.0));
+    vec3 baseRgb = mix(adaptiveBaseRgb, uGlassColor.rgb, isClear);
     vec3 pmRgb = baseRgb * pmA;
 
-    // Min 3% ambient darkening + bottom volumetric gradient shadow:
+    // Min 3% ambient darkening + bottom volumetric gradient shadow (adaptive mode only):
     float bottomDarken = vertCoord * 0.04;
     float ambientDarken = clamp((uAmbientStrength * 0.25 + 0.03) * (1.0 + densityFactor * 0.5) + bottomDarken, 0.0, 0.8);
-    // Reduce ambient darken in light mode to prevent greyness
+    // Reduce ambient darken in light mode to prevent greyness; zero out in clear mode
     ambientDarken *= mix(1.0, 0.2, isLight);
+    ambientDarken *= (1.0 - isClear);
     
     pmA = pmA + ambientDarken * (1.0 - pmA);
 

--- a/shaders/liquid_glass_final_render.frag
+++ b/shaders/liquid_glass_final_render.frag
@@ -98,6 +98,10 @@ uniform vec4 uEdgeConfig;
 // See PlatformViewGlassMode. At 0 this shader is bit for bit unchanged.
 uniform float uPlatformViewMode;
 
+// Slot 33: uBodyMode — 0 = adaptive (default, iOS 26 Glass.regular), 1 = clear (iOS 26 Glass.clear).
+// See GlassBodyMode. In clear mode, luminance normalization is bypassed for direct alpha compositing.
+uniform float uBodyMode;
+
 // uThickness directly and is already DPR-independent).
 // uniform float uRefractScale; // Removed in favor of scaling uThickness
 
@@ -364,7 +368,7 @@ void main() {
         refractColor.rgb /= refractColor.a;
     }
 
-    vec4 finalColor = applyGlassColor(refractColor, uGlassColor);
+    vec4 finalColor = applyGlassColor(refractColor, uGlassColor, uBodyMode);
 
     // VQ4: Content-adaptive glass strength.
     //
@@ -400,9 +404,10 @@ void main() {
     // weight = ±2.4%) — within a single JND step, noticeable as a property
     // not a glitch.  Uses mix() to re-blend toward uGlassColor.rgb over the
     // already-tinted finalColor, scaled by the adaptive delta only.
+    // In clear mode (uBodyMode == 1.0), adaptive tint modulation is bypassed.
     finalColor.rgb = mix(finalColor.rgb,
                          uGlassColor.rgb,
-                         uGlassColor.a * 0.12 * (adaptiveStrength - 1.0));
+                         uGlassColor.a * 0.12 * (adaptiveStrength - 1.0) * (1.0 - uBodyMode));
 
     // Whitening veil — applied here, right after the body tint and BEFORE the
     // rim/fresnel passes. Applying it before the edge lighting means the rim

--- a/shaders/render.glsl
+++ b/shaders/render.glsl
@@ -62,14 +62,19 @@ vec3 applySaturation(vec3 color, float saturation) {
 
 // ── applyGlassColor ───────────────────────────────────────────────────────────
 // Apply glass color tinting to the liquid color.
-// iOS 26 model: chromatic glass (blue, amber) preserves backdrop luminance while
-// shifting hue — unlike Overlay which produced unintuitive darkening/brightening.
-// Achromatic glass (white, grey, black) uses a direct alpha-composite mix so
-// that white glass actually lifts toward white (brightness effect). Without this,
-// whites collapse to a luminance-matched grey and can never frost the surface.
-// The chroma factor blends smoothly between the two paths — fully branchless.
-// glassColor.a = 0 naturally returns liquidColor via mix() in both paths.
-vec4 applyGlassColor(vec4 liquidColor, vec4 glassColor) {
+// iOS 26 model:
+// - bodyMode == 0.0 (adaptive / Glass.regular): chromatic glass preserves
+//   backdrop luminance while shifting hue; achromatic glass lifts toward white.
+// - bodyMode == 1.0 (clear / Glass.clear): direct alpha-composite tint without
+//   luminance normalization, preserving exact design token hex values while
+//   retaining specular, Fresnel, and rim physics.
+// glassColor.a = 0 naturally returns liquidColor via mix() in all paths.
+vec4 applyGlassColor(vec4 liquidColor, vec4 glassColor, float bodyMode) {
+    vec3 directMix = mix(liquidColor.rgb, glassColor.rgb, glassColor.a);
+    if (bodyMode > 0.5) {
+        return vec4(directMix, liquidColor.a);
+    }
+
     float backdropLuminance = dot(liquidColor.rgb, LUMA_WEIGHTS);
     float glassLuminance    = dot(glassColor.rgb, LUMA_WEIGHTS);
 
@@ -82,10 +87,12 @@ vec4 applyGlassColor(vec4 liquidColor, vec4 glassColor) {
                  - min(min(glassColor.r, glassColor.g), glassColor.b);
     float chromaWeight = clamp(chroma * 8.0, 0.0, 1.0);
 
-    // achromatic path: direct mix toward the glass colour (white lifts to white)
-    vec3 directMix     = mix(liquidColor.rgb, glassColor.rgb, glassColor.a);
     // chromatic path:  mix toward luminosity-shifted tint (hue shift, brightness held)
     vec3 luminosityMix = mix(liquidColor.rgb, tinted, glassColor.a);
 
     return vec4(mix(directMix, luminosityMix, chromaWeight), liquidColor.a);
+}
+
+vec4 applyGlassColor(vec4 liquidColor, vec4 glassColor) {
+    return applyGlassColor(liquidColor, glassColor, 0.0);
 }

--- a/test/renderer/liquid_glass_settings_test.dart
+++ b/test/renderer/liquid_glass_settings_test.dart
@@ -446,5 +446,53 @@ void main() {
         expect(a.hashCode, isNot(equals(c.hashCode)));
       });
     });
+
+    group('bodyMode', () {
+      test('defaults to GlassBodyMode.adaptive', () {
+        const s = LiquidGlassSettings();
+        expect(s.bodyMode, equals(GlassBodyMode.adaptive));
+      });
+
+      test('copyWith sets bodyMode without touching other fields', () {
+        const base = LiquidGlassSettings();
+        final copy = base.copyWith(bodyMode: GlassBodyMode.clear);
+        expect(copy.bodyMode, equals(GlassBodyMode.clear));
+        expect(copy.blur, equals(base.blur));
+        expect(copy.thickness, equals(base.thickness));
+      });
+
+      test('copyWithPinch preserves bodyMode', () {
+        const base = LiquidGlassSettings(bodyMode: GlassBodyMode.clear);
+        final pinched = base.copyWithPinch(0.5);
+        expect(pinched.bodyMode, equals(GlassBodyMode.clear));
+      });
+
+      test('lerp switches bodyMode at t=0.5', () {
+        const a = LiquidGlassSettings(bodyMode: GlassBodyMode.adaptive);
+        const b = LiquidGlassSettings(bodyMode: GlassBodyMode.clear);
+        expect(LiquidGlassSettings.lerp(a, b, 0.49).bodyMode,
+            equals(GlassBodyMode.adaptive));
+        expect(LiquidGlassSettings.lerp(a, b, 0.50).bodyMode,
+            equals(GlassBodyMode.clear));
+        expect(LiquidGlassSettings.lerp(a, b, 0.99).bodyMode,
+            equals(GlassBodyMode.clear));
+      });
+
+      test('equality includes bodyMode', () {
+        const a = LiquidGlassSettings(bodyMode: GlassBodyMode.adaptive);
+        const b = LiquidGlassSettings(bodyMode: GlassBodyMode.adaptive);
+        const c = LiquidGlassSettings(bodyMode: GlassBodyMode.clear);
+        expect(a, equals(b));
+        expect(a, isNot(equals(c)));
+      });
+
+      test('hashCode includes bodyMode', () {
+        const a = LiquidGlassSettings(bodyMode: GlassBodyMode.adaptive);
+        const b = LiquidGlassSettings(bodyMode: GlassBodyMode.adaptive);
+        const c = LiquidGlassSettings(bodyMode: GlassBodyMode.clear);
+        expect(a.hashCode, equals(b.hashCode));
+        expect(a.hashCode, isNot(equals(c.hashCode)));
+      });
+    });
   });
 }

--- a/test/renderer/liquid_glass_test.dart
+++ b/test/renderer/liquid_glass_test.dart
@@ -21,6 +21,26 @@ void main() {
       );
     });
 
+    testWidgets('renders cleanly with bodyMode: GlassBodyMode.clear',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: LiquidGlass.withOwnLayer(
+              shape: const LiquidOval(),
+              settings: const LiquidGlassSettings(
+                bodyMode: GlassBodyMode.clear,
+                blur: 0,
+                glassColor: Color(0xD9C3E0F5),
+              ),
+              child: const SizedBox(width: 100, height: 100),
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(LiquidGlass), findsOneWidget);
+    });
+
     group('LiquidRoundedSuperellipse', () {
       goldenTest(
         'should render a rounded superellipse with different thickness',

--- a/test/widgets/overlays/glass_menu_test.dart
+++ b/test/widgets/overlays/glass_menu_test.dart
@@ -791,4 +791,186 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('EarlyItem'), findsOneWidget);
   });
+
+  // ── Route-aware dismissal tests (#274) ────────────────────────────────────
+  testWidgets(
+      'GlassMenu dismisses instantly on route navigation without overlapping destination (#274)',
+      (tester) async {
+    bool closedCalled = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: GlassMenu(
+                onClose: () => closedCalled = true,
+                trigger: const SizedBox(
+                  width: 80,
+                  height: 40,
+                  child: Text('Open Menu'),
+                ),
+                items: [
+                  GlassMenuItem(
+                    title: 'Navigate Item',
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => const Scaffold(
+                            body: Center(child: Text('Page 2')),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Open the menu
+    await tester.tap(find.text('Open Menu'));
+    await tester.pumpAndSettle();
+    expect(find.text('Navigate Item'), findsOneWidget);
+    expect(closedCalled, isFalse);
+
+    // Tap navigate item
+    await tester.tap(find.text('Navigate Item'));
+
+    // Advance into the route transition
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    // Mid-transition into the new route, the menu must already be dismissed.
+    // It should not linger in the root overlay over the incoming page.
+    expect(find.text('Navigate Item'), findsNothing);
+    expect(find.text('Page 2'), findsOneWidget);
+    expect(closedCalled, isTrue);
+
+    // Complete the transition
+    await tester.pumpAndSettle();
+    expect(find.text('Page 2'), findsOneWidget);
+    expect(find.text('Navigate Item'), findsNothing);
+
+    // Pop back to Page 1
+    final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+    navigator.pop();
+    await tester.pumpAndSettle();
+
+    // Back on Page 1: trigger is visible and menu is closed
+    expect(find.text('Open Menu'), findsOneWidget);
+    expect(find.text('Navigate Item'), findsNothing);
+
+    // Menu can be reopened cleanly
+    await tester.tap(find.text('Open Menu'));
+    await tester.pumpAndSettle();
+    expect(find.text('Navigate Item'), findsOneWidget);
+  });
+
+  testWidgets(
+      'GlassMenu dismisses instantly when route is pushed externally while open',
+      (tester) async {
+    late BuildContext homeContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            homeContext = context;
+            return Scaffold(
+              body: Center(
+                child: GlassMenu(
+                  trigger: const Text('Open Menu'),
+                  items: [
+                    GlassMenuItem(
+                      title: 'Option',
+                      onTap: () {},
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open Menu'));
+    await tester.pumpAndSettle();
+    expect(find.text('Option'), findsOneWidget);
+
+    // Push an external route
+    Navigator.of(homeContext).push(
+      MaterialPageRoute(
+        builder: (_) => const Scaffold(
+          body: Center(child: Text('External Route')),
+        ),
+      ),
+    );
+
+    // Advance into transition
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(find.text('Option'), findsNothing);
+    expect(find.text('External Route'), findsOneWidget);
+
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+      'GlassMenu dismisses instantly when containing route is popped while open',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => Scaffold(
+                      appBar: AppBar(title: const Text('Second Route')),
+                      body: Center(
+                        child: GlassMenu(
+                          trigger: const Text('Open SubMenu'),
+                          items: [
+                            GlassMenuItem(
+                              title: 'Sub Option',
+                              onTap: () {},
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Go to Second'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Go to Second'));
+    await tester.pumpAndSettle();
+    expect(find.text('Second Route'), findsOneWidget);
+
+    // Open menu on second route
+    await tester.tap(find.text('Open SubMenu'));
+    await tester.pumpAndSettle();
+    expect(find.text('Sub Option'), findsOneWidget);
+
+    // Pop the containing route
+    final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+    navigator.pop();
+
+    // First frame of pop
+    await tester.pump();
+    expect(find.text('Sub Option'), findsNothing);
+
+    await tester.pumpAndSettle();
+    expect(find.text('Go to Second'), findsOneWidget);
+  });
 }

--- a/test/widgets/overlays/glass_menu_test.dart
+++ b/test/widgets/overlays/glass_menu_test.dart
@@ -919,6 +919,51 @@ void main() {
   });
 
   testWidgets(
+      'GlassMenu dismisses instantly when route with zero duration is pushed while open',
+      (tester) async {
+    late BuildContext homeContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            homeContext = context;
+            return Scaffold(
+              body: Center(
+                child: GlassMenu(
+                  trigger: const Text('Open Menu'),
+                  items: [
+                    GlassMenuItem(
+                      title: 'Option',
+                      onTap: () {},
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open Menu'));
+    await tester.pumpAndSettle();
+    expect(find.text('Option'), findsOneWidget);
+
+    Navigator.of(homeContext).push(
+      PageRouteBuilder(
+        transitionDuration: Duration.zero,
+        pageBuilder: (_, __, ___) => const Scaffold(
+          body: Center(child: Text('Zero Duration Route')),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(find.text('Option'), findsNothing);
+    expect(find.text('Zero Duration Route'), findsOneWidget);
+  });
+
+  testWidgets(
       'GlassMenu dismisses instantly when containing route is popped while open',
       (tester) async {
     await tester.pumpWidget(

--- a/test/widgets/overlays/glass_modal_sheet_progress_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_progress_test.dart
@@ -62,7 +62,8 @@ void main() {
       double? seen;
       void listener() => seen = controller.progress;
       controller.progressListenable!.addListener(listener);
-      addTearDown(() => controller.progressListenable?.removeListener(listener));
+      addTearDown(
+          () => controller.progressListenable?.removeListener(listener));
 
       controller.snapToState(GlassSheetState.full, animate: false);
       expect(seen, 1.0, reason: 'the jump to full should read as 1.0 at once');

--- a/test/widgets/overlays/glass_modal_sheet_scroll_handover_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_scroll_handover_test.dart
@@ -116,7 +116,8 @@ void main() {
     expect(controller.currentState, GlassSheetState.full);
   });
 
-  testWidgets('the handover finishes the sheet\'s travel before the finger lifts',
+  testWidgets(
+      'the handover finishes the sheet\'s travel before the finger lifts',
       (tester) async {
     final states = <GlassSheetState>[];
     final controller = GlassModalSheetController();

--- a/test/widgets/overlays/glass_popover_test.dart
+++ b/test/widgets/overlays/glass_popover_test.dart
@@ -637,4 +637,174 @@ void main() {
 
     expect(find.text('MinimalContent'), findsOneWidget);
   });
+
+  // ── Route-aware dismissal tests (#274) ────────────────────────────────────
+  testWidgets(
+      'GlassPopover dismisses instantly on route navigation without overlapping destination (#274)',
+      (tester) async {
+    bool closedCalled = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: GlassPopover(
+                onClose: () => closedCalled = true,
+                trigger: const SizedBox(
+                  width: 80,
+                  height: 40,
+                  child: Text('Open Popover'),
+                ),
+                contentBuilder: (context, close) => ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => const Scaffold(
+                          body: Center(child: Text('Page 2')),
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('Navigate From Popover'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Open popover
+    await tester.tap(find.text('Open Popover'));
+    await tester.pumpAndSettle();
+    expect(find.text('Navigate From Popover'), findsOneWidget);
+    expect(closedCalled, isFalse);
+
+    // Tap navigate button inside popover
+    await tester.tap(find.text('Navigate From Popover'));
+
+    // Advance into route transition
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    // Popover must be immediately dismissed during route transition
+    expect(find.text('Navigate From Popover'), findsNothing);
+    expect(find.text('Page 2'), findsOneWidget);
+    expect(closedCalled, isTrue);
+
+    // Settle transition
+    await tester.pumpAndSettle();
+    expect(find.text('Page 2'), findsOneWidget);
+    expect(find.text('Navigate From Popover'), findsNothing);
+
+    // Pop back to Page 1
+    final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+    navigator.pop();
+    await tester.pumpAndSettle();
+
+    // Back on Page 1: trigger is visible and popover is closed
+    expect(find.text('Open Popover'), findsOneWidget);
+    expect(find.text('Navigate From Popover'), findsNothing);
+
+    // Reopen popover cleanly
+    await tester.tap(find.text('Open Popover'));
+    await tester.pumpAndSettle();
+    expect(find.text('Navigate From Popover'), findsOneWidget);
+  });
+
+  testWidgets(
+      'GlassPopover dismisses instantly when route is pushed externally while open',
+      (tester) async {
+    late BuildContext homeContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            homeContext = context;
+            return Scaffold(
+              body: Center(
+                child: GlassPopover(
+                  trigger: const Text('Open Popover'),
+                  contentBuilder: (context, close) => const Text('Popover Body'),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open Popover'));
+    await tester.pumpAndSettle();
+    expect(find.text('Popover Body'), findsOneWidget);
+
+    // Push an external route
+    Navigator.of(homeContext).push(
+      MaterialPageRoute(
+        builder: (_) => const Scaffold(
+          body: Center(child: Text('External Route')),
+        ),
+      ),
+    );
+
+    // Advance into transition
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(find.text('Popover Body'), findsNothing);
+    expect(find.text('External Route'), findsOneWidget);
+
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+      'GlassPopover dismisses instantly when containing route is popped while open',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => Scaffold(
+                      appBar: AppBar(title: const Text('Second Route')),
+                      body: Center(
+                        child: GlassPopover(
+                          trigger: const Text('Open SubPopover'),
+                          contentBuilder: (context, close) =>
+                              const Text('Sub Popover Content'),
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Go to Second'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Go to Second'));
+    await tester.pumpAndSettle();
+    expect(find.text('Second Route'), findsOneWidget);
+
+    // Open popover on second route
+    await tester.tap(find.text('Open SubPopover'));
+    await tester.pumpAndSettle();
+    expect(find.text('Sub Popover Content'), findsOneWidget);
+
+    // Pop the containing route
+    final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+    navigator.pop();
+
+    // Advance 1 frame of pop
+    await tester.pump();
+    expect(find.text('Sub Popover Content'), findsNothing);
+
+    await tester.pumpAndSettle();
+    expect(find.text('Go to Second'), findsOneWidget);
+  });
 }

--- a/test/widgets/overlays/glass_popover_test.dart
+++ b/test/widgets/overlays/glass_popover_test.dart
@@ -758,6 +758,47 @@ void main() {
   });
 
   testWidgets(
+      'GlassPopover dismisses instantly when route with zero duration is pushed while open',
+      (tester) async {
+    late BuildContext homeContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            homeContext = context;
+            return Scaffold(
+              body: Center(
+                child: GlassPopover(
+                  trigger: const Text('Open Popover'),
+                  contentBuilder: (context, close) =>
+                      const Text('Popover Body'),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open Popover'));
+    await tester.pumpAndSettle();
+    expect(find.text('Popover Body'), findsOneWidget);
+
+    Navigator.of(homeContext).push(
+      PageRouteBuilder(
+        transitionDuration: Duration.zero,
+        pageBuilder: (_, __, ___) => const Scaffold(
+          body: Center(child: Text('Zero Duration Route')),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(find.text('Popover Body'), findsNothing);
+    expect(find.text('Zero Duration Route'), findsOneWidget);
+  });
+
+  testWidgets(
       'GlassPopover dismisses instantly when containing route is popped while open',
       (tester) async {
     await tester.pumpWidget(

--- a/test/widgets/overlays/glass_popover_test.dart
+++ b/test/widgets/overlays/glass_popover_test.dart
@@ -725,7 +725,8 @@ void main() {
               body: Center(
                 child: GlassPopover(
                   trigger: const Text('Open Popover'),
-                  contentBuilder: (context, close) => const Text('Popover Body'),
+                  contentBuilder: (context, close) =>
+                      const Text('Popover Body'),
                 ),
               ),
             );

--- a/test/widgets/rtl_layout_audit_test.dart
+++ b/test/widgets/rtl_layout_audit_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
@@ -269,6 +268,67 @@ void main() {
         greaterThan(barCenter),
         reason:
             'RTL centerTitle:false — title centre must be right of bar centre',
+      );
+    });
+
+    testWidgets(
+        'centerTitle:false — title aligns to right padding without leading (RTL regression #282)',
+        (tester) async {
+      const double horizontalPadding = 16.0;
+
+      await tester.pumpWidget(
+        _rtlBare(
+          const Scaffold(
+            appBar: GlassAppBar(
+              title: Text('Title'),
+              centerTitle: false,
+              padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+            ),
+          ),
+        ),
+      );
+
+      final appBarBox =
+          tester.renderObject<RenderBox>(find.byType(GlassAppBar));
+      final titleRight = tester.getTopRight(find.text('Title')).dx;
+
+      // In RTL with no leading, title's right edge should be at barWidth - horizontalPadding
+      expect(
+        titleRight,
+        appBarBox.size.width - horizontalPadding,
+        reason: 'RTL title should align to right padding without extra gap',
+      );
+    });
+
+    testWidgets(
+        'centerTitle:false — title places 8px to the left of leading without overlapping (RTL)',
+        (tester) async {
+      const double horizontalPadding = 16.0;
+      const double leadingWidth = 44.0;
+
+      await tester.pumpWidget(
+        _rtlBare(
+          const Scaffold(
+            appBar: GlassAppBar(
+              title: Text('Title'),
+              centerTitle: false,
+              padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+              leading: SizedBox(width: leadingWidth, height: 44),
+            ),
+          ),
+        ),
+      );
+
+      final appBarBox =
+          tester.renderObject<RenderBox>(find.byType(GlassAppBar));
+      final titleRight = tester.getTopRight(find.text('Title')).dx;
+
+      // Leading occupies [width - padding - 44, width - padding]
+      // Title right edge must be width - padding - leadingWidth - 8.0
+      expect(
+        titleRight,
+        appBarBox.size.width - horizontalPadding - leadingWidth - 8.0,
+        reason: 'RTL title should have an 8px gap to the left of leading',
       );
     });
   });

--- a/test/widgets/shared/adaptive_glass_test.dart
+++ b/test/widgets/shared/adaptive_glass_test.dart
@@ -340,4 +340,69 @@ void main() {
       expect(find.text('premGroup'), findsOneWidget);
     });
   });
+
+  group('AdaptiveGlass bodyMode (GlassBodyMode.clear)', () {
+    testWidgets('renders cleanly with bodyMode: GlassBodyMode.clear in all quality tiers',
+        (tester) async {
+      const clearSettings = LiquidGlassSettings(
+        bodyMode: GlassBodyMode.clear,
+        glassColor: Color(0xD9C3E0F5),
+        blur: 0,
+      );
+
+      for (final quality in [
+        GlassQuality.minimal,
+        GlassQuality.standard,
+        GlassQuality.premium,
+      ]) {
+        await tester.pumpWidget(
+          createTestApp(
+            child: AdaptiveGlass(
+              shape: _shape,
+              settings: clearSettings,
+              quality: quality,
+              useOwnLayer: true,
+              child: Text('clear_${quality.name}'),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('clear_${quality.name}'), findsOneWidget);
+      }
+    });
+
+    testWidgets('preserves exact zero alpha in clear mode minimal tier',
+        (tester) async {
+      const clearSettings = LiquidGlassSettings(
+        bodyMode: GlassBodyMode.clear,
+        glassColor: Color(0x00FFFFFF),
+        blur: 0,
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          child: AdaptiveGlass(
+            shape: _shape,
+            settings: clearSettings,
+            quality: GlassQuality.minimal,
+            child: const Text('zeroAlphaClear'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('zeroAlphaClear'), findsOneWidget);
+
+      // Verify DecoratedBox has withValues(alpha: 0.0)
+      final decoratedBoxes =
+          tester.widgetList<DecoratedBox>(find.byType(DecoratedBox));
+      expect(
+        decoratedBoxes.any((box) {
+          final dec = box.decoration;
+          return (dec is ShapeDecoration && dec.color?.a == 0.0) ||
+              (dec is BoxDecoration && dec.color?.a == 0.0);
+        }),
+        isTrue,
+      );
+    });
+  });
 }

--- a/test/widgets/shared/adaptive_glass_test.dart
+++ b/test/widgets/shared/adaptive_glass_test.dart
@@ -342,7 +342,8 @@ void main() {
   });
 
   group('AdaptiveGlass bodyMode (GlassBodyMode.clear)', () {
-    testWidgets('renders cleanly with bodyMode: GlassBodyMode.clear in all quality tiers',
+    testWidgets(
+        'renders cleanly with bodyMode: GlassBodyMode.clear in all quality tiers',
         (tester) async {
       const clearSettings = LiquidGlassSettings(
         bodyMode: GlassBodyMode.clear,

--- a/test/widgets/shared/lightweight_liquid_glass_test.dart
+++ b/test/widgets/shared/lightweight_liquid_glass_test.dart
@@ -24,6 +24,25 @@ void main() {
       expect(find.byType(LightweightLiquidGlass), findsOneWidget);
     });
 
+    testWidgets('renders cleanly with bodyMode: GlassBodyMode.clear',
+        (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          child: LightweightLiquidGlass(
+            shape: const LiquidRoundedSuperellipse(borderRadius: 16),
+            settings: const LiquidGlassSettings(
+              bodyMode: GlassBodyMode.clear,
+              blur: 0,
+              glassColor: Color(0xD9C3E0F5),
+            ),
+            child: const Text('clear body mode'),
+          ),
+        ),
+      );
+      expect(find.byType(LightweightLiquidGlass), findsOneWidget);
+      expect(find.text('clear body mode'), findsOneWidget);
+    });
+
     testWidgets('inLayer constructor inherits settings from ancestor',
         (tester) async {
       await tester.pumpWidget(

--- a/test/widgets/surfaces/glass_app_bar_test.dart
+++ b/test/widgets/surfaces/glass_app_bar_test.dart
@@ -550,4 +550,181 @@ void main() {
       );
     });
   });
+
+  group('left-aligned title spacing (regression #282)', () {
+    testWidgets(
+      'left-aligned title respects padding without a leading widget (pinned)',
+      (tester) async {
+        tester.view.physicalSize = const Size(375, 812);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          const CupertinoApp(
+            home: GlassScaffold(
+              appBar: GlassAppBar.pinned(
+                backButton: false,
+                centerTitle: false,
+                padding: EdgeInsets.symmetric(horizontal: 16),
+                title: Text('Activity Summary'),
+              ),
+              body: SizedBox.shrink(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final titleLeft = tester.getTopLeft(find.text('Activity Summary')).dx;
+
+        expect(
+          titleLeft,
+          16.0,
+          reason:
+              'Title should align to 16px content padding without extra gap',
+        );
+      },
+    );
+
+    testWidgets(
+      'left-aligned title respects padding without a leading widget (unpinned)',
+      (tester) async {
+        tester.view.physicalSize = const Size(375, 812);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          createTestApp(
+            child: const Scaffold(
+              appBar: GlassAppBar(
+                centerTitle: false,
+                padding: EdgeInsets.symmetric(horizontal: 16),
+                title: Text('Activity Summary'),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final titleLeft = tester.getTopLeft(find.text('Activity Summary')).dx;
+
+        expect(
+          titleLeft,
+          16.0,
+          reason:
+              'Title should align directly to padding when no leading widget is provided',
+        );
+      },
+    );
+
+    testWidgets(
+      'left-aligned title applies 8px gap when leading widget is present',
+      (tester) async {
+        tester.view.physicalSize = const Size(375, 812);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        const double leadingWidth = 44.0;
+        const double horizontalPadding = 16.0;
+
+        await tester.pumpWidget(
+          createTestApp(
+            child: const Scaffold(
+              appBar: GlassAppBar(
+                centerTitle: false,
+                padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+                leading: SizedBox(width: leadingWidth, height: 44),
+                title: Text('Activity Summary'),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final titleLeft = tester.getTopLeft(find.text('Activity Summary')).dx;
+
+        // padding (16) + leadingWidth (44) + _titleGap (8) = 68.0
+        expect(
+          titleLeft,
+          horizontalPadding + leadingWidth + 8.0,
+          reason:
+              'Title should include an 8px gap when a leading widget is present',
+        );
+      },
+    );
+
+    testWidgets(
+      'left-aligned title constrains width to preserve 8px gap before actions',
+      (tester) async {
+        const double barWidth = 375.0;
+        const double horizontalPadding = 16.0;
+        const double actionsWidth = 50.0;
+
+        await tester.pumpWidget(
+          createTestApp(
+            child: SizedBox(
+              width: barWidth,
+              child: const Scaffold(
+                appBar: GlassAppBar(
+                  centerTitle: false,
+                  padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+                  actions: [SizedBox(width: actionsWidth, height: 44)],
+                  title: Text(
+                    'Very Long Title That Should Be Constrained By Layout',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final titleRight = tester
+            .getTopRight(
+              find.text('Very Long Title That Should Be Constrained By Layout'),
+            )
+            .dx;
+
+        // Total width = 375.
+        // Actions start at 375 - 16 - 50 = 309.
+        // Title must end at or before 309 - 8 = 301.
+        expect(titleRight, lessThanOrEqualTo(301.0));
+      },
+    );
+
+    testWidgets(
+      'relayouts when centerTitle changes',
+      (tester) async {
+        await tester.pumpWidget(
+          createTestApp(
+            child: const Scaffold(
+              appBar: GlassAppBar(
+                centerTitle: false,
+                title: Text('Title'),
+              ),
+            ),
+          ),
+        );
+
+        final initialLeft = tester.getTopLeft(find.text('Title')).dx;
+
+        // Rebuild with centerTitle: true
+        await tester.pumpWidget(
+          createTestApp(
+            child: const Scaffold(
+              appBar: GlassAppBar(
+                centerTitle: true,
+                title: Text('Title'),
+              ),
+            ),
+          ),
+        );
+
+        final centeredLeft = tester.getTopLeft(find.text('Title')).dx;
+        expect(centeredLeft, greaterThan(initialLeft));
+      },
+    );
+  });
 }

--- a/test/widgets/surfaces/glass_tab_bar_bottom_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_bottom_test.dart
@@ -295,6 +295,120 @@ void main() {
       );
       expect(button.iconColor, Colors.red);
     });
+
+    test('GlassTabBarExtraButton.menu constructor sets properties correctly', () {
+      final button = GlassTabBarExtraButton.menu(
+        icon: const Icon(CupertinoIcons.ellipsis),
+        label: 'More',
+        size: 72,
+        placement: GlassExtraButtonPlacement.left,
+        menuWidth: 220,
+        menuAlignment: GlassMenuAlignment.topRight,
+        menuItems: [
+          GlassMenuItem(
+            icon: const Icon(CupertinoIcons.share),
+            title: 'Share',
+            onTap: () {},
+          ),
+        ],
+      );
+
+      expect(button.isMenu, isTrue);
+      expect(button.label, 'More');
+      expect(button.enabled, isTrue);
+      expect(button.size, 72);
+      expect(button.placement, GlassExtraButtonPlacement.left);
+      expect(button.menuWidth, 220);
+      expect(button.menuAlignment, GlassMenuAlignment.topRight);
+      expect(button.menuItems?.length, 1);
+    });
+
+    testWidgets(
+        'tapping extraButton in menu mode opens GlassMenu in GlassTabBar.bottom',
+        (tester) async {
+      var itemTapped = false;
+      const tabs = [
+        GlassTab(label: 'Home', icon: Icon(CupertinoIcons.home)),
+        GlassTab(label: 'Profile', icon: Icon(CupertinoIcons.person)),
+      ];
+
+      final menuButton = GlassTabBarExtraButton.menu(
+        icon: const Icon(CupertinoIcons.ellipsis),
+        label: 'Options',
+        menuItems: [
+          GlassMenuItem(
+            icon: const Icon(CupertinoIcons.share),
+            title: 'Share Action',
+            onTap: () => itemTapped = true,
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassTabBar.bottom(
+            tabs: tabs,
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            maskingQuality: MaskingQuality.off,
+            extraButton: menuButton,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Share Action'), findsNothing);
+
+      await tester.tap(find.byIcon(CupertinoIcons.ellipsis));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Share Action'), findsOneWidget);
+
+      await tester.tap(find.text('Share Action'));
+      await tester.pumpAndSettle();
+
+      expect(itemTapped, isTrue);
+      expect(find.text('Share Action'), findsNothing);
+    });
+
+    testWidgets('disabled extraButton in menu mode does not open menu on tap',
+        (tester) async {
+      const tabs = [
+        GlassTab(label: 'Home', icon: Icon(CupertinoIcons.home)),
+        GlassTab(label: 'Profile', icon: Icon(CupertinoIcons.person)),
+      ];
+
+      final menuButton = GlassTabBarExtraButton.menu(
+        icon: const Icon(CupertinoIcons.ellipsis),
+        label: 'Options',
+        enabled: false,
+        menuItems: [
+          GlassMenuItem(
+            icon: const Icon(CupertinoIcons.share),
+            title: 'Share Action',
+            onTap: () {},
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassTabBar.bottom(
+            tabs: tabs,
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            maskingQuality: MaskingQuality.off,
+            extraButton: menuButton,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(CupertinoIcons.ellipsis));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Share Action'), findsNothing);
+    });
   });
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -1153,6 +1267,71 @@ void main() {
       final indicator = tester.widget<AnimatedGlassIndicator>(
           find.byType(AnimatedGlassIndicator).first);
       expect(indicator.borderRadius, equals(10.0));
+    });
+
+    group('backgroundQuality', () {
+      testWidgets(
+          'propagates backgroundQuality to track AdaptiveGlass and preserves quality on indicator',
+          (tester) async {
+        await tester.pumpWidget(
+          createTestApp(
+            child: GlassTabBar.bottom(
+              tabs: const [
+                GlassTab(label: 'A', icon: Icon(CupertinoIcons.home)),
+                GlassTab(label: 'B', icon: Icon(CupertinoIcons.search)),
+              ],
+              selectedIndex: 0,
+              onTabSelected: (_) {},
+              quality: GlassQuality.premium,
+              backgroundQuality: GlassQuality.minimal,
+            ),
+          ),
+        );
+
+        final bar = tester.widget<GlassTabBar>(find.byType(GlassTabBar));
+        expect(bar.backgroundQuality, equals(GlassQuality.minimal));
+        expect(bar.quality, equals(GlassQuality.premium));
+
+        final indicator = tester.widget<AnimatedGlassIndicator>(
+            find.byType(AnimatedGlassIndicator).first);
+        expect(indicator.quality, equals(GlassQuality.premium));
+
+        final adaptiveGlasses =
+            tester.widgetList<AdaptiveGlass>(find.byType(AdaptiveGlass));
+        expect(
+            adaptiveGlasses.any((g) => g.quality == GlassQuality.minimal), isTrue);
+      });
+
+      testWidgets('inherits from quality when backgroundQuality is null',
+          (tester) async {
+        await tester.pumpWidget(
+          createTestApp(
+            child: GlassTabBar.bottom(
+              tabs: const [
+                GlassTab(label: 'A', icon: Icon(CupertinoIcons.home)),
+                GlassTab(label: 'B', icon: Icon(CupertinoIcons.search)),
+              ],
+              selectedIndex: 0,
+              onTabSelected: (_) {},
+              quality: GlassQuality.standard,
+            ),
+          ),
+        );
+
+        final bar = tester.widget<GlassTabBar>(find.byType(GlassTabBar));
+        expect(bar.backgroundQuality, isNull);
+        expect(bar.quality, equals(GlassQuality.standard));
+
+        final indicator = tester.widget<AnimatedGlassIndicator>(
+            find.byType(AnimatedGlassIndicator).first);
+        expect(indicator.quality, equals(GlassQuality.standard));
+
+        final adaptiveGlasses =
+            tester.widgetList<AdaptiveGlass>(find.byType(AdaptiveGlass));
+        expect(
+            adaptiveGlasses.every((g) => g.quality == GlassQuality.standard),
+            isTrue);
+      });
     });
   });
 }

--- a/test/widgets/surfaces/glass_tab_bar_bottom_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_bottom_test.dart
@@ -323,6 +323,7 @@ void main() {
       expect(button.menuWidth, 220);
       expect(button.menuAlignment, GlassMenuAlignment.topRight);
       expect(button.menuItems?.length, 1);
+      expect(() => button.onTap(), returnsNormally);
     });
 
     testWidgets(
@@ -480,6 +481,23 @@ void main() {
             onTabSelected: (_) {},
             showIndicator: false,
             maskingQuality: MaskingQuality.off,
+          ),
+        ),
+      );
+      expect(find.byType(GlassTabBar), findsOneWidget);
+    });
+
+    testWidgets(
+        'showIndicator=false with backgroundQuality and default maskingQuality renders',
+        (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          child: GlassTabBar.bottom(
+            tabs: testTabs3,
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            showIndicator: false,
+            backgroundQuality: GlassQuality.minimal,
           ),
         ),
       );

--- a/test/widgets/surfaces/glass_tab_bar_bottom_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_bottom_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/src/widgets/surfaces/tab_bar_bottom_internal.dart';
 
 import '../../shared/test_helpers.dart';
 
@@ -296,7 +297,8 @@ void main() {
       expect(button.iconColor, Colors.red);
     });
 
-    test('GlassTabBarExtraButton.menu constructor sets properties correctly', () {
+    test('GlassTabBarExtraButton.menu constructor sets properties correctly',
+        () {
       final button = GlassTabBarExtraButton.menu(
         icon: const Icon(CupertinoIcons.ellipsis),
         label: 'More',
@@ -1298,8 +1300,8 @@ void main() {
 
         final adaptiveGlasses =
             tester.widgetList<AdaptiveGlass>(find.byType(AdaptiveGlass));
-        expect(
-            adaptiveGlasses.any((g) => g.quality == GlassQuality.minimal), isTrue);
+        expect(adaptiveGlasses.any((g) => g.quality == GlassQuality.minimal),
+            isTrue);
       });
 
       testWidgets('inherits from quality when backgroundQuality is null',
@@ -1328,9 +1330,35 @@ void main() {
 
         final adaptiveGlasses =
             tester.widgetList<AdaptiveGlass>(find.byType(AdaptiveGlass));
-        expect(
-            adaptiveGlasses.every((g) => g.quality == GlassQuality.standard),
+        expect(adaptiveGlasses.every((g) => g.quality == GlassQuality.standard),
             isTrue);
+      });
+
+      testWidgets('propagates backgroundQuality to BottomBarExtraBtn',
+          (tester) async {
+        await tester.pumpWidget(
+          createTestApp(
+            child: GlassTabBar.bottom(
+              tabs: const [
+                GlassTab(label: 'A', icon: Icon(CupertinoIcons.home)),
+                GlassTab(label: 'B', icon: Icon(CupertinoIcons.search)),
+              ],
+              selectedIndex: 0,
+              onTabSelected: (_) {},
+              quality: GlassQuality.premium,
+              backgroundQuality: GlassQuality.minimal,
+              extraButton: GlassTabBarExtraButton(
+                icon: const Icon(CupertinoIcons.add),
+                onTap: () {},
+                label: 'Add',
+              ),
+            ),
+          ),
+        );
+
+        final extraBtn =
+            tester.widget<BottomBarExtraBtn>(find.byType(BottomBarExtraBtn));
+        expect(extraBtn.quality, equals(GlassQuality.minimal));
       });
     });
   });

--- a/test/widgets/surfaces/glass_tab_bar_constructors_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_constructors_test.dart
@@ -557,6 +557,25 @@ void main() {
 
       expect(tester.takeException(), isNull);
     });
+
+    testWidgets('forwards backgroundQuality to TabBarBottomLayout',
+        (tester) async {
+      await tester.pumpWidget(_wrap(_box(
+        GlassTabBar.inline(
+          tabs: [_tab('A'), _tab('B')],
+          selectedIndex: 0,
+          onTabSelected: (_) {},
+          quality: GlassQuality.premium,
+          backgroundQuality: GlassQuality.minimal,
+        ),
+      )));
+      await tester.pump();
+
+      final layout = tester.widget<TabBarBottomLayout>(
+        find.byType(TabBarBottomLayout),
+      );
+      expect(layout.backgroundQuality, equals(GlassQuality.minimal));
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -701,6 +720,29 @@ void main() {
       await tester.pump();
 
       expect(find.text('A'), findsWidgets);
+    });
+
+    testWidgets('forwards backgroundQuality to TabBarSearchableLayout',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        SizedBox(
+          height: 150,
+          child: GlassTabBar.searchable(
+            tabs: [_tab('A'), _tab('B')],
+            selectedIndex: 0,
+            onTabSelected: (_) {},
+            searchConfig: searchConfig,
+            quality: GlassQuality.premium,
+            backgroundQuality: GlassQuality.minimal,
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      final layout = tester.widget<TabBarSearchableLayout>(
+        find.byType(TabBarSearchableLayout),
+      );
+      expect(layout.backgroundQuality, equals(GlassQuality.minimal));
     });
   });
 

--- a/test/widgets/surfaces/glass_tab_bar_minimizable_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_minimizable_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/src/widgets/surfaces/tab_bar_searchable_layout.dart';
 
 import '../../shared/test_helpers.dart';
 
@@ -56,6 +57,25 @@ void main() {
     testWidgets('can be instantiated with required parameters', (tester) async {
       await tester.pumpWidget(_buildBar());
       expect(find.byType(GlassTabBar), findsOneWidget);
+    });
+
+    testWidgets('forwards backgroundQuality to underlying TabBarSearchableLayout',
+        (tester) async {
+      await tester.pumpWidget(createTestApp(
+        child: GlassTabBar.minimizable(
+          tabs: _testTabs,
+          selectedIndex: 0,
+          onTabSelected: (_) {},
+          quality: GlassQuality.premium,
+          backgroundQuality: GlassQuality.minimal,
+        ),
+      ));
+      await tester.pump();
+
+      final layout = tester.widget<TabBarSearchableLayout>(
+        find.byType(TabBarSearchableLayout),
+      );
+      expect(layout.backgroundQuality, equals(GlassQuality.minimal));
     });
 
     testWidgets('displays tab labels while expanded', (tester) async {
@@ -219,6 +239,99 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(taps, 1);
+    });
+
+    // ── Trailing button: menu mode (Issue #275) ──────────────────────────────
+
+    test('GlassTabBarTrailingButton.menu constructor sets properties correctly', () {
+      final button = GlassTabBarTrailingButton.menu(
+        icon: const Icon(CupertinoIcons.ellipsis),
+        label: 'Actions',
+        menuWidth: 240,
+        menuAlignment: GlassMenuAlignment.topLeft,
+        menuItems: [
+          GlassMenuItem(
+            icon: const Icon(CupertinoIcons.share),
+            title: 'Share',
+            onTap: () {},
+          ),
+        ],
+      );
+
+      expect(button.isMenu, isTrue);
+      expect(button.label, 'Actions');
+      expect(button.enabled, isTrue);
+      expect(button.menuWidth, 240);
+      expect(button.menuAlignment, GlassMenuAlignment.topLeft);
+      expect(button.menuItems?.length, 1);
+    });
+
+    testWidgets('tapping trailing button in menu mode opens GlassMenu',
+        (tester) async {
+      var itemTapped = false;
+
+      final menuButton = GlassTabBarTrailingButton.menu(
+        icon: const Icon(CupertinoIcons.ellipsis),
+        label: 'Options',
+        menuItems: [
+          GlassMenuItem(
+            icon: const Icon(CupertinoIcons.share),
+            title: 'Share Action',
+            onTap: () => itemTapped = true,
+          ),
+          GlassMenuItem(
+            icon: const Icon(CupertinoIcons.trash),
+            title: 'Delete Action',
+            isDestructive: true,
+            onTap: () {},
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(_buildBar(trailingButton: menuButton));
+      await tester.pumpAndSettle();
+
+      // Menu items should not be visible before tap
+      expect(find.text('Share Action'), findsNothing);
+
+      // Tap the trailing menu pill
+      await tester.tap(find.byIcon(CupertinoIcons.ellipsis).first);
+      await tester.pumpAndSettle();
+
+      // Menu overlay is now open and items are visible
+      expect(find.text('Share Action'), findsOneWidget);
+      expect(find.text('Delete Action'), findsOneWidget);
+
+      // Tap a menu item
+      await tester.tap(find.text('Share Action'));
+      await tester.pumpAndSettle();
+
+      expect(itemTapped, isTrue);
+      // Menu should be dismissed
+      expect(find.text('Share Action'), findsNothing);
+    });
+
+    testWidgets('disabled trailing menu button does not open menu on tap',
+        (tester) async {
+      final menuButton = GlassTabBarTrailingButton.menu(
+        icon: const Icon(CupertinoIcons.ellipsis),
+        enabled: false,
+        menuItems: [
+          GlassMenuItem(
+            icon: const Icon(CupertinoIcons.share),
+            title: 'Share Action',
+            onTap: () {},
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(_buildBar(trailingButton: menuButton));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(CupertinoIcons.ellipsis).first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Share Action'), findsNothing);
     });
 
     // ── preferredSize ─────────────────────────────────────────────────────────

--- a/test/widgets/surfaces/glass_tab_bar_minimizable_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_minimizable_test.dart
@@ -287,6 +287,7 @@ void main() {
       expect(button.menuWidth, 240);
       expect(button.menuAlignment, GlassMenuAlignment.topLeft);
       expect(button.menuItems?.length, 1);
+      expect(() => button.onTap(), returnsNormally);
     });
 
     testWidgets('tapping trailing button in menu mode opens GlassMenu',

--- a/test/widgets/surfaces/glass_tab_bar_minimizable_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_minimizable_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/src/widgets/surfaces/tab_bar_searchable_internal.dart';
 import 'package:liquid_glass_widgets/src/widgets/surfaces/tab_bar_searchable_layout.dart';
 
 import '../../shared/test_helpers.dart';
@@ -59,7 +60,8 @@ void main() {
       expect(find.byType(GlassTabBar), findsOneWidget);
     });
 
-    testWidgets('forwards backgroundQuality to underlying TabBarSearchableLayout',
+    testWidgets(
+        'forwards backgroundQuality to underlying TabBarSearchableLayout',
         (tester) async {
       await tester.pumpWidget(createTestApp(
         child: GlassTabBar.minimizable(
@@ -76,6 +78,26 @@ void main() {
         find.byType(TabBarSearchableLayout),
       );
       expect(layout.backgroundQuality, equals(GlassQuality.minimal));
+    });
+
+    testWidgets('propagates backgroundQuality to MinimizableTrailingPill',
+        (tester) async {
+      await tester.pumpWidget(createTestApp(
+        child: GlassTabBar.minimizable(
+          tabs: _testTabs,
+          selectedIndex: 0,
+          onTabSelected: (_) {},
+          quality: GlassQuality.premium,
+          backgroundQuality: GlassQuality.minimal,
+          trailingButton: _trailingButton(),
+        ),
+      ));
+      await tester.pump();
+
+      final pill = tester.widget<MinimizableTrailingPill>(
+        find.byType(MinimizableTrailingPill),
+      );
+      expect(pill.quality, equals(GlassQuality.minimal));
     });
 
     testWidgets('displays tab labels while expanded', (tester) async {
@@ -243,7 +265,8 @@ void main() {
 
     // ── Trailing button: menu mode (Issue #275) ──────────────────────────────
 
-    test('GlassTabBarTrailingButton.menu constructor sets properties correctly', () {
+    test('GlassTabBarTrailingButton.menu constructor sets properties correctly',
+        () {
       final button = GlassTabBarTrailingButton.menu(
         icon: const Icon(CupertinoIcons.ellipsis),
         label: 'Actions',

--- a/test/widgets/surfaces/glass_tab_bar_searchable_test.dart
+++ b/test/widgets/surfaces/glass_tab_bar_searchable_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/src/widgets/surfaces/tab_bar_bottom_internal.dart';
+import 'package:liquid_glass_widgets/src/widgets/surfaces/tab_bar_searchable_internal.dart';
 
 import '../../shared/test_helpers.dart';
 
@@ -34,6 +36,7 @@ Widget _buildBar({
   ValueChanged<String>? onChanged,
   GlassTabBarExtraButton? extraButton,
   GlassQuality? quality,
+  GlassQuality? backgroundQuality,
   bool showPill = true,
 }) {
   return createTestApp(
@@ -44,6 +47,7 @@ Widget _buildBar({
       isSearchActive: isSearchActive,
       maskingQuality: MaskingQuality.off, // no dual-layer in tests
       quality: quality,
+      backgroundQuality: backgroundQuality,
       extraButton: extraButton,
       searchConfig: GlassSearchBarConfig(
         onSearchToggle: onSearchToggle ?? (_) {},
@@ -1231,6 +1235,92 @@ void main() {
       // Fully disappeared pills leave the tree entirely — a zero-scale glass
       // shape would still fuse with the tab pill on the blend layer.
       expect(find.byIcon(CupertinoIcons.search), findsNothing);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GlassTabBar.searchable backgroundQuality
+  // ─────────────────────────────────────────────────────────────────────────
+
+  group('GlassTabBar.searchable backgroundQuality', () {
+    testWidgets(
+        'propagates backgroundQuality to SearchPill and BottomBarExtraBtn',
+        (tester) async {
+      await tester.pumpWidget(_buildBar(
+        quality: GlassQuality.premium,
+        backgroundQuality: GlassQuality.minimal,
+        extraButton: GlassTabBarExtraButton(
+          icon: const Icon(CupertinoIcons.add),
+          onTap: () {},
+          label: 'Add',
+        ),
+      ));
+      await tester.pump();
+
+      final searchPill = tester.widget<SearchPill>(find.byType(SearchPill));
+      expect(searchPill.quality, equals(GlassQuality.minimal));
+
+      final extraBtn =
+          tester.widget<BottomBarExtraBtn>(find.byType(BottomBarExtraBtn));
+      expect(extraBtn.quality, equals(GlassQuality.minimal));
+    });
+
+    testWidgets(
+        'propagates backgroundQuality to DismissPill when search is active with keyboard',
+        (tester) async {
+      final searchCtrl = SearchableBottomBarController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MediaQuery(
+              data: const MediaQueryData(
+                viewInsets: EdgeInsets.only(bottom: 200),
+              ),
+              child: GlassTabBar.searchable(
+                tabs: _testTabs,
+                selectedIndex: 0,
+                onTabSelected: (_) {},
+                controller: searchCtrl,
+                isSearchActive: true,
+                quality: GlassQuality.premium,
+                backgroundQuality: GlassQuality.minimal,
+                maskingQuality: MaskingQuality.off,
+                searchConfig: GlassSearchBarConfig(
+                  showsCancelButton: true,
+                  onSearchToggle: (_) {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      searchCtrl.onFocusChanged(true);
+      await tester.pumpAndSettle();
+
+      final dismissPill = tester.widget<DismissPill>(find.byType(DismissPill));
+      expect(dismissPill.quality, equals(GlassQuality.minimal));
+    });
+
+    testWidgets('inherits from quality when backgroundQuality is null',
+        (tester) async {
+      await tester.pumpWidget(_buildBar(
+        quality: GlassQuality.standard,
+        extraButton: GlassTabBarExtraButton(
+          icon: const Icon(CupertinoIcons.add),
+          onTap: () {},
+          label: 'Add',
+        ),
+      ));
+      await tester.pump();
+
+      final searchPill = tester.widget<SearchPill>(find.byType(SearchPill));
+      expect(searchPill.quality, equals(GlassQuality.standard));
+
+      final extraBtn =
+          tester.widget<BottomBarExtraBtn>(find.byType(BottomBarExtraBtn));
+      expect(extraBtn.quality, equals(GlassQuality.standard));
     });
   });
 }

--- a/test/widgets/surfaces/tab_bar_searchable_internal_test.dart
+++ b/test/widgets/surfaces/tab_bar_searchable_internal_test.dart
@@ -234,6 +234,42 @@ void main() {
       expect(find.byType(SearchableTabIndicator), findsOneWidget);
     });
 
+    testWidgets('propagates backgroundQuality to track AdaptiveGlass.grouped',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        SearchableTabIndicator(
+          tabIndex: 0,
+          tabCount: 3,
+          visible: true,
+          childUnselected: const SizedBox(),
+          selectedTabBuilder: (_, __, ___) => const SizedBox.shrink(),
+          onTabChanged: (_) {},
+          quality: GlassQuality.standard,
+          backgroundQuality: GlassQuality.minimal,
+          barHeight: 64,
+          barBorderRadius: 20,
+          tabPadding: EdgeInsets.zero,
+          magnification: 1.0,
+          innerBlur: 0,
+          maskingQuality: MaskingQuality.off,
+          isSearchActive: false,
+          onDismissSearch: () {},
+          enableBackgroundAnimation: true,
+          backgroundPressScale: 1.06,
+        ),
+      ));
+      await tester.pump();
+
+      final indicator = tester.widget<SearchableTabIndicator>(
+          find.byType(SearchableTabIndicator));
+      expect(indicator.quality, equals(GlassQuality.standard));
+      expect(indicator.backgroundQuality, equals(GlassQuality.minimal));
+
+      final glasses =
+          tester.widgetList<AdaptiveGlass>(find.byType(AdaptiveGlass));
+      expect(glasses.any((g) => g.quality == GlassQuality.minimal), isTrue);
+    });
+
     testWidgets('horizontal drag updates alignment and calls onTabChanged',
         (tester) async {
       final changedIndices = <int>[];

--- a/test/widgets/surfaces/tab_bar_searchable_internal_test.dart
+++ b/test/widgets/surfaces/tab_bar_searchable_internal_test.dart
@@ -260,8 +260,8 @@ void main() {
       ));
       await tester.pump();
 
-      final indicator = tester.widget<SearchableTabIndicator>(
-          find.byType(SearchableTabIndicator));
+      final indicator = tester
+          .widget<SearchableTabIndicator>(find.byType(SearchableTabIndicator));
       expect(indicator.quality, equals(GlassQuality.standard));
       expect(indicator.backgroundQuality, equals(GlassQuality.minimal));
 


### PR DESCRIPTION
## Summary

This PR bundles feature enhancements, API additions, and bug fixes for the **1.4.0** release:

### 🌟 Features
- **`GlassBodyMode` (`adaptive` vs `clear`) — exact color fidelity (#269):**
  - Added `GlassBodyMode` enum (`adaptive`, `clear`) and `bodyMode` property to `LiquidGlassSettings` (defaulting to `GlassBodyMode.adaptive`).
  - Implements 1:1 parity with Apple iOS 26 Liquid Glass (`Glass.regular` vs `Glass.clear`).
  - `GlassBodyMode.clear` bypasses luminosity normalization, ambient tint modulation, and white-point lift, directly compositing the designer's exact hex color and alpha from `glassColor` while retaining specular reflections, Fresnel edge glow, meniscus edge absorption, and surface refraction.
  - Resolves tint color fidelity issues when combining `blur: 0` with custom tints.
  - Implemented across all 3 shader tiers: Impeller (`liquid_glass_final_render.frag`), standard (`lightweight_glass.frag`), and Skia (`_FrostedFallback`).
- **Decoupled Track `backgroundQuality` in `GlassTabBar`:**
  - Added `backgroundQuality: GlassQuality?` to `GlassTabBar.bottom`, `GlassTabBar.inline`, `GlassTabBar.searchable`, and `GlassTabBar.minimizable`.
  - Mirrors UIKit's `UITabBarAppearance.backgroundEffect` decoupling from active selection pill.
  - Container can render lightweight frosted glass (`.standard` or `.minimal`) while selection capsule retains liquid refraction (`.premium`).
- **Native Pull-down Menus on Tab Bars (#275):**
  - Added `GlassTabBarTrailingButton.menu` and `GlassTabBarExtraButton.menu` named constructors.
  - Supports liquid spring expansion originating from the button's render box coordinates, auto-adjusts upward inside bottom bars, and respects accessibility semantics.

### 🐛 Bug Fixes & Refinements
- **`GlassAppBar` Title Spacing (#282):** Corrected left-aligned title spacing when no leading widget is provided.
- **Overlay Navigation Dismissal (#274):** Immediate dismissal of `GlassMenu` and `GlassPopover` on route transitions.
- **Minimized Bar Icon Color (#279, #280):** Minimized pill keeps `selectedIconColor` for the active tab.
- **Progressive Blur Route Clipping (#278, #281):** Confines backdrop filters within their own route boundary.

### 🧪 Demos & Tests
- Added `example/lib/demos/color_fidelity_demo.dart` showcasing `GlassBodyMode.adaptive` vs `GlassBodyMode.clear` and decoupled `backgroundQuality`.
- Updated `example/lib/demos/glass_tab_bar_bottom_demo.dart` with live background quality toggle.
- Added card to `example/lib/main.dart` showcase grid.
- **2,906 / 2,906 tests passing.**
- **0 `flutter analyze` issues.**