### PR TITLE
feat(GlassBarItem): present a sheet that morphs out of the pinned capsule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 1.4.3
+
+## Features
+
+- **`GlassBarItem.sheet` — a bar item whose sheet morphs out of the capsule (#303):** Nothing reached the capsule a pinned bar draws, so an app wanting the liquid morph had to hoist its cluster as one `GlassBarItemBackground.own` item and give up the cross-route morph. The new item hands its tap a `GlassMorphAnchor` for `GlassModalSheet.show(morphFrom:)` — the route's own capsule, which is the one still on screen once the sheet has handed the chrome back, and the only one a sheet can cover.
+
+  ```dart
+  GlassAppBar.pinned(
+    actions: [
+      GlassBarItem.sheet(
+        icon: const Icon(CupertinoIcons.add),
+        onPresent: (anchor) => GlassModalSheet.show<void>(
+          context: context,
+          morphFrom: anchor,
+          builder: (context) => const AddSheet(),
+        ),
+      ),
+    ],
+  )
+  ```
+
 # 1.4.2
 
 ## Bug Fixes

--- a/docs/GLASS_NAVIGATION_TRANSITION.md
+++ b/docs/GLASS_NAVIGATION_TRANSITION.md
@@ -159,6 +159,14 @@ bar.
   transition is running, and one already open is dismissed if navigation
   starts — the capsule outlives the route that owns the menu, so nothing else
   would take it down.
+- **`GlassBarItem.sheet` morphs the capsule into a `GlassModalSheet`.** Its
+  tap is handed a `GlassMorphAnchor` for `GlassModalSheet.show(morphFrom:)`,
+  and the whole capsule empties for it, for the same reason `menu` morphs the
+  whole capsule. The anchor is always the route's own capsule rather than the
+  hoisted copy: presenting hands the chrome back to the route, so that is the
+  one still on screen under the sheet — and the only one a sheet can cover,
+  since the hoisted chrome is drawn above the `Navigator`. A hoisted tap is
+  routed back to the bar that registered it.
 - **Participation is the constructor.** A `GlassAppBar.pinned` screen keeps
   the chrome pinned even with no actions; a plain `GlassAppBar` screen does
   not participate, and the pinned chrome retreats while it covers the bar.

--- a/example/lib/demos/nav_bar_patterns_demo.dart
+++ b/example/lib/demos/nav_bar_patterns_demo.dart
@@ -193,6 +193,14 @@ class NavBarPatternsDemo extends StatelessWidget {
                 ),
                 SizedBox(height: 16),
                 _PatternTile(
+                  title: 'Sheet From The Capsule',
+                  subtitle: 'GlassBarItem.sheet — the capsule empties and '
+                      'stretches into the sheet, hoisted or in-route',
+                  icon: CupertinoIcons.arrow_up_left_square,
+                  onTap: () => _push(context, const _SheetItemDemo()),
+                ),
+                SizedBox(height: 16),
+                _PatternTile(
                   title: 'Title Centering',
                   subtitle:
                       'Verifies title is centred on full bar width with asymmetric leading/trailing (fix #198)',
@@ -2279,6 +2287,124 @@ class _PresentedSheetsDemo extends StatelessWidget {
                   icon: CupertinoIcons.square_arrow_up,
                   onTap: () => _showFullscreenDialog(context),
                 ),
+              ],
+            ),
+          ),
+          _buildDummyContent(),
+          const SliverToBoxAdapter(child: SizedBox(height: 100)),
+        ],
+      ),
+    );
+  }
+}
+
+/// A trailing cluster whose first item morphs into a sheet.
+///
+/// The counterpart to [_PresentedSheetsDemo]: presenting hands the chrome back
+/// to the route, and the morph comes out of the capsule that lands there —
+/// which is why nothing is drawn where it was until the droplet is caught.
+/// Push into the second screen to see the same item morph across a route
+/// change as ordinary data.
+class _SheetItemDemo extends StatelessWidget {
+  const _SheetItemDemo({this.detail = false});
+
+  void _push(BuildContext context, Widget page) {
+    Navigator.of(context).push(
+      CupertinoPageRoute<void>(builder: (_) => page),
+    );
+  }
+
+  /// Whether this is the pushed screen, which carries a second action.
+  final bool detail;
+
+  void _present(BuildContext context, GlassMorphAnchor? anchor) {
+    GlassModalSheet.show<void>(
+      context: context,
+      morphFrom: anchor,
+      initialState: GlassSheetState.half,
+      builder: (_) => const _PresentedSheetBody(
+        title: 'Out of the capsule',
+        body: 'The capsule emptied, a droplet stretched out of it and became '
+            'this sheet. Dismiss it and the droplet is poured back into the '
+            'bar it came from.',
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final topPad = MediaQuery.paddingOf(context).top;
+
+    return GlassScaffold(
+      background: const ShowcaseBackground(),
+      settings: RecommendedGlassSettings.standard,
+      statusBarStyle: GlassStatusBarStyle.auto,
+      appBar: GlassAppBar.pinned(
+        title: Text(
+          detail ? 'Detail' : 'Sheet Item',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: CupertinoColors.label.resolveFrom(context),
+          ),
+        ),
+        actions: [
+          GlassBarItem.sheet(
+            icon: const Icon(CupertinoIcons.add),
+            label: 'Add',
+            id: 'add',
+            onPresent: (anchor) => _present(context, anchor),
+          ),
+          if (detail)
+            GlassBarItem.icon(
+              icon: const Icon(CupertinoIcons.share),
+              label: 'Share',
+              id: 'share',
+              onTap: () {},
+            ),
+          GlassBarItem.menu(
+            icon: const Icon(CupertinoIcons.ellipsis),
+            label: 'More',
+            id: 'more',
+            menuItems: [
+              GlassMenuItem(
+                title: 'Rename',
+                icon: const Icon(CupertinoIcons.pencil),
+                onTap: () {},
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(child: SizedBox(height: topPad + 44 + 16)),
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            sliver: SliverList.list(
+              children: [
+                Text(
+                  'Tap (+). The whole capsule empties — the ellipsis with it, '
+                  'because on screen the cluster is one control — and the '
+                  'droplet stretches out of its frame rather than out of the '
+                  'glyph. Nothing is drawn where the capsule was until the '
+                  'sheet is dismissed.',
+                  style: TextStyle(
+                    fontSize: 15,
+                    height: 1.4,
+                    color: CupertinoColors.secondaryLabel.resolveFrom(context),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                if (!detail)
+                  _PatternTile(
+                    title: 'Push To A Second Screen',
+                    subtitle: 'The item is ordinary data, so the capsule '
+                        'morphs across the push and (+) holds its place',
+                    icon: CupertinoIcons.arrow_right,
+                    onTap: () =>
+                        _push(context, const _SheetItemDemo(detail: true)),
+                  ),
               ],
             ),
           ),

--- a/lib/widgets/surfaces/glass_bar_item.dart
+++ b/lib/widgets/surfaces/glass_bar_item.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../overlays/glass_menu.dart';
+import '../overlays/glass_modal_sheet.dart';
 
 /// How an item's glass background is drawn.
 ///
@@ -126,6 +127,35 @@ sealed class GlassBarItem {
     String? label,
     GlassBarItemBackground background,
   }) = GlassBarMenuItem;
+
+  /// An icon whose tap presents a `GlassModalSheet` that morphs out of the
+  /// capsule, mirroring the iOS 26 bar button that grows into a sheet.
+  ///
+  /// [onPresent] is handed the [GlassMorphAnchor] of the capsule this item
+  /// sits in; pass it to `GlassModalSheet.show(morphFrom:)` and the capsule
+  /// empties, stretches into the sheet, and is poured back on dismissal. It is
+  /// the capsule rather than the icon's own slot for the reason
+  /// [GlassBarItem.menu] morphs the whole capsule: on screen the cluster is one
+  /// control, and a droplet crawling out of a hole in it reads as a second
+  /// object arriving.
+  ///
+  /// The anchor is always the one the *route's* bar owns, never the hoisted
+  /// copy — a presentation hands the chrome back to its route, so that is the
+  /// capsule still on screen once the sheet is up, and it is inside the
+  /// [Navigator] where the sheet can cover it. It is the group's own box where
+  /// the group draws no glass ([GlassBarItemBackground.none] and
+  /// [GlassBarItemBackground.own]).
+  ///
+  /// Dismiss the sheet before navigating, as an open [GlassMenu] is dismissed
+  /// for you.
+  const factory GlassBarItem.sheet({
+    required Widget icon,
+    required void Function(GlassMorphAnchor? anchor) onPresent,
+    Object? id,
+    String? label,
+    bool enabled,
+    GlassBarItemBackground background,
+  }) = GlassBarSheetItem;
 
   /// Splits the shared glass background, mirroring SwiftUI's
   /// `ToolbarSpacer(.fixed)` and UIKit's `UIBarButtonItem.fixedSpace`.
@@ -259,6 +289,40 @@ final class GlassBarMenuItem extends GlassBarActionItem {
 
   /// Width of the expanded menu panel, in logical pixels.
   final double menuWidth;
+
+  @override
+  Widget get content => icon;
+}
+
+/// A sheet-presenting item in a pinned navigation-bar cluster.
+///
+/// Created via [GlassBarItem.sheet].
+final class GlassBarSheetItem extends GlassBarActionItem {
+  /// Creates a sheet item. Prefer [GlassBarItem.sheet].
+  const GlassBarSheetItem({
+    required this.icon,
+    required this.onPresent,
+    super.id,
+    super.label,
+    super.enabled,
+    super.background,
+  }) : super(onTap: GlassBarActionItem._noOp);
+
+  /// The icon widget, typically an [Icon].
+  ///
+  /// Size and colour are applied by the enclosing cluster.
+  final Widget icon;
+
+  /// Called on tap with the anchor of the capsule this item sits in.
+  ///
+  /// Read at tap time, so a bar that moves between the pinned chrome and its
+  /// route hands out the anchor that is actually on screen.
+  ///
+  /// Null when no capsule can be resolved — a bar that renders the items
+  /// itself and offers no anchor of its own. `GlassModalSheet.show` takes a
+  /// null `morphFrom` and presents the way it always did, so the tap still
+  /// does its job and only the morph is lost.
+  final void Function(GlassMorphAnchor? anchor) onPresent;
 
   @override
   Widget get content => icon;

--- a/lib/widgets/surfaces/glass_navigation_shell.dart
+++ b/lib/widgets/surfaces/glass_navigation_shell.dart
@@ -20,6 +20,7 @@ class GlassNavBarRegistration {
     required this.showsBackButton,
     this.onBack,
     this.buttonSettings,
+    this.presentSheet,
   });
 
   /// The trailing cluster items for this route.
@@ -40,6 +41,19 @@ class GlassNavBarRegistration {
 
   /// Glass settings applied to this route's pinned chrome.
   final LiquidGlassSettings? buttonSettings;
+
+  /// Presents [GlassBarItem.sheet]'s sheet out of the route's own capsule.
+  ///
+  /// The morph has to come out of a capsule the sheet can then cover, and the
+  /// hoisted one is drawn above the [Navigator] where no route reaches it — so
+  /// the shell hands the tap back to the bar that registered it, which owns a
+  /// capsule inside the route and empties that. By the frame the droplet is
+  /// drawn the chrome is in-route anyway: a presentation hands it back.
+  ///
+  /// Null for a registrant that offers no capsule of its own — one that draws
+  /// the items itself. The item is then presented with a null anchor, which
+  /// costs the morph and nothing else.
+  final void Function(GlassBarSheetItem item)? presentSheet;
 
   /// The tappable items in [actions], with spacers removed.
   List<GlassBarActionItem> get actionItems =>

--- a/lib/widgets/surfaces/glass_pinned_bar_chrome.dart
+++ b/lib/widgets/surfaces/glass_pinned_bar_chrome.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import '../../src/renderer/liquid_glass_renderer.dart';
 import '../interactive/glass_button.dart';
 import '../interactive/glass_button_group.dart';
+import '../overlays/glass_modal_sheet.dart';
 import 'glass_app_bar.dart' show DefaultButtonSettings, GlassAppBar;
 import 'glass_bar_item.dart';
 import 'glass_navigation_shell.dart';
@@ -178,6 +179,9 @@ class GlassPinnedBarChrome extends StatefulWidget {
   State<GlassPinnedBarChrome> createState() => _GlassPinnedBarChromeState();
 }
 
+/// Which end of the bar a group sits at, so its anchor can be found again.
+enum _BarSlot { leading, actions }
+
 class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
   GlassNavigationShellState? _shell;
   ModalRoute<dynamic>? _route;
@@ -246,6 +250,7 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
         showsBackButton: _showsBack,
         onBack: widget.onBack,
         buttonSettings: widget.buttonSettings,
+        presentSheet: _presentSheet,
       ),
     );
   }
@@ -330,40 +335,89 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
     );
   }
 
-  /// One group of items, drawn as the shell it asked for.
-  Widget _buildGroup(GlassNavBarGroup group) {
-    if (_handedOver) return _measuringGroup(group);
-    if (!group.glass) {
-      final item = group.items.single;
-      return Semantics(
-        button: true,
-        label: item.label,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: item.enabled ? item.onTap : null,
-          child: SizedBox(height: group.height, child: item.content),
-        ),
+  /// The morph anchor of each group's capsule, by slot and position.
+  ///
+  /// Written as the group builds and read at tap time, never captured: the
+  /// anchor belongs to the trigger's element, and a hoisted tap arrives from
+  /// the shell long after the build that produced it.
+  final Map<(_BarSlot, int), GlassMorphAnchor> _groupAnchors = {};
+
+  /// Presents [item]'s sheet out of this bar's own capsule.
+  ///
+  /// Handed to the shell in the registration, so a hoisted tap morphs the
+  /// capsule that will still be here when the sheet is up. Silently does
+  /// nothing if the item is no longer in this bar, which a rebuild between the
+  /// tap and the frame it lands on can leave true.
+  void _presentSheet(GlassBarSheetItem item) {
+    for (final entry in <(_BarSlot, List<GlassBarItem>)>[
+      (_BarSlot.leading, widget.leading),
+      (_BarSlot.actions, widget.actions),
+    ]) {
+      final groups = groupGlassNavBarItems(
+        entry.$2.whereType<GlassBarActionItem>().toList(),
       );
+      for (var i = 0; i < groups.length; i++) {
+        if (!groups[i].items.any((candidate) => identical(candidate, item))) {
+          continue;
+        }
+        item.onPresent(_groupAnchors[(entry.$1, i)]);
+        return;
+      }
     }
-    return GlassButtonGroup.icons(
-      items: [
-        for (final item in group.items)
-          if (item is GlassBarMenuItem)
-            GlassButtonGroupItem.menu(
-              icon: item.icon,
-              menuItems: item.menuItems,
-              menuAlignment: item.menuAlignment,
-              menuWidth: item.menuWidth,
-              label: item.label,
-            )
-          else
-            GlassButtonGroupItem(
-              icon: item.content,
-              onTap: item.onTap,
-              label: item.label,
-              enabled: item.enabled,
+  }
+
+  /// One group of items, drawn as the shell it asked for.
+  ///
+  /// The morph trigger wraps both renderings and is unconditional, matching
+  /// the pinned host's own wrappers: a group that gained or lost one would
+  /// remount its glass and pop its backdrop, and spanning the hand-over is
+  /// what lets a capsule emptied while the bar was hoisted stay emptied when
+  /// it comes back. At rest it paints through a zero translation and a full
+  /// opacity, neither of which pushes a layer.
+  Widget _buildGroup(GlassNavBarGroup group, _BarSlot slot, int index) {
+    return GlassMorphTrigger(
+      builder: (context, anchor) {
+        _groupAnchors[(slot, index)] = anchor;
+        if (_handedOver) return _measuringGroup(group);
+
+        VoidCallback tapOf(GlassBarActionItem item) =>
+            item is GlassBarSheetItem
+                ? () => item.onPresent(anchor)
+                : item.onTap;
+
+        if (!group.glass) {
+          final item = group.items.single;
+          return Semantics(
+            button: true,
+            label: item.label,
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: item.enabled ? tapOf(item) : null,
+              child: SizedBox(height: group.height, child: item.content),
             ),
-      ],
+          );
+        }
+        return GlassButtonGroup.icons(
+          items: [
+            for (final item in group.items)
+              if (item is GlassBarMenuItem)
+                GlassButtonGroupItem.menu(
+                  icon: item.icon,
+                  menuItems: item.menuItems,
+                  menuAlignment: item.menuAlignment,
+                  menuWidth: item.menuWidth,
+                  label: item.label,
+                )
+              else
+                GlassButtonGroupItem(
+                  icon: item.content,
+                  onTap: tapOf(item),
+                  label: item.label,
+                  enabled: item.enabled,
+                ),
+          ],
+        );
+      },
     );
   }
 
@@ -407,7 +461,8 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
     );
     final slot = <Widget>[
       if (_showsBack) _buildBackButton(context),
-      for (final group in groups) _buildGroup(group),
+      for (var i = 0; i < groups.length; i++)
+        _buildGroup(groups[i], _BarSlot.leading, i),
     ];
     if (slot.isEmpty) return null;
     if (slot.length == 1) return slot.single;
@@ -423,7 +478,10 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
     final groups = groupGlassNavBarItems(
       widget.actions.whereType<GlassBarActionItem>().toList(),
     );
-    return [for (final group in groups) _buildGroup(group)];
+    return [
+      for (var i = 0; i < groups.length; i++)
+        _buildGroup(groups[i], _BarSlot.actions, i),
+    ];
   }
 
   @override

--- a/lib/widgets/surfaces/shared/glass_nav_pinned_host.dart
+++ b/lib/widgets/surfaces/shared/glass_nav_pinned_host.dart
@@ -1504,6 +1504,7 @@ class _PinnedGroupState extends State<_PinnedGroup> {
                 enabled: state.settled,
                 slotWidth: toGroup.slotWidth,
                 onMenuTap: identical(toItem, menuItem) ? _menu.open : null,
+                onSheetTap: state.to.presentSheet,
               ),
             ));
           }
@@ -1520,6 +1521,7 @@ class _PinnedGroupState extends State<_PinnedGroup> {
               enabled: state.settled,
               slotWidth: toGroup.slotWidth,
               onMenuTap: identical(toItem, menuItem) ? _menu.open : null,
+              onSheetTap: state.to.presentSheet,
             ),
           ));
         }
@@ -1656,6 +1658,7 @@ class _ClusterItem extends StatelessWidget {
     required this.enabled,
     required this.slotWidth,
     this.onMenuTap,
+    this.onSheetTap,
   });
 
   final GlassBarActionItem item;
@@ -1671,8 +1674,16 @@ class _ClusterItem extends StatelessWidget {
   /// its way out.
   final VoidCallback? onMenuTap;
 
+  /// Presents a [GlassBarItem.sheet]'s sheet, through the route's own capsule
+  /// rather than this one. Supplied on the same terms as [onMenuTap]; a bar
+  /// that offers none leaves the item to present without a morph.
+  final void Function(GlassBarSheetItem item)? onSheetTap;
+
   @override
   Widget build(BuildContext context) {
+    // Promoted to a local so the switch below and the sheet branch further
+    // down can both narrow it.
+    final item = this.item;
     final interactive = enabled && item.enabled;
 
     Widget content = switch (item) {
@@ -1681,6 +1692,10 @@ class _ClusterItem extends StatelessWidget {
           child: Center(child: icon),
         ),
       GlassBarMenuItem(:final icon) => SizedBox(
+          width: slotWidth,
+          child: Center(child: icon),
+        ),
+      GlassBarSheetItem(:final icon) => SizedBox(
           width: slotWidth,
           child: Center(child: icon),
         ),
@@ -1699,12 +1714,20 @@ class _ClusterItem extends StatelessWidget {
       content = Opacity(opacity: 0.5, child: content);
     }
 
+    // A sheet item is presented by the bar that registered it, which owns a
+    // capsule the sheet can cover; this one is drawn above the Navigator,
+    // where no route reaches it.
+    final present = onSheetTap;
+    final onTap = item is GlassBarSheetItem
+        ? () => present == null ? item.onPresent(null) : present(item)
+        : (onMenuTap ?? item.onTap);
+
     return Semantics(
       button: true,
       label: item.label,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: interactive ? (onMenuTap ?? item.onTap) : null,
+        onTap: interactive ? onTap : null,
         child: content,
       ),
     );

--- a/test/widgets/surfaces/glass_nav_pinned_sheet_test.dart
+++ b/test/widgets/surfaces/glass_nav_pinned_sheet_test.dart
@@ -1,0 +1,243 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
+import 'package:liquid_glass_widgets/widgets/surfaces/shared/glass_nav_pinned_host.dart';
+
+void main() {
+  setUp(() {
+    GlassNavigationShellState.debugPinningSupported = true;
+    GlassModalSheet.debugMorphSupportsBlending = true;
+  });
+
+  tearDown(() {
+    GlassNavigationShellState.debugPinningSupported = null;
+    GlassModalSheet.debugMorphSupportsBlending = null;
+  });
+
+  Widget shellApp(Widget home) => CupertinoApp(
+        builder: (context, child) => GlassNavigationShell(child: child!),
+        home: home,
+      );
+
+  /// Settles the route transition and the post-frame registration handover.
+  Future<void> settle(WidgetTester tester) async {
+    await tester.pumpAndSettle();
+    await tester.pump();
+  }
+
+  Finder inHost(Finder matching) => find.descendant(
+        of: find.byType(GlassNavPinnedHost),
+        matching: matching,
+      );
+
+  /// What the route's own capsule is painted at. The screen declares one
+  /// group, so the bar owns exactly one trigger, and the first [Opacity] below
+  /// it is the one the trigger empties.
+  double barCapsuleOpacity(WidgetTester tester) => tester
+      .widget<Opacity>(
+        find
+            .descendant(
+              of: find.byType(GlassMorphTrigger),
+              matching: find.byType(Opacity),
+            )
+            .first,
+      )
+      .opacity;
+
+  group('a sheet item in the pinned chrome', () {
+    testWidgets(
+        'presents through the route\'s own capsule, not the hoisted one',
+        (tester) async {
+      await tester.pumpWidget(shellApp(const _Screen()));
+      await settle(tester);
+      expect(inHost(find.byIcon(CupertinoIcons.add)), findsOneWidget);
+      expect(barCapsuleOpacity(tester), 1.0);
+
+      await tester.tap(inHost(find.byIcon(CupertinoIcons.add)));
+      await tester.pump();
+      await tester.pump();
+
+      // The hoisted capsule is drawn above the Navigator, where the sheet
+      // cannot cover it; the one the bar owns is inside the route.
+      expect(barCapsuleOpacity(tester), 0.0);
+    });
+
+    testWidgets('leaves the sheet free to cover the rest of the chrome',
+        (tester) async {
+      await tester.pumpWidget(shellApp(const _Screen()));
+      await settle(tester);
+      final route = ModalRoute.of(tester.element(find.text('body')))!;
+      final shell = tester.state<GlassNavigationShellState>(
+        find.byType(GlassNavigationShell),
+      );
+
+      await tester.tap(inHost(find.byIcon(CupertinoIcons.add)));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // A presentation hands the chrome back, so it sits under the sheet with
+      // the rest of the page. Holding it hoisted for the morph would leave a
+      // back button painted over the sheet and live above its barrier.
+      expect(shell.isHoisting(route), isFalse);
+      expect(find.byType(GlassNavPinnedHost), findsNothing);
+    });
+
+    testWidgets('empties the capsule rather than the glyph it was tapped on',
+        (tester) async {
+      await tester.pumpWidget(shellApp(const _Screen()));
+      await settle(tester);
+
+      await tester.tap(inHost(find.byIcon(CupertinoIcons.add)));
+      await tester.pump();
+      await tester.pump();
+
+      // The neighbouring icon goes with it: on screen the cluster is one
+      // control, and a droplet out of a hole in it reads as a second object.
+      final emptied = find.ancestor(
+        of: find.byIcon(CupertinoIcons.share),
+        matching: find.byType(Opacity),
+      );
+      expect(
+        emptied.evaluate().any((e) => (e.widget as Opacity).opacity == 0.0),
+        isTrue,
+      );
+    });
+
+    testWidgets('is inert while a transition is running', (tester) async {
+      await tester.pumpWidget(shellApp(const _Screen()));
+      await settle(tester);
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      navigator.push(
+        CupertinoPageRoute<void>(builder: (_) => const _Screen(title: 'Next')),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 150));
+
+      // Mid-transition the item is not hit-testable at all, which is the
+      // point — a miss here is the assertion, not a flake.
+      await tester.tap(
+        inHost(find.byIcon(CupertinoIcons.add)).first,
+        warnIfMissed: false,
+      );
+      await tester.pump();
+
+      expect(barCapsuleOpacity(tester), 1.0);
+      await settle(tester);
+    });
+
+    testWidgets('still presents when the bar offers no capsule of its own',
+        (tester) async {
+      var presented = 0;
+      GlassMorphAnchor? seen;
+      await tester.pumpWidget(shellApp(_OwnBarScreen(
+        onPresent: (anchor) {
+          presented++;
+          seen = anchor;
+        },
+      )));
+      await settle(tester);
+
+      await tester.tap(inHost(find.byIcon(CupertinoIcons.add)));
+      await tester.pump();
+
+      // A bar that renders the items itself has no anchor to offer. Losing the
+      // morph is the cost; losing the tap would be a bug.
+      expect(presented, 1);
+      expect(seen, isNull);
+    });
+  });
+
+  group('a sheet item drawn in-route', () {
+    testWidgets('presents through the same capsule it would hoisted',
+        (tester) async {
+      await tester.pumpWidget(const CupertinoApp(home: _Screen()));
+      await settle(tester);
+      expect(find.byType(GlassNavPinnedHost), findsNothing);
+      expect(barCapsuleOpacity(tester), 1.0);
+
+      await tester.tap(find.byIcon(CupertinoIcons.add));
+      await tester.pump();
+      await tester.pump();
+
+      expect(barCapsuleOpacity(tester), 0.0);
+    });
+  });
+}
+
+/// A screen whose one trailing group presents a sheet out of its capsule.
+class _Screen extends StatelessWidget {
+  const _Screen({this.title = 'Home'});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassScaffold(
+      appBar: GlassAppBar.pinned(
+        title: Text(title),
+        backButton: false,
+        actions: [
+          GlassBarItem.sheet(
+            icon: const Icon(CupertinoIcons.add),
+            onPresent: (anchor) => GlassModalSheet.show<void>(
+              context: context,
+              morphFrom: anchor,
+              builder: (_) => const SizedBox(height: 200),
+            ),
+          ),
+          GlassBarItem.icon(
+            icon: const Icon(CupertinoIcons.share),
+            onTap: () {},
+          ),
+        ],
+      ),
+      body: const Center(child: Text('body')),
+    );
+  }
+}
+
+/// A screen that registers with the shell directly, drawing its own bar — the
+/// shape `GlassPinnedBarChrome`'s own doc points such an app at.
+class _OwnBarScreen extends StatefulWidget {
+  const _OwnBarScreen({required this.onPresent});
+
+  final void Function(GlassMorphAnchor? anchor) onPresent;
+
+  @override
+  State<_OwnBarScreen> createState() => _OwnBarScreenState();
+}
+
+class _OwnBarScreenState extends State<_OwnBarScreen> {
+  GlassNavigationShellState? _shell;
+  ModalRoute<dynamic>? _route;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _shell = GlassNavigationShell.maybeOf(context);
+    _route = ModalRoute.of(context);
+    _shell?.register(
+      _route!,
+      GlassNavBarRegistration(
+        actions: [
+          GlassBarItem.sheet(
+            icon: const Icon(CupertinoIcons.add),
+            onPresent: widget.onPresent,
+          ),
+        ],
+        showsBackButton: false,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    if (_route != null) _shell?.unregister(_route!);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      const CupertinoPageScaffold(child: Center(child: Text('body')));
+}


### PR DESCRIPTION
## Description

A `GlassModalSheet` morphs out of the control that presented it, and on iOS 26 that control is the whole capsule: `GlassMorphTrigger` wraps it, the sheet empties it, and the droplet stretches out of its frame. Under `GlassNavigationShell` the capsule is drawn from item data and nothing reached one, a tap handler being a `VoidCallback` with no anchor. Keeping the morph meant hoisting the cluster as one `GlassBarItem.custom` carrying an app-built capsule with `GlassBarItemBackground.own`, which gives up the transition in exchange — two `own` items matched across a route change are finished surfaces the host can only take turns between.

`GlassBarItem.sheet` hands its tap a `GlassMorphAnchor`, following `GlassBarItem.menu` — the existing item whose overlay morphs the whole capsule rather than its own slot. It is always the **route's own** capsule and never the hoisted copy. Presenting hands the chrome back to its route (`_isPresentedOver`), so the route's is the one still on screen under the sheet; it is also the only one a sheet can cover, the hoisted chrome being drawn above the `Navigator` in an overlay no route reaches. A hoisted tap is therefore routed back to the bar that registered the item, through a presenter on the registration: `GlassPinnedBarChrome` keeps its groups' anchors — one trigger per group, spanning the hand-over so a capsule emptied while hoisted stays emptied when it comes back — and looks the item up.

The anchor is nullable. A bar that renders the items itself rather than placing the resolved slots offers none, and `GlassModalSheet.show` takes a null `morphFrom` as the presentation it always had: losing the morph is the cost of drawing your own capsule, losing the tap would be a bug.

Six tests: the tap empties the route's capsule and not the hoisted one, the chrome is left free to hand back so the sheet covers it, the whole capsule empties rather than the tapped glyph, the item is inert mid-transition, a bar offering no anchor still presents, and an in-route bar presents through the same capsule it would hoisted.

Recorded on the example's new `Sheet From The Capsule` pattern, which also pushes to a second screen so the item can be seen morphing across a route change as ordinary data.

| Sheet morph | Across a route change |
|--------|--------|
| <!-- VIDEO: sheet --> | <!-- VIDEO: merge --> |

Fixes #303.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Platforms Tested

- [x] iOS (Impeller)
- [ ] Android (Impeller)
- [ ] macOS
- [ ] Windows
- [ ] Web
- [ ] Linux

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (shaders, painting logic)
- [x] I have made corresponding changes to the documentation / CHANGELOG.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/golden tests pass locally (`flutter test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ofAEEnJpXySKTbjow3cAG
