### PR TITLE
feat(GlassPinnedBarChrome): take the inset the bar draws its capsules at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.4
+
+## Features
+
+- **`GlassPinnedBarChrome.horizontalInset` — the guide a hoisted bar is drawn on (#307):** The chrome was always positioned at `GlassNavPinnedMetrics.horizontalPadding`, which is right for a bar the package draws at both ends and wrong for one the app draws. Presenting a sheet hands the chrome back to its route, and a bar aligned to its own page gutter stepped sideways at every hand-over. It now takes the inset its bar reports, defaulting to the old one.
+
 # 1.4.3
 
 ## Features

--- a/docs/GLASS_NAVIGATION_TRANSITION.md
+++ b/docs/GLASS_NAVIGATION_TRANSITION.md
@@ -209,6 +209,13 @@ its own, and there is nothing to keep in sync with the item data.
 `chrome.hoisted` is there for a bar that wants to substitute *its own* chrome
 rather than the package's; reading it is not needed for the common case.
 
+`horizontalInset` is the guide your capsules sit on, defaulting to the
+`GlassNavPinnedMetrics.horizontalPadding` a `GlassAppBar` uses for its own.
+Pass yours if the bar is aligned to something else — an app's page gutter,
+say. The chrome hands back to the route whenever a sheet or dialog is
+presented over it, and that hand-over is invisible only while both renderings
+land on the same guide; a bar that disagrees steps sideways at every one.
+
 `leading`, `backButton`, `leadingItemsSupplementBackButton`, `onBack` and
 `buttonSettings` mean exactly what they do on `GlassAppBar.pinned` — a
 non-empty `leading` replaces the back button in `chrome.leading` unless

--- a/lib/widgets/surfaces/glass_navigation_shell.dart
+++ b/lib/widgets/surfaces/glass_navigation_shell.dart
@@ -21,6 +21,7 @@ class GlassNavBarRegistration {
     this.onBack,
     this.buttonSettings,
     this.presentSheet,
+    this.horizontalInset,
   });
 
   /// The trailing cluster items for this route.
@@ -54,6 +55,19 @@ class GlassNavBarRegistration {
   /// the items itself. The item is then presented with a null anchor, which
   /// costs the morph and nothing else.
   final void Function(GlassBarSheetItem item)? presentSheet;
+
+  /// Inset from each screen edge to the pinned chrome, in logical pixels.
+  ///
+  /// Defaults to [GlassNavPinnedMetrics.horizontalPadding], which is what
+  /// [GlassAppBar] insets its own chrome by — so a bar the package draws at
+  /// both ends already agrees with itself and passes nothing.
+  ///
+  /// A bar the app draws is the case for it. The chrome hoists and hands back
+  /// on its own schedule — a presented sheet gives it to the route, a
+  /// transition takes it away again — and each hand-over is invisible only
+  /// while the two renderings land on the same guide. A bar aligned to its
+  /// app's page gutter rather than to this default passes that gutter here.
+  final double? horizontalInset;
 
   /// The tappable items in [actions], with spacers removed.
   List<GlassBarActionItem> get actionItems =>

--- a/lib/widgets/surfaces/glass_pinned_bar_chrome.dart
+++ b/lib/widgets/surfaces/glass_pinned_bar_chrome.dart
@@ -114,6 +114,7 @@ class GlassPinnedBarChrome extends StatefulWidget {
     this.leadingItemsSupplementBackButton = false,
     this.onBack,
     this.buttonSettings,
+    this.horizontalInset,
     this.enabled = true,
   });
 
@@ -159,6 +160,15 @@ class GlassPinnedBarChrome extends StatefulWidget {
   /// Applied to the in-route buttons as well as the pinned ones, so the two
   /// look identical across the hand-over.
   final LiquidGlassSettings? buttonSettings;
+
+  /// Inset from each screen edge to the pinned chrome, in logical pixels.
+  ///
+  /// Defaults to [GlassNavPinnedMetrics.horizontalPadding], the inset
+  /// [GlassAppBar] uses for its own. Pass the inset **your** bar draws its
+  /// capsules at, so the two land on the same guide and the hand-over between
+  /// them is invisible — a bar aligned to its app's page gutter otherwise
+  /// steps sideways every time a sheet hands the chrome back.
+  final double? horizontalInset;
 
   /// Whether this bar participates in pinning at all.
   ///
@@ -251,6 +261,7 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
         onBack: widget.onBack,
         buttonSettings: widget.buttonSettings,
         presentSheet: _presentSheet,
+        horizontalInset: widget.horizontalInset,
       ),
     );
   }

--- a/lib/widgets/surfaces/shared/glass_nav_pinned_host.dart
+++ b/lib/widgets/surfaces/shared/glass_nav_pinned_host.dart
@@ -391,10 +391,17 @@ class GlassNavPinnedHost extends StatelessWidget {
       chrome = DefaultButtonSettings(settings: settings, child: chrome);
     }
 
+    // The incoming route's guide, as `buttonSettings` above resolves the
+    // material: a transition between two bars that disagree lands on the one
+    // being entered rather than sliding the chrome between them.
+    final inset = state.to.horizontalInset ??
+        state.from.horizontalInset ??
+        GlassNavPinnedMetrics.horizontalPadding;
+
     return Positioned(
       top: topPad,
-      left: GlassNavPinnedMetrics.horizontalPadding,
-      right: GlassNavPinnedMetrics.horizontalPadding,
+      left: inset,
+      right: inset,
       height: GlassNavPinnedMetrics.toolbarHeight,
       child: GlassIsolationScope(
         isolated: true,

--- a/test/widgets/surfaces/glass_pinned_bar_chrome_test.dart
+++ b/test/widgets/surfaces/glass_pinned_bar_chrome_test.dart
@@ -36,6 +36,68 @@ void main() {
   Finder inBar(Finder matching) =>
       find.descendant(of: find.byType(AppBar), matching: matching);
 
+  group('horizontal inset', () {
+    /// The chrome's own box, which is what the inset positions.
+    Rect hostRect(WidgetTester tester) {
+      final box =
+          tester.renderObject<RenderBox>(find.byType(GlassNavPinnedHost));
+      return box.localToGlobal(Offset.zero) & box.size;
+    }
+
+    testWidgets('defaults to the inset GlassAppBar draws its own chrome at',
+        (tester) async {
+      await tester.pumpWidget(shellApp(const _MaterialBarScreen(
+        title: 'Inbox',
+        actionIcon: CupertinoIcons.add,
+      )));
+      await settle(tester);
+
+      final screen =
+          tester.view.physicalSize.width / tester.view.devicePixelRatio;
+      final rect = hostRect(tester);
+      expect(rect.left, GlassNavPinnedMetrics.horizontalPadding);
+      expect(rect.right, screen - GlassNavPinnedMetrics.horizontalPadding);
+    });
+
+    testWidgets('follows the bar that registered it', (tester) async {
+      await tester.pumpWidget(shellApp(const _MaterialBarScreen(
+        title: 'Inbox',
+        actionIcon: CupertinoIcons.add,
+        horizontalInset: 16,
+      )));
+      await settle(tester);
+
+      // A bar aligned to its app's page gutter rather than the package's
+      // default steps sideways at every hand-over unless the shell follows it.
+      final screen =
+          tester.view.physicalSize.width / tester.view.devicePixelRatio;
+      final rect = hostRect(tester);
+      expect(rect.left, 16);
+      expect(rect.right, screen - 16);
+    });
+
+    testWidgets('a push lands on the incoming route\'s guide', (tester) async {
+      await tester.pumpWidget(shellApp(const _MaterialBarScreen(
+        title: 'Inbox',
+        actionIcon: CupertinoIcons.add,
+        horizontalInset: 16,
+      )));
+      await settle(tester);
+
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      navigator.push(MaterialPageRoute<void>(
+        builder: (_) => const _MaterialBarScreen(
+          title: 'Detail',
+          actionIcon: CupertinoIcons.share,
+          horizontalInset: 4,
+        ),
+      ));
+      await settle(tester);
+
+      expect(hostRect(tester).left, 4);
+    });
+  });
+
   group('registration', () {
     testWidgets('a plain Material AppBar hands its items to the shell',
         (tester) async {
@@ -274,6 +336,7 @@ class _MaterialBarScreen extends StatelessWidget {
     this.onBack,
     this.backButton = true,
     this.enabled = true,
+    this.horizontalInset,
   });
 
   final String title;
@@ -281,6 +344,7 @@ class _MaterialBarScreen extends StatelessWidget {
   final VoidCallback? onBack;
   final bool backButton;
   final bool enabled;
+  final double? horizontalInset;
 
   @override
   Widget build(BuildContext context) {
@@ -291,6 +355,7 @@ class _MaterialBarScreen extends StatelessWidget {
       backButton: backButton,
       onBack: onBack,
       enabled: enabled,
+      horizontalInset: horizontalInset,
       builder: (context, chrome) => Scaffold(
         appBar: AppBar(
           title: Text(title),


### PR DESCRIPTION
## Description

`GlassNavPinnedHost` positioned the chrome at `GlassNavPinnedMetrics.horizontalPadding` from each screen edge. That is right for `GlassAppBar`, which insets its own in-route chrome by the same constant: the two renderings coincide, and the hand-over between them is invisible because there is nothing to see. `GlassPinnedBarChrome` is the other case — an app that already has a bar and draws the capsules itself — and there the constant is a guess about someone else's layout.

The chrome hands back to its route on its own schedule, most visibly the moment anything is presented over it, since `_isPresentedOver` gives it back on that frame. So a bar aligned to something other than the package's default steps sideways at every one. Measured on a bar at a 16pt page gutter: both capsules jump 8pt inward as a sheet opens and 8pt back out as it closes, with no vertical change.

The registration carries the inset now, beside `buttonSettings` — which is there for the same reason, a value the bar knows and the shell has to match. It resolves the same way too, `state.to` before `state.from`, so a push between two bars that disagree lands on the guide it is entering rather than sliding the chrome between them. It defaults to the old constant, so a bar that passes nothing renders exactly as before, and `GlassAppBar.pinned` needs nothing: it draws both renderings and already agrees with itself.

Three tests: the default is the constant, a bar that reports an inset is positioned at it, and a push between two that disagree lands on the incoming one. The last two fail on main.

Fixes #307.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Platforms Tested

- [x] iOS (Impeller)
- [ ] Android (Impeller)
- [ ] macOS
- [ ] Windows
- [ ] Web
- [ ] Linux

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (shaders, painting logic)
- [x] I have made corresponding changes to the documentation / CHANGELOG.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/golden tests pass locally (`flutter test`)