### PR TITLE
GlassModalSheet: dragIndicatorHeight and dragIndicatorTopPadding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 1.3.1
 
+## New Features
+
+- **`GlassModalSheet` drag indicator geometry (#288):** `dragIndicatorHeight` (default 4) and `dragIndicatorTopPadding` (default 8) join `dragIndicatorWidth`, so a sheet can match a host's own pill. Apple's own apps vary the pill's thickness, width and inset from sheet to sheet, and sit it higher where a control row follows (Maps), so there is no one right value to bake in; the defaults are unchanged.
+
 ## Bug Fixes
 
 - **Minimized bar keeps the selected tab's icon colour (#279):** On `GlassTabBar.minimizable`, the minimized pill drew the selected tab's icon in `unselectedIconColor`, so a custom `selectedIconColor` dropped out on minimize and returned on expand. The pill now uses `selectedIconColor`, as the native bar does — the tab is still selected, only the bar has shrunk. `GlassTabBar.searchable` is unchanged: its collapsed pill shows the tab search was opened from, which is no longer the selected one.

--- a/lib/widgets/overlays/glass_modal_sheet.dart
+++ b/lib/widgets/overlays/glass_modal_sheet.dart
@@ -217,6 +217,15 @@ class GlassModalSheet extends StatefulWidget {
   /// too subtle relative to the rest of the sheet's content.
   final double dragIndicatorWidth;
 
+  /// Thickness of the drag handle pill in logical pixels. Defaults to 4.
+  /// Apple's sheets draw theirs 5pt thick.
+  final double dragIndicatorHeight;
+
+  /// Gap between the sheet's top edge and the drag handle pill, in logical
+  /// pixels. Defaults to 8. Apple's sheets sit theirs about 5pt down, which
+  /// also leaves more room between the pill and a header row beneath it.
+  final double dragIndicatorTopPadding;
+
   /// Whether to enable a gradient fade effect at the top of the sheet.
   final bool enableTopFade;
 
@@ -265,6 +274,8 @@ class GlassModalSheet extends StatefulWidget {
     this.showDragIndicator = true,
     this.dragIndicatorColor,
     this.dragIndicatorWidth = 36,
+    this.dragIndicatorHeight = 4,
+    this.dragIndicatorTopPadding = 8,
     this.glowColor,
     this.glowRadius = 1.5,
     this.suppressInteractionOnChildren = false,
@@ -371,6 +382,8 @@ class GlassModalSheet extends StatefulWidget {
     bool showDragIndicator = true,
     Color? dragIndicatorColor,
     double dragIndicatorWidth = 36,
+    double dragIndicatorHeight = 4,
+    double dragIndicatorTopPadding = 8,
     double? topBorderRadius = 56,
     double? bottomBorderRadius,
     double? fullTopBorderRadius = 46,
@@ -499,6 +512,8 @@ class GlassModalSheet extends StatefulWidget {
           showDragIndicator: showDragIndicator,
           dragIndicatorColor: dragIndicatorColor,
           dragIndicatorWidth: dragIndicatorWidth,
+          dragIndicatorHeight: dragIndicatorHeight,
+          dragIndicatorTopPadding: dragIndicatorTopPadding,
           topBorderRadius: topBorderRadius,
           bottomBorderRadius: bottomBorderRadius,
           fullTopBorderRadius: fullTopBorderRadius,

--- a/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_internal.dart
@@ -38,6 +38,8 @@ class _SheetLayout extends StatelessWidget {
   final bool showDragIndicator;
   final Color? dragIndicatorColor;
   final double dragIndicatorWidth;
+  final double dragIndicatorHeight;
+  final double dragIndicatorTopPadding;
   final EdgeInsetsGeometry? padding;
   final bool maintainContentGlass;
   final LiquidGlassSettings? fullStateContentSettings;
@@ -80,6 +82,8 @@ class _SheetLayout extends StatelessWidget {
     required this.showDragIndicator,
     this.dragIndicatorColor,
     required this.dragIndicatorWidth,
+    required this.dragIndicatorHeight,
+    required this.dragIndicatorTopPadding,
     this.padding,
     required this.maintainContentGlass,
     this.fullStateContentSettings,
@@ -94,6 +98,8 @@ class _SheetLayout extends StatelessWidget {
   Widget build(BuildContext context) {
     final handleZone = _SheetHandleZone(
       indicatorWidth: dragIndicatorWidth,
+      indicatorHeight: dragIndicatorHeight,
+      topPadding: dragIndicatorTopPadding,
       color: dragIndicatorColor,
       onDismiss: onDismiss,
     );
@@ -347,11 +353,15 @@ class _SheetLayout extends StatelessWidget {
 class _SheetHandleZone extends StatelessWidget {
   const _SheetHandleZone({
     required this.indicatorWidth,
+    required this.indicatorHeight,
+    required this.topPadding,
     this.color,
     this.onDismiss,
   });
 
   final double indicatorWidth;
+  final double indicatorHeight;
+  final double topPadding;
   final Color? color;
   final VoidCallback? onDismiss;
 
@@ -364,10 +374,11 @@ class _SheetHandleZone extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const SizedBox(height: 8),
+          SizedBox(height: topPadding),
           _GlassDragIndicator(
             isGlass: isGlass,
             width: indicatorWidth,
+            height: indicatorHeight,
             color: color,
             onDismiss: onDismiss,
           ),
@@ -382,12 +393,14 @@ class _GlassDragIndicator extends StatelessWidget {
   const _GlassDragIndicator({
     required this.isGlass,
     required this.width,
+    required this.height,
     this.color,
     this.onDismiss,
   });
 
   final bool isGlass;
   final double width;
+  final double height;
   final Color? color;
   final VoidCallback? onDismiss;
 
@@ -404,10 +417,10 @@ class _GlassDragIndicator extends StatelessWidget {
       onTap: onDismiss ?? () => Navigator.maybePop(context),
       child: Container(
         width: width,
-        height: 4,
+        height: height,
         decoration: BoxDecoration(
           color: color ?? defaultColor,
-          borderRadius: BorderRadius.circular(2),
+          borderRadius: BorderRadius.circular(height / 2),
         ),
       ),
     );
@@ -805,6 +818,13 @@ class GlassModalSheetScaffold extends StatelessWidget {
   /// too subtle relative to the rest of the sheet's content.
   final double dragIndicatorWidth;
 
+  /// Thickness of the drag handle pill in logical pixels. Defaults to 4.
+  final double dragIndicatorHeight;
+
+  /// Gap between the sheet's top edge and the drag handle pill. Defaults
+  /// to 8.
+  final double dragIndicatorTopPadding;
+
   /// Whether to enable a gradient fade effect at the top.
   final bool enableTopFade;
 
@@ -878,6 +898,8 @@ class GlassModalSheetScaffold extends StatelessWidget {
     this.showDragIndicator = true,
     this.dragIndicatorColor,
     this.dragIndicatorWidth = 36,
+    this.dragIndicatorHeight = 4,
+    this.dragIndicatorTopPadding = 8,
     this.glowColor,
     this.glowRadius = 1.5,
     this.suppressInteractionOnChildren = false,
@@ -947,6 +969,8 @@ class GlassModalSheetScaffold extends StatelessWidget {
           showDragIndicator: showDragIndicator,
           dragIndicatorColor: dragIndicatorColor,
           dragIndicatorWidth: dragIndicatorWidth,
+          dragIndicatorHeight: dragIndicatorHeight,
+          dragIndicatorTopPadding: dragIndicatorTopPadding,
           glowColor: glowColor,
           glowRadius: glowRadius,
           suppressInteractionOnChildren: suppressInteractionOnChildren,

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -958,6 +958,8 @@ class _GlassModalSheetState extends State<GlassModalSheet>
           showDragIndicator: widget.showDragIndicator,
           dragIndicatorColor: widget.dragIndicatorColor,
           dragIndicatorWidth: widget.dragIndicatorWidth,
+          dragIndicatorHeight: widget.dragIndicatorHeight,
+          dragIndicatorTopPadding: widget.dragIndicatorTopPadding,
           colorOpacity: metrics.colorOpacity,
           glassOpacity: metrics.glassOpacity,
           effectiveExpandedColor: metrics.effectiveExpandedColor,

--- a/test/widgets/overlays/glass_modal_sheet_drag_indicator_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_drag_indicator_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import '../../shared/test_helpers.dart';
+
+/// The drag indicator pill's geometry: width, thickness and top inset.
+void main() {
+  Future<void> pumpSheet(
+    WidgetTester tester, {
+    double? width,
+    double? height,
+    double? topPadding,
+  }) async {
+    await tester.pumpWidget(
+      createTestApp(
+        child: Stack(
+          children: [
+            GlassModalSheet(
+              initialState: GlassSheetState.half,
+              dragIndicatorWidth: width ?? 36,
+              dragIndicatorHeight: height ?? 4,
+              dragIndicatorTopPadding: topPadding ?? 8,
+              child: const SizedBox(height: 400, child: Text('Content')),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  // The pill is the child of the 'Drag handle' Semantics node, which wraps
+  // it exactly, so that node's size and position are the pill's.
+  Finder handle() => find.byWidgetPredicate(
+      (w) => w is Semantics && w.properties.label == 'Drag handle');
+
+  group('GlassModalSheet drag indicator geometry', () {
+    testWidgets('defaults are 36 × 4, 8 below the sheet top', (tester) async {
+      await pumpSheet(tester);
+      expect(tester.getSize(handle()), const Size(36, 4));
+    });
+
+    testWidgets('dragIndicatorWidth and dragIndicatorHeight size the pill',
+        (tester) async {
+      await pumpSheet(tester, width: 54, height: 5);
+      expect(tester.getSize(handle()), const Size(54, 5));
+    });
+
+    testWidgets('dragIndicatorTopPadding moves the pill, not the sheet',
+        (tester) async {
+      await pumpSheet(tester);
+      final defaultTop = tester.getTopLeft(handle()).dy;
+      await pumpSheet(tester, topPadding: 14 / 3);
+      final movedTop = tester.getTopLeft(handle()).dy;
+      // The sheet rests at the same detent; only the pill's inset changed.
+      expect(defaultTop - movedTop, closeTo(8 - 14 / 3, 0.01));
+    });
+  });
+}


### PR DESCRIPTION
`GlassModalSheet` exposes the drag indicator's width and colour, but its thickness (4pt) and the gap above it (8pt) are fixed. A host whose other sheets draw their own pill can't make the package's match, and 8pt down also puts the pill close to a header row laid out under the handle zone.

This adds two parameters alongside `dragIndicatorWidth`:

- `dragIndicatorHeight` — pill thickness, default 4 (unchanged)
- `dragIndicatorTopPadding` — gap from the sheet's top edge, default 8 (unchanged)

Both flow through `GlassModalSheet`, `GlassModalSheet.scaffold`, the internal sheet and `_SheetHandleZone`; the pill's corner radius follows its height. Defaults are untouched, so existing sheets render exactly as before.

Why parameters rather than new defaults: measuring Apple's own apps, the pill's thickness, width and inset differ from sheet to sheet, and Maps sits it higher where a control row follows directly beneath. There isn't one right value to bake in; there is a per-sheet choice the host should be able to make.

Tests: `glass_modal_sheet_drag_indicator_test.dart` covers the defaults, the sized pill, and that the top padding moves the pill without moving the sheet. Changelog entry under 1.3.1 → New Features.