### PR TITLE
fix(GlassNavigationShell): dissolve a custom item's own glass through its surface, not a paint layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **Custom bar items that draw their own glass no longer flash across a push or pop:** The pinned chrome fades and blurs item content by painting it under opacity and image-filter layers, and a glass surface painted under either has no backdrop to sample — a `GlassBarItem.custom` carrying its own `GlassButton.custom` capsule rendered as its opaque backer for the whole transition and snapped to glass on the last frame. `GlassBarItemBackground.own` marks such an item, and the cluster dissolves it through the surface's own visibility instead.
 
+- **Pinned clusters now dissolve across a push or pop instead of popping in and out:** `GlassMenu` wraps its trigger in a resting `GlassMaterializeScope` so the trigger can fade under an open menu, and every pinned cluster sits inside that wrapper — so the materialize the shell runs around a cluster only one route has never reached the glass. The outgoing shell stayed solid until it was dropped, the incoming one appeared solid, and for a few frames both were drawn. The menu's scope now composes with an enclosing one.
+
 # 1.4.1
 
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.2
+
+## Bug Fixes
+
+- **Custom bar items that draw their own glass no longer flash across a push or pop:** The pinned chrome fades and blurs item content by painting it under opacity and image-filter layers, and a glass surface painted under either has no backdrop to sample — a `GlassBarItem.custom` carrying its own `GlassButton.custom` capsule rendered as its opaque backer for the whole transition and snapped to glass on the last frame. `GlassBarItemBackground.own` marks such an item, and the cluster dissolves it through the surface's own visibility instead.
+
 # 1.4.1
 
 ## Bug Fixes

--- a/docs/GLASS_NAVIGATION_TRANSITION.md
+++ b/docs/GLASS_NAVIGATION_TRANSITION.md
@@ -136,7 +136,10 @@ bar.
   `separate` (`sharesBackground: NO` — its own shell, which at a lone icon's
   size is the circular button the back button already is), and `none`
   (`hidesSharedBackground` — no glass, for content that carries its own shape,
-  such as a profile photo).
+  such as a profile photo). A fourth, `own`, is `none` for content that is
+  itself a glass surface: the shell dissolves it through the surface's own
+  visibility instead of fading it under a layer, which a glass surface cannot
+  survive.
 - **`id` mirrors `UIBarButtonItem.identifier`.** Items sharing an `id` across
   two routes are treated as the same item and hold their position while
   everything around them morphs. Without an `id`, items are matched

--- a/lib/widgets/overlays/shared/glass_menu_internal.dart
+++ b/lib/widgets/overlays/shared/glass_menu_internal.dart
@@ -262,6 +262,13 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
                 child: widget.trigger,
               );
 
+        // Composed with any enclosing scope rather than replacing it. The
+        // scope is unconditional so the trigger's element survives a menu
+        // open, but on its own it shadowed a materialize running above —
+        // a pinned cluster dissolving across a route transition sits inside
+        // this wrapper and never saw its fade.
+        final outer = GlassMaterializeScope.maybeOf(context);
+
         return Stack(
           clipBehavior: Clip.none,
           children: [
@@ -271,9 +278,11 @@ class _GlassMenuState extends State<GlassMenu> with TickerProviderStateMixin {
               child: Opacity(
                 opacity: triggerOpacity,
                 child: GlassMaterializeScope(
-                  glassProgress: triggerOpacity,
-                  contentOpacity: triggerOpacity,
-                  contentSigma: 0.0,
+                  glassProgress:
+                      triggerOpacity * (outer?.glassProgress ?? 1.0),
+                  contentOpacity:
+                      triggerOpacity * (outer?.contentOpacity ?? 1.0),
+                  contentSigma: outer?.contentSigma ?? 0.0,
                   child: IgnorePointer(
                     ignoring: isMenuBlocking,
                     child: triggerChild,

--- a/lib/widgets/surfaces/glass_bar_item.dart
+++ b/lib/widgets/surfaces/glass_bar_item.dart
@@ -7,7 +7,8 @@ import '../overlays/glass_menu.dart';
 /// Mirrors the two booleans iOS 26 added to `UIBarButtonItem`:
 /// `sharesBackground` (default `YES`) and `hidesSharedBackground` (default
 /// `NO`). Their four combinations describe three distinct results, which are
-/// the three values here.
+/// the first three values here; [own] is [none] for content that is itself
+/// glass.
 ///
 /// Both are documented as being ignored for an item inside an explicit group
 /// of more than one; the equivalent here is that [GlassBarItemBackground.shared]
@@ -33,18 +34,12 @@ enum GlassBarItemBackground {
 
   /// The item's content is itself a glass surface.
   ///
-  /// Like [none], nothing is drawn behind it. The difference is how it
-  /// dissolves across a push or pop: the pinned chrome fades and blurs
-  /// ordinary content by painting it under opacity and image-filter layers,
-  /// and a glass surface painted under either has no backdrop to sample —
-  /// it renders as its opaque backer until the layer is gone, then snaps to
-  /// glass on the last frame. An [own] item is dissolved through the
-  /// surface's own visibility instead, the same channel `GlassMaterialize`
-  /// uses, which every package surface honours.
-  ///
-  /// For a custom capsule built from `GlassButton.custom` or another package
-  /// surface. Plain content should stay [none], where the cluster's own fade
-  /// still applies.
+  /// `hidesSharedBackground = YES`, as [none] — but the pinned chrome fades
+  /// and blurs ordinary content under opacity and image-filter layers, and a
+  /// glass surface painted under either has no backdrop to sample. An [own]
+  /// item dissolves through its surface's own visibility instead, the channel
+  /// `GlassMaterialize` uses. For a capsule built from `GlassButton.custom`;
+  /// plain content stays [none].
   own,
 }
 

--- a/lib/widgets/surfaces/glass_bar_item.dart
+++ b/lib/widgets/surfaces/glass_bar_item.dart
@@ -30,6 +30,22 @@ enum GlassBarItemBackground {
   /// a profile photo, a coloured badge — where a capsule behind it would read
   /// as a second, competing surface.
   none,
+
+  /// The item's content is itself a glass surface.
+  ///
+  /// Like [none], nothing is drawn behind it. The difference is how it
+  /// dissolves across a push or pop: the pinned chrome fades and blurs
+  /// ordinary content by painting it under opacity and image-filter layers,
+  /// and a glass surface painted under either has no backdrop to sample —
+  /// it renders as its opaque backer until the layer is gone, then snaps to
+  /// glass on the last frame. An [own] item is dissolved through the
+  /// surface's own visibility instead, the same channel `GlassMaterialize`
+  /// uses, which every package surface honours.
+  ///
+  /// For a custom capsule built from `GlassButton.custom` or another package
+  /// surface. Plain content should stay [none], where the cluster's own fade
+  /// still applies.
+  own,
 }
 
 /// A single item in a pinned navigation-bar cluster.

--- a/lib/widgets/surfaces/glass_pinned_bar_chrome.dart
+++ b/lib/widgets/surfaces/glass_pinned_bar_chrome.dart
@@ -333,7 +333,7 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
   /// One group of items, drawn as the shell it asked for.
   Widget _buildGroup(GlassNavBarGroup group) {
     if (_handedOver) return _measuringGroup(group);
-    if (group.background == GlassBarItemBackground.none) {
+    if (!group.glass) {
       final item = group.items.single;
       return Semantics(
         button: true,

--- a/lib/widgets/surfaces/shared/glass_nav_pinned_host.dart
+++ b/lib/widgets/surfaces/shared/glass_nav_pinned_host.dart
@@ -5,6 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
 
+import '../../../src/renderer/internal/glass_materialize_scope.dart';
 import '../../../src/renderer/liquid_glass_renderer.dart';
 import '../../../types/glass_quality.dart';
 import '../../../utils/glass_spring.dart';
@@ -435,7 +436,9 @@ class GlassNavBarGroup {
   final GlassBarItemBackground background;
 
   /// Whether a glass shell is drawn behind [items].
-  bool get glass => background != GlassBarItemBackground.none;
+  bool get glass =>
+      background != GlassBarItemBackground.none &&
+      background != GlassBarItemBackground.own;
 
   /// Height of the shell, and of an icon slot inside it.
   ///
@@ -1402,6 +1405,44 @@ class _PinnedGroupState extends State<_PinnedGroup> {
     final inSigma =
         state.settled ? 0.0 : GlassNavPinnedMetrics.incomingSigmaAt(morphT);
 
+    // An item whose content is itself glass cannot be faded or blurred from
+    // outside: painted under an opacity or image-filter layer it has no
+    // backdrop to sample, and renders as its backer until the layer is gone.
+    // Those items dissolve through GlassMaterializeScope instead, which every
+    // package surface honours, and the cluster paints them plain. The scope
+    // sits here, below the GlassMenu wrapper, so it is the nearest one; it
+    // still composes with any enclosing scope, so a menu morph can fade the
+    // trigger.
+    Widget clusterChild({
+      required int slot,
+      required bool isFrom,
+      required double opacity,
+      required double blurSigma,
+      required GlassBarActionItem item,
+      required Widget child,
+    }) {
+      if (item.background != GlassBarItemBackground.own) {
+        return _ClusterChild(
+          slot: slot,
+          isFrom: isFrom,
+          opacity: opacity,
+          blurSigma: blurSigma,
+          child: child,
+        );
+      }
+      return _ClusterChild(
+        slot: slot,
+        isFrom: isFrom,
+        opacity: 1.0,
+        blurSigma: 0.0,
+        child: _OwnGlassDissolve(
+          opacity: opacity,
+          sigma: blurSigma,
+          child: child,
+        ),
+      );
+    }
+
     final children = <Widget>[];
     for (var i = 0; i < slots.length; i++) {
       final slot = slots[i];
@@ -1416,11 +1457,12 @@ class _PinnedGroupState extends State<_PinnedGroup> {
           final visible =
               state.settled ? !showsIncoming : (morphing || q < 1.0);
           if (visible) {
-            children.add(_ClusterChild(
+            children.add(clusterChild(
               slot: i,
               isFrom: true,
               opacity: state.settled ? 1.0 : (1.0 - q),
               blurSigma: outSigma,
+              item: fromItem,
               child: _ClusterItem(
                 item: fromItem,
                 enabled: false,
@@ -1430,11 +1472,12 @@ class _PinnedGroupState extends State<_PinnedGroup> {
           }
         } else if (crossFades && (!state.settled ? q < 1.0 : !showsIncoming)) {
           // Cross-fading outgoing side.
-          children.add(_ClusterChild(
+          children.add(clusterChild(
             slot: i,
             isFrom: true,
             opacity: state.settled ? 1.0 : (1.0 - q),
             blurSigma: outSigma,
+            item: fromItem,
             child: _ClusterItem(
               item: fromItem,
               enabled: false,
@@ -1450,11 +1493,12 @@ class _PinnedGroupState extends State<_PinnedGroup> {
           // While transition is in-flight, keep mounted in morphing groups so natural width is preserved.
           final visible = state.settled ? showsIncoming : (morphing || q > 0.0);
           if (visible) {
-            children.add(_ClusterChild(
+            children.add(clusterChild(
               slot: i,
               isFrom: false,
               opacity: state.settled ? 1.0 : q,
               blurSigma: inSigma,
+              item: toItem,
               child: _ClusterItem(
                 item: toItem,
                 enabled: state.settled,
@@ -1465,11 +1509,12 @@ class _PinnedGroupState extends State<_PinnedGroup> {
           }
         } else if (!crossFades || (!state.settled ? q > 0.0 : showsIncoming)) {
           // Matched persistent item or cross-fading incoming side.
-          children.add(_ClusterChild(
+          children.add(clusterChild(
             slot: i,
             isFrom: false,
             opacity: crossFades ? (state.settled ? 1.0 : q) : 1.0,
             blurSigma: crossFades ? inSigma : 0.0,
+            item: toItem,
             child: _ClusterItem(
               item: toItem,
               enabled: state.settled,
@@ -1567,6 +1612,36 @@ class _PinnedGroupState extends State<_PinnedGroup> {
       canRequestFocus: false,
       excludeFromSemantics: true,
       child: ClipRect(child: cluster),
+    );
+  }
+}
+
+/// Dissolves a [GlassBarItemBackground.own] item through its own glass.
+///
+/// The cluster's fade and blur are handed to the item's surface as a
+/// [GlassMaterializeScope] — visibility for the glass, opacity and blur for
+/// the content inside it — in place of the paint-time layers ordinary items
+/// get. Composed with any enclosing scope rather than replacing it, so a
+/// menu fading its trigger still reaches the surface.
+class _OwnGlassDissolve extends StatelessWidget {
+  const _OwnGlassDissolve({
+    required this.opacity,
+    required this.sigma,
+    required this.child,
+  });
+
+  final double opacity;
+  final double sigma;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final outer = GlassMaterializeScope.maybeOf(context);
+    return GlassMaterializeScope(
+      glassProgress: opacity * (outer?.glassProgress ?? 1.0),
+      contentOpacity: opacity * (outer?.contentOpacity ?? 1.0),
+      contentSigma: math.max(sigma, outer?.contentSigma ?? 0.0),
+      child: child,
     );
   }
 }

--- a/test/widgets/surfaces/glass_nav_pinned_leading_test.dart
+++ b/test/widgets/surfaces/glass_nav_pinned_leading_test.dart
@@ -47,10 +47,12 @@ void main() {
 
   /// The [GlassMaterializeScope] closest above [finder].
   GlassMaterializeScope nearestScope(WidgetTester tester, Finder finder) =>
-      tester.widgetList<GlassMaterializeScope>(find.ancestor(
-        of: finder,
-        matching: find.byType(GlassMaterializeScope),
-      )).first;
+      tester
+          .widgetList<GlassMaterializeScope>(find.ancestor(
+            of: finder,
+            matching: find.byType(GlassMaterializeScope),
+          ))
+          .first;
 
   group('the automatic back button', () {
     testWidgets('a back-only cluster is still the 44pt circle', (tester) async {
@@ -201,15 +203,17 @@ void main() {
         (tester) async {
       await tester.pumpWidget(shellApp(const _Screen(title: 'Root')));
       await settle(tester);
-      await _push(tester, const _Screen(
-        title: 'Detail',
-        leading: [
-          GlassBarItem.custom(
-            child: SizedBox(width: 44, height: 44, child: Text('avatar')),
-            background: GlassBarItemBackground.none,
-          ),
-        ],
-      ));
+      await _push(
+          tester,
+          const _Screen(
+            title: 'Detail',
+            leading: [
+              GlassBarItem.custom(
+                child: SizedBox(width: 44, height: 44, child: Text('avatar')),
+                background: GlassBarItemBackground.none,
+              ),
+            ],
+          ));
       await tester.pump(const Duration(milliseconds: 250));
 
       // Only the menu wrapper's resting scope: the item is faded at paint.

--- a/test/widgets/surfaces/glass_nav_pinned_leading_test.dart
+++ b/test/widgets/surfaces/glass_nav_pinned_leading_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/src/renderer/internal/glass_materialize_scope.dart';
 import 'package:liquid_glass_widgets/widgets/surfaces/shared/glass_nav_pinned_host.dart';
 
 void main() {
@@ -43,6 +44,13 @@ void main() {
         of: find.byType(GlassNavPinnedHost),
         matching: matching,
       );
+
+  /// The [GlassMaterializeScope] closest above [finder].
+  GlassMaterializeScope nearestScope(WidgetTester tester, Finder finder) =>
+      tester.widgetList<GlassMaterializeScope>(find.ancestor(
+        of: finder,
+        matching: find.byType(GlassMaterializeScope),
+      )).first;
 
   group('the automatic back button', () {
     testWidgets('a back-only cluster is still the 44pt circle', (tester) async {
@@ -163,6 +171,52 @@ void main() {
 
       expect(inHost(find.text('avatar')), findsOneWidget);
       expect(inHost(find.byType(GlassButton)), findsNothing);
+    });
+
+    testWidgets(
+        'an item that draws its own glass dissolves through the materialize '
+        'scope, not a layer', (tester) async {
+      await tester.pumpWidget(shellApp(const _Screen(title: 'Root')));
+      await settle(tester);
+      await _push(tester, _Screen(title: 'Detail', leading: [_ownCapsule()]));
+
+      // Mid cross-fade, where an ordinary item is painted under an opacity
+      // layer. A glass surface under one has no backdrop to sample, so the
+      // cluster hands the fade to the surface itself instead.
+      await tester.pump(const Duration(milliseconds: 250));
+      final scope = nearestScope(tester, inHost(find.text('capsule')));
+      expect(scope.glassProgress, lessThan(1.0));
+      expect(scope.glassProgress, greaterThan(0.0));
+      expect(scope.contentSigma, greaterThan(0.0));
+
+      await settle(tester);
+      expect(
+        nearestScope(tester, inHost(find.text('capsule'))).glassProgress,
+        1.0,
+      );
+    });
+
+    testWidgets(
+        'plain content that hides its background keeps the cluster fade',
+        (tester) async {
+      await tester.pumpWidget(shellApp(const _Screen(title: 'Root')));
+      await settle(tester);
+      await _push(tester, const _Screen(
+        title: 'Detail',
+        leading: [
+          GlassBarItem.custom(
+            child: SizedBox(width: 44, height: 44, child: Text('avatar')),
+            background: GlassBarItemBackground.none,
+          ),
+        ],
+      ));
+      await tester.pump(const Duration(milliseconds: 250));
+
+      // Only the menu wrapper's resting scope: the item is faded at paint.
+      expect(
+        nearestScope(tester, inHost(find.text('avatar'))).glassProgress,
+        1.0,
+      );
     });
 
     testWidgets('a separate item is its own shell beside a shared capsule',
@@ -403,6 +457,15 @@ void main() {
     });
   });
 }
+
+/// A custom item that is a glass surface in its own right.
+GlassBarItem _ownCapsule() => GlassBarItem.custom(
+      background: GlassBarItemBackground.own,
+      child: GlassButton.custom(
+        onTap: () {},
+        child: const Text('capsule'),
+      ),
+    );
 
 GlassBarItem _cancel() => GlassBarItem.icon(
       icon: const Icon(CupertinoIcons.xmark),

--- a/test/widgets/surfaces/glass_nav_pinned_leading_test.dart
+++ b/test/widgets/surfaces/glass_nav_pinned_leading_test.dart
@@ -45,14 +45,15 @@ void main() {
         matching: matching,
       );
 
+  /// Every [GlassMaterializeScope] above [finder], nearest first.
+  Iterable<GlassMaterializeScope> scopesAbove(Finder finder) => find
+      .ancestor(of: finder, matching: find.byType(GlassMaterializeScope))
+      .evaluate()
+      .map((e) => e.widget as GlassMaterializeScope);
+
   /// The [GlassMaterializeScope] closest above [finder].
   GlassMaterializeScope nearestScope(WidgetTester tester, Finder finder) =>
-      tester
-          .widgetList<GlassMaterializeScope>(find.ancestor(
-            of: finder,
-            matching: find.byType(GlassMaterializeScope),
-          ))
-          .first;
+      scopesAbove(finder).first;
 
   group('the automatic back button', () {
     testWidgets('a back-only cluster is still the 44pt circle', (tester) async {
@@ -205,22 +206,41 @@ void main() {
       await settle(tester);
       await _push(
           tester,
-          const _Screen(
+          _Screen(
             title: 'Detail',
             leading: [
-              GlassBarItem.custom(
+              const GlassBarItem.custom(
                 child: SizedBox(width: 44, height: 44, child: Text('avatar')),
                 background: GlassBarItemBackground.none,
               ),
+              _ownCapsule(),
             ],
           ));
       await tester.pump(const Duration(milliseconds: 250));
 
-      // Only the menu wrapper's resting scope: the item is faded at paint.
-      expect(
-        nearestScope(tester, inHost(find.text('avatar'))).glassProgress,
-        1.0,
-      );
+      // Both sit under the group's own materialize; only the glass item gets
+      // the cluster's fade as a scope of its own. The avatar is faded at
+      // paint, as before.
+      final avatarScopes = scopesAbove(inHost(find.text('avatar')));
+      final capsuleScopes = scopesAbove(inHost(find.text('capsule')));
+      expect(capsuleScopes.length, avatarScopes.length + 1);
+    });
+
+    testWidgets(
+        'a cluster only one route has dissolves through the materialize',
+        (tester) async {
+      await tester.pumpWidget(shellApp(const _Screen(title: 'Root')));
+      await settle(tester);
+      await _push(tester, _Screen(title: 'Detail', leading: [_cancel()]));
+
+      // Inside the materialize window. The menu wrapper around every group
+      // used to install a resting scope of its own here, so the group's
+      // shell never saw this fade and popped in solid at the window's start.
+      await tester.pump(const Duration(milliseconds: 350));
+      final scope =
+          nearestScope(tester, inHost(find.byIcon(CupertinoIcons.xmark)));
+      expect(scope.glassProgress, lessThan(1.0));
+      expect(scope.glassProgress, greaterThan(0.0));
     });
 
     testWidgets('a separate item is its own shell beside a shared capsule',


### PR DESCRIPTION
## Description

`_RenderPinnedCluster._paintChildren` fades and blurs each item's content by painting it under an `OpacityLayer` while it cross-fades and an `ImageFilterLayer` while the glyph sharpens, on the assumption that item contents are not glass. A `GlassBarItem.custom` whose child is itself a glass surface — a `GlassButton.custom` capsule with `background: none`, the shape an app takes when it wants its own capsule in the bar — has no backdrop to sample inside either layer, so it renders as its backer (or nothing) for the whole transition and snaps to glass on the last frame, where the blur sigma finally reaches zero. On a pop the capsule vanishes on the first frame.

This adds `GlassBarItemBackground.own`: like `none`, nothing is drawn behind the item, but the cluster dissolves it through the surface's own visibility instead of a paint-time layer. `_OwnGlassDissolve` wraps such an item in a `GlassMaterializeScope` carrying the cluster's opacity as `glassProgress` and `contentOpacity` and its blur as `contentSigma`, composed with any enclosing scope so a menu morph can still fade the trigger; the cluster paints it plain. It sits at the cluster child, below the `GlassMenu` wrapper's own resting scope, so it is the nearest one. Plain `none` content keeps the layer fade — it is what gives an avatar or badge its cross-fade — and the in-route fallback treats `own` as `none`.

The new tests push a route with an `own` item and assert that mid cross-fade its nearest `GlassMaterializeScope` is partway through with a non-zero sigma, and settled at one after the transition; and that a `none` item at the same moment sees only the resting scope. The first fails on main and passes with the change.


A second commit fixes what the same recording showed once the item was `own`: the outgoing cluster stayed solid until the shell dropped it, the incoming one appeared solid, and for a few frames both were drawn. `GlassMenu` wraps its trigger in a resting `GlassMaterializeScope` so the trigger can fade under an open menu, and every pinned cluster sits inside that wrapper — so the materialize the shell runs around a cluster only one route has never reached the glass. The menu's scope now composes with an enclosing one. A test pushes a route whose leading cluster exists only on that route and asserts its nearest scope is partway through mid-materialize; it fails on main.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/a56f93ac-a4c3-4431-92f2-9e7348fec1d9" /> | <video src="https://github.com/user-attachments/assets/d75f96fb-f35e-4188-b3a2-38e4bf247efb" /> | 

Fixes #296

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Platforms Tested

- [x] iOS (Impeller)
- [ ] Android (Impeller)
- [ ] macOS
- [ ] Windows
- [ ] Web
- [ ] Linux

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (shaders, painting logic)
- [x] I have made corresponding changes to the documentation / CHANGELOG.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/golden tests pass locally (`flutter test`)


