### PR TITLE
GlassModalSheet: refresh the cached window size when it is still zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Thanks to [@JakeThomson](https://github.com/JakeThomson) for the fix and on-devi
 
 - **`GlassModalSheetController.progress` and `value` are current inside `progressListenable` (#285):** Both reported the position the sheet had last *built* at, and the listener fires before that build — a frame behind, so the final tick of any drag never showed where the sheet stopped. They now refresh on every controller tick, before listeners run.
 
+- **`GlassModalSheet` drags after a background launch (#290):** The sheet read the window size once, in its first post-frame callback, and re-read it only on a change *from* a non-zero size. An app the system launches in the background for a push builds against a 0×0 window, so a sheet created then kept the zero for life: when the app came to the foreground, its first drag divided by that zero and parked the sheet at infinity — nothing painted, no `onStateChanged`, and every later `snapToState` starting from infinity — until the process was killed. The size is now taken from the view whenever the cache still holds that zero and refreshed on every window-size change, and a drag on a window with no size is ignored.
+
 ---
 
 # 1.3.0

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -50,7 +50,19 @@ class _GlassModalSheetState extends State<GlassModalSheet>
 
   // ── Geometry & Metrics ────────────────────────────────────────────────────
   late SheetGeometry _geometry;
-  Size _screenSize = Size.zero;
+
+  /// The view size the drag math divides by, cached because pointer moves
+  /// arrive faster than an inherited lookup is worth. Read it through
+  /// [_screenSize], which refreshes a cache still holding the zero it was
+  /// born with: a sheet built before the window has a size — an app the
+  /// system launched in the background for a push, a test on a zero-size
+  /// view — would otherwise keep that zero for life and divide every drag
+  /// by it.
+  Size _cachedScreenSize = Size.zero;
+  Size get _screenSize {
+    if (_cachedScreenSize.isEmpty && mounted) _updateScreenSize();
+    return _cachedScreenSize;
+  }
 
   @override
   void initState() {
@@ -139,10 +151,15 @@ class _GlassModalSheetState extends State<GlassModalSheet>
     if (!mounted) return;
 
     final view = View.of(context);
-    // Filter system call spam: the spring only jitters if the window size actually changes
+    // Filter system call spam: the spring only jitters if the window size
+    // actually changes.
     if (_lastPhysicalSize != view.physicalSize) {
+      _updateScreenSize();
+      // A window that had no size is being sized for the first time (an app
+      // launched in the background, coming to the foreground), not resized:
+      // there is nothing to re-settle, and the size cache above is all that
+      // first size has to update.
       if (_lastPhysicalSize != Size.zero) {
-        _updateScreenSize();
         _snapToState(_currentState, animate: true);
       }
       _lastPhysicalSize = view.physicalSize;
@@ -186,7 +203,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
 
   void _updateScreenSize() {
     final view = View.of(context);
-    _screenSize = view.physicalSize / view.devicePixelRatio;
+    _cachedScreenSize = view.physicalSize / view.devicePixelRatio;
   }
 
   // ════════════════════════════════════════════════════════════════════════
@@ -490,11 +507,15 @@ class _GlassModalSheetState extends State<GlassModalSheet>
   // ════════════════════════════════════════════════════════════════════════
 
   void _applyDrag(double currentY) {
+    final screenHeight = _screenSize.height;
+    // No sized window means nothing visible is being dragged; dividing by
+    // zero here would park the sheet at infinity for good.
+    if (screenHeight <= 0) return;
     final delta = currentY - _gestureArena.dragStartY;
     double newPosition =
-        _gestureArena.dragStartSheetPosition - delta / _screenSize.height;
+        _gestureArena.dragStartSheetPosition - delta / screenHeight;
 
-    newPosition = _geometry.applyResistance(newPosition, _screenSize.height,
+    newPosition = _geometry.applyResistance(newPosition, screenHeight,
         resistance: widget.resistance);
     _animationController.value = newPosition;
 

--- a/test/widgets/overlays/glass_modal_sheet_zero_size_view_test.dart
+++ b/test/widgets/overlays/glass_modal_sheet_zero_size_view_test.dart
@@ -1,0 +1,110 @@
+// A sheet built while the window has no size — an app the system launched
+// in the background for a push, before it was ever shown — must pick up the
+// real size when it arrives and drag normally afterwards. It used to keep
+// the zero for life and divide every drag by it.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+import '../../shared/test_helpers.dart';
+
+const _content = Key('content');
+const _screen = Size(1320, 2868);
+const _dpr = 3.0;
+const _halfSize = 500.0;
+final _halfPosition = _halfSize / (_screen.height / _dpr);
+
+Widget _sheetApp(
+  GlassModalSheetController controller,
+  List<GlassSheetState> log,
+) =>
+    createTestApp(
+      child: Stack(
+        children: [
+          GlassModalSheet(
+            controller: controller,
+            initialState: GlassSheetState.hidden,
+            detents: const {GlassSheetDetent.medium},
+            halfSize: _halfSize,
+            quality: GlassQuality.minimal,
+            onStateChanged: log.add,
+            child: const SizedBox(key: _content, height: 300),
+          ),
+        ],
+      ),
+    );
+
+/// Builds the sheet on a 0×0 view, then sizes the view (the app coming to
+/// the foreground) and opens the sheet to half.
+Future<void> _pumpLaunchedInBackground(
+  WidgetTester tester,
+  GlassModalSheetController controller,
+  List<GlassSheetState> log,
+) async {
+  tester.view.physicalSize = Size.zero;
+  tester.view.devicePixelRatio = _dpr;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(_sheetApp(controller, log));
+  await tester.pump(); // the sheet's post-frame size read sees 0×0
+  tester.view.physicalSize = _screen;
+  await tester.pump();
+  controller.snapToState(GlassSheetState.half);
+  await tester.pumpAndSettle();
+  expect(controller.currentState, GlassSheetState.half);
+  expect(controller.value, closeTo(_halfPosition, 0.001));
+}
+
+void main() {
+  group('GlassModalSheet — built before the window has a size', () {
+    testWidgets('a short upward drag settles back at half', (tester) async {
+      final controller = GlassModalSheetController();
+      final log = <GlassSheetState>[];
+      await _pumpLaunchedInBackground(tester, controller, log);
+
+      await tester.drag(find.byKey(_content), const Offset(0, -20));
+      await tester.pumpAndSettle();
+
+      expect(controller.value, closeTo(_halfPosition, 0.001));
+      expect(controller.currentState, GlassSheetState.half);
+      expect(log, [GlassSheetState.half]);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('an upward flick keeps a finite position', (tester) async {
+      final controller = GlassModalSheetController();
+      final log = <GlassSheetState>[];
+      await _pumpLaunchedInBackground(tester, controller, log);
+
+      await tester.fling(find.byKey(_content), const Offset(0, -40), 2000);
+      await tester.pumpAndSettle();
+
+      expect(controller.value.isFinite, isTrue);
+      expect(controller.value, closeTo(_halfPosition, 0.001));
+      expect(controller.currentState, GlassSheetState.half);
+      expect(log, [GlassSheetState.half]);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('a long downward drag still dismisses', (tester) async {
+      final controller = GlassModalSheetController();
+      final log = <GlassSheetState>[];
+      await _pumpLaunchedInBackground(tester, controller, log);
+
+      // Frames between the moves and the release, as a finger gets.
+      final gesture =
+          await tester.startGesture(tester.getCenter(find.byKey(_content)));
+      await gesture.moveBy(const Offset(0, 40));
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, 360));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(controller.value, closeTo(0.0, 0.001));
+      expect(controller.currentState, GlassSheetState.hidden);
+      expect(log, [GlassSheetState.half, GlassSheetState.hidden]);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
A sheet caches the window size in its first post-frame callback and re-reads it only on a metrics change *from* a non-zero size. An app the system launches in the background for a push builds against a 0×0 window, so a sheet created then keeps the zero for life. When the app comes to the foreground, its first drag divides by that zero: the position goes to infinity, the release resolves to `half` with no state change, and every later `snapToState` starts from infinity. In release nothing paints and the host still believes the sheet is open, until the process is killed.

This refreshes the cache from the view whenever it still holds zero, refreshes it on every window-size change while keeping the re-snap for real resizes, and ignores a drag on a window with no size.

Three widget tests build the sheet on a zero-size view, size it, and check a short drag, a flick, and a full dismiss. The dismiss test pumps frames between moves, as a finger does.

Seen in the wild: a plan-details sheet in our app vanished on its first touch after iOS had launched the app in the background for a silent push, with the host's tab bar left hidden and the sheet unrecoverable until relaunch.
