### PR TITLE
fix: preserve dismissible sheet geometry without a small detent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Bug Fixes
+
+- **Dismissible modal sheets retain their frame below the lowest enabled detent:** Sheets without a small detent no longer jump to peek width, margins, or corners during dismissal. Large-only sheets slide away with their full frame; medium+large sheets preserve the medium frame below that detent.
+
 # 1.4.1
 
 ## Bug Fixes
@@ -3751,5 +3757,4 @@ The four optional stretch-axis override parameters introduced in 0.10.3 have bee
 | `allowNegativeYStretch` | `allowNegativeY` |
 
 All four remain optional with `null` defaults (auto-inferred from menu position). Only code explicitly passing the old names needs updating.
-
 

--- a/lib/widgets/overlays/shared/glass_modal_sheet_morph.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_morph.dart
@@ -417,14 +417,16 @@ class SheetMorphGeometry {
   /// The detent a swipe-to-dismiss drag falls away from.
   ///
   /// Mirrors the pivot `_calculateMetrics` drags from: the peek floor when
-  /// there is one, the half detent otherwise.
+  /// there is one, otherwise the lowest enabled visible detent.
   ///
   /// Deliberately *not* [SheetGeometry.minState], which is
   /// [GlassSheetState.hidden] for the common dismissible peek-less sheet —
   /// hidden is the position a swipe drags the sheet *to*, and measuring travel
   /// from it would read every drag as zero.
   static GlassSheetState dismissPivotState(SheetGeometry geometry) =>
-      geometry.enablePeek ? GlassSheetState.peek : GlassSheetState.half;
+      geometry.orderedStates.firstWhere(
+        (state) => state != GlassSheetState.hidden,
+      );
 
   /// How far the sheet has been dragged below its lowest detent, as a fraction
   /// of screen height.

--- a/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
+++ b/lib/widgets/overlays/shared/glass_modal_sheet_state.dart
@@ -590,6 +590,23 @@ class _GlassModalSheetState extends State<GlassModalSheet>
     required double bottomRadiusFull,
     required double fullPos,
   }) {
+    // Without a peek detent, dismissal translates the lowest enabled frame.
+    // Do not interpolate through disabled half/peek geometry on the way out:
+    // peekWidth and peek margins may describe a completely different surface.
+    double dismissOffset = 0.0;
+    if (widget.mode == GlassSheetMode.dismissible && !_geometry.enablePeek) {
+      final pivotPos = _geometry.positionForState(
+        SheetMorphGeometry.dismissPivotState(_geometry), mqHeight);
+      if (pos < pivotPos) {
+        dismissOffset = (pivotPos - pos) * mqHeight;
+        pos = pivotPos;
+        final expansionRange = fullPos - halfPos;
+        t = expansionRange > 0.0001
+            ? ((pos - halfPos) / expansionRange).clamp(0.0, 1.0)
+            : 1.0;
+      }
+    }
+
     late LiquidGlassSettings effectiveSettings;
     // Disable scaling in full state by lerping effective interactionScale to 1.0
     // Also disable scaling if we are interacting with a child (Smart Silence)
@@ -864,7 +881,7 @@ class _GlassModalSheetState extends State<GlassModalSheet>
     return _RenderMetrics(
       stretchT: stretchT,
       effectiveHeight: effectiveHeight,
-      effectiveBottom: effectiveBottom,
+      effectiveBottom: effectiveBottom - dismissOffset,
       topRadius: topRadius,
       bottomRadius: bottomRadius,
       hPad: hPad,

--- a/test/widgets/overlays/glass_sheet_dismiss_geometry_test.dart
+++ b/test/widgets/overlays/glass_sheet_dismiss_geometry_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+
+void main() {
+  for (final medium in [false, true]) {
+    testWidgets('dismiss geometry stays continuous (medium: $medium)',
+        (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final controller = GlassModalSheetController();
+      const contentKey = ValueKey('sheet-frame');
+      await tester.pumpWidget(MaterialApp(
+        home: GlassModalSheetScaffold(
+          controller: controller,
+          initialState: GlassSheetState.full,
+          mode: GlassSheetMode.dismissible,
+          detents: {
+            if (medium) GlassSheetDetent.medium,
+            GlassSheetDetent.large
+          },
+          fullSize: .9,
+          halfSize: .5,
+          horizontalMargin: 8,
+          bottomMargin: 6,
+          peekWidth: 240,
+          peekBottomMargin: 24,
+          enableInteractionGlow: false,
+          enableSaturationGlow: false,
+          interactionScale: 1,
+          padding: EdgeInsets.zero,
+          body: const SizedBox.expand(),
+          sheet: const SizedBox.expand(key: contentKey),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      final frame = find.byKey(contentKey);
+      var previous = tester.getRect(frame);
+      final gesture = await tester.startGesture(Offset(200, previous.top + 12));
+      await gesture.moveBy(const Offset(0, 20));
+      await tester.pump();
+      previous = tester.getRect(frame);
+      for (var i = 0; i < 125; i++) {
+        await gesture.moveBy(const Offset(0, 4));
+        await tester.pump();
+        final current = tester.getRect(frame);
+        expect((current.width - previous.width).abs(), lessThan(2),
+            reason: 'width jumped at drag step $i: $previous → $current');
+        expect(current.top - previous.top, closeTo(4, .02),
+            reason: 'the sheet must track the finger without a vertical jump');
+        if (!medium) {
+          expect(current.width, closeTo(400, .01),
+              reason: 'large-only dismissal should preserve the full frame');
+          expect(current.height, closeTo(previous.height, .01));
+        } else if (current.top > 400) {
+          expect(current.width, closeTo(384, .01),
+              reason: 'dismissal must preserve the medium frame, not peek');
+          expect(current.height, closeTo(394, .01));
+        }
+        previous = current;
+      }
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.currentState, GlassSheetState.hidden);
+      expect(tester.takeException(), isNull);
+    });
+  }
+}


### PR DESCRIPTION
## Description

Fix a width jump when dragging a dismissible `GlassModalSheetScaffold` with `{large}` or `{medium, large}` detents and distinct peek geometry. With `horizontalMargin: 8` and `peekWidth: 240` on a 400 px screen, crossing below the medium-height boundary changes the sheet width from 384 px to 240 px in a single 4 px drag step, even though the small detent is disabled.

The dismissal path currently uses peek geometry below that boundary, and `dismissPivotState` assumes medium exists whenever peek is absent. This change selects the lowest enabled visible detent and holds its render metrics while translating the sheet downward. Large-only sheets therefore slide between full and hidden with their full frame; medium+large sheets retain the medium frame during dismissal. Small-detent morphing is unchanged.

The regression tests drive the actual scaffold through the boundary in 4 px steps and check width continuity, finger tracking, fixed dismissal dimensions, and the final hidden state. Both cases fail against unpatched 1.4.1 and pass with this change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 Visual / shader change (impacts rendering output; no shader changes)

## Platforms Tested

Headless Flutter widget tests on macOS. 
Device/Impeller visual verified for dismissible `GlassModalSheetScaffold` with `{large}` or `{medium, large}` detents .

## Validation

- `flutter analyze --fatal-warnings` — passes.
- 169 tests pass across `glass_modal_sheet_mechanics_test.dart`, `glass_modal_sheet_morph_test.dart`, `glass_modal_sheet_state_coverage_test.dart`, `glass_modal_sheet_scroll_handover_test.dart`, and the new `glass_sheet_dismiss_geometry_test.dart`.
- Full package test suite and device visual checks have not been run for this draft.

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented the non-obvious dismissal geometry logic
- [x] I have updated CHANGELOG.md
- [x] I have added tests that prove the fix is effective
- [ ] Full unit/golden test suite passes locally (`flutter test`)

## Screenshots / Recordings

No device recording attached yet; the regression tests reproduce the frame discontinuity numerically.
