### PR TITLE
fix(GlassNavigationShell): defer animation ticks that land in the build phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.1
+
+## Bug Fixes
+
+- **`GlassNavigationShell` no longer marks its chrome dirty mid-build (#293):** The shell listens to every registered route's animations and re-resolved the pinned chrome synchronously on each tick. A page-based `Navigator` applies its pages inside `didUpdateWidget` — the build phase — and a route with no transition completes its animation right there, so the tick landed as `setState() or markNeedsBuild() called during build` on the chrome's `ListenableBuilder` for every such push and pop, and the chrome missed that frame. Ticks now defer past build the way status changes already did.
+
 # 1.4.0
 
 ## Features

--- a/lib/widgets/surfaces/glass_navigation_shell.dart
+++ b/lib/widgets/surfaces/glass_navigation_shell.dart
@@ -303,7 +303,11 @@ class GlassNavigationShellState extends State<GlassNavigationShell>
     animation.removeStatusListener(_onAnimationStatus);
   }
 
-  void _onAnimationTick() => _tick.notify();
+  // A route wiring its secondary animation (`ProxyAnimation.parent=` inside
+  // `didChangeNext`) notifies value listeners synchronously, and for a
+  // page-based Navigator that runs inside `didUpdateWidget` — the build
+  // phase — so the tick has to defer exactly as a status change does.
+  void _onAnimationTick() => _scheduleNotify();
 
   void _onAnimationStatus(AnimationStatus status) {
     // Not while a finger is down: several routes' animations are listened to

--- a/test/widgets/surfaces/glass_navigation_shell_test.dart
+++ b/test/widgets/surfaces/glass_navigation_shell_test.dart
@@ -1065,6 +1065,55 @@ void main() {
     });
   });
 
+  group('page-based navigators', () {
+    testWidgets(
+        'a pages update that drives a route animation does not mark '
+        'the chrome dirty mid-build', (tester) async {
+      // A declarative Navigator applies its pages inside didUpdateWidget —
+      // the build phase. Wiring a secondary animation there
+      // (ProxyAnimation.parent=) and starting a pop's reverse both notify
+      // value listeners synchronously, so the shell's tick has to defer or
+      // the chrome's ListenableBuilder is marked dirty mid-build.
+      final key = GlobalKey<_PagesNavigatorState>();
+      await tester.pumpWidget(_PagesApp(navigatorKey: key));
+      await settle(tester);
+
+      key.currentState!.push(const _Screen(title: 'Detail', actions: []));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+      await settle(tester);
+      expect(find.text('Detail'), findsOneWidget);
+
+      key.currentState!.pop();
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+      await settle(tester);
+      expect(find.text('Detail'), findsNothing);
+    });
+
+    testWidgets('and neither does a route with no transition', (tester) async {
+      // A zero-duration route completes its animation synchronously inside
+      // the same didUpdateWidget, which is the case that notifies value
+      // listeners rather than only status listeners.
+      final key = GlobalKey<_PagesNavigatorState>();
+      await tester.pumpWidget(_PagesApp(navigatorKey: key));
+      await settle(tester);
+
+      key.currentState!
+          .push(const _Screen(title: 'Instant', actions: []), instant: true);
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+      await settle(tester);
+      expect(find.text('Instant'), findsOneWidget);
+
+      key.currentState!.pop();
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+      await settle(tester);
+      expect(find.text('Instant'), findsNothing);
+    });
+  });
+
   group('fallback rendering', () {
     Finder inRouteCapsule() => find.descendant(
           of: find.byType(GlassAppBar),
@@ -1296,4 +1345,73 @@ class _TogglingScreenState extends State<_TogglingScreen> {
       ),
     );
   }
+}
+
+/// A root-level page-based Navigator under the shell whose pages change
+/// with setState BELOW the shell — the way go_router's Router sits inside
+/// an app's builder-installed shell. The rebuild that applies the pages then
+/// starts beneath the chrome, not above it.
+class _PagesApp extends StatelessWidget {
+  const _PagesApp({required this.navigatorKey});
+
+  final GlobalKey<_PagesNavigatorState> navigatorKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      builder: (context, _) => GlassNavigationShell(
+        child: _PagesNavigator(key: navigatorKey),
+      ),
+    );
+  }
+}
+
+class _PagesNavigator extends StatefulWidget {
+  const _PagesNavigator({super.key});
+
+  @override
+  State<_PagesNavigator> createState() => _PagesNavigatorState();
+}
+
+class _PagesNavigatorState extends State<_PagesNavigator> {
+  final _pages = <Page<void>>[
+    const CupertinoPage<void>(
+      key: ValueKey('root'),
+      child: _Screen(title: 'Root', actions: []),
+    ),
+  ];
+
+  void push(Widget screen, {bool instant = false}) => setState(() {
+        final key = ValueKey(_pages.length);
+        _pages.add(
+          instant
+              ? _InstantPage(key: key, child: screen)
+              : CupertinoPage<void>(key: key, child: screen),
+        );
+      });
+
+  void pop() => setState(() => _pages.removeLast());
+
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      pages: List.of(_pages),
+      onDidRemovePage: (page) => _pages.remove(page),
+    );
+  }
+}
+
+/// A page whose route has no transition, like a `NoTransitionPage`.
+class _InstantPage extends Page<void> {
+  const _InstantPage({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Route<void> createRoute(BuildContext context) => PageRouteBuilder<void>(
+        settings: this,
+        transitionDuration: Duration.zero,
+        reverseTransitionDuration: Duration.zero,
+        pageBuilder: (_, __, ___) => child,
+      );
 }


### PR DESCRIPTION
## Description

`GlassNavigationShell` listens to every registered route's `animation` and `secondaryAnimation` and re-resolves the pinned chrome on each tick through a `ChangeNotifier` that the chrome's `ListenableBuilder` rebuilds on. `_onAnimationTick` notified synchronously.

A page-based `Navigator` applies its pages inside `didUpdateWidget`, which is the build phase, and two things there notify value listeners synchronously: a route with no transition completes its animation at once in `_animateToInternal`, so a pop's `reverse()` ticks mid-build, and wiring a route's secondary animation (`ProxyAnimation.parent=`) notifies when the neighbour's value differs from the proxy's, which it does when that neighbour is a completed zero-duration route. The chrome's `ListenableBuilder` is a sibling of the `Navigator`, not a descendant of the rebuilding `Router`, so the mark is refused: `setState() or markNeedsBuild() called during build` on every such push and pop, and the chrome misses that frame. In a go_router app whose tab roots are `NoTransitionPage`s, that is every tab switch.

The shell already defers status changes past build for this reason (`_scheduleNotify`), but not value ticks. This routes `_onAnimationTick` through the same deferral: a tick that lands in `persistentCallbacks` or `midFrameMicrotasks` is queued to one coalesced post-frame notification, and any other tick notifies inline as before.

The new test mounts a root-level `Navigator(pages:)` under the shell with the page state held **below** the shell (where go_router's `Router` sits), pushes and pops a `PageRouteBuilder` page with `transitionDuration: Duration.zero`, and asserts no exception after the pump that applies the pages. It fails on 1.4.0 with the error above and passes with the change. The 1.4.0 test commit removed the same kind of synchronous tick listener from `GlassMenu` and `GlassPopover`; the shell had the same problem.

Fixes #293

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Platforms Tested

- [x] iOS (Impeller)
- [ ] Android (Impeller)
- [ ] macOS
- [ ] Windows
- [ ] Web
- [ ] Linux

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (shaders, painting logic)
- [x] I have made corresponding changes to the documentation / CHANGELOG.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/golden tests pass locally (`flutter test`)
