### PR TITLE
fix(sheet): remove redundant inner SafeArea padding

### DIFF
--- a/lib/widgets/overlays/glass_sheet.dart
+++ b/lib/widgets/overlays/glass_sheet.dart
@@ -538,42 +538,39 @@ class _GlassSheetState extends State<GlassSheet> with TickerProviderStateMixin {
         );
 
         // The core inner content of the sheet
-        Widget innerContent = SafeArea(
-          bottom: true,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              _SheetHeader(
-                showIndicator: widget.showDragIndicator,
-                color: widget.dragIndicatorColor,
-                onDismiss: () => Navigator.maybePop(context),
-              ),
-              if (widget.isScrollable)
-                Flexible(
-                  child: NotificationListener<ScrollNotification>(
-                    onNotification: (notification) {
-                      if (notification is ScrollStartNotification &&
-                          notification.dragDetails != null) {
-                        GlassGlowLayer.maybeOf(context)?.removeTouch();
-                      }
-                      return false;
-                    },
-                    child: SingleChildScrollView(
-                      physics: const BouncingScrollPhysics(),
-                      padding: widget.padding,
-                      child: RepaintBoundary(child: widget.child),
-                    ),
+        Widget innerContent = Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _SheetHeader(
+              showIndicator: widget.showDragIndicator,
+              color: widget.dragIndicatorColor,
+              onDismiss: () => Navigator.maybePop(context),
+            ),
+            if (widget.isScrollable)
+              Flexible(
+                child: NotificationListener<ScrollNotification>(
+                  onNotification: (notification) {
+                    if (notification is ScrollStartNotification &&
+                        notification.dragDetails != null) {
+                      GlassGlowLayer.maybeOf(context)?.removeTouch();
+                    }
+                    return false;
+                  },
+                  child: SingleChildScrollView(
+                    physics: const BouncingScrollPhysics(),
+                    padding: widget.padding,
+                    child: RepaintBoundary(child: widget.child),
                   ),
-                )
-              else
-                Padding(
-                  padding: widget.padding ?? EdgeInsets.zero,
-                  child: RepaintBoundary(child: widget.child),
                 ),
-              const SizedBox(height: 24),
-            ],
-          ),
+              )
+            else
+              Padding(
+                padding: widget.padding ?? EdgeInsets.zero,
+                child: RepaintBoundary(child: widget.child),
+              ),
+            const SizedBox(height: 24),
+          ],
         );
 
         Widget result = AdaptiveGlass(

--- a/test/widgets/overlays/glass_sheet_coverage_test.dart
+++ b/test/widgets/overlays/glass_sheet_coverage_test.dart
@@ -45,6 +45,32 @@ void main() {
     });
   });
 
+  // ── scroll notification path ─────────────────────────────────────────────
+
+  group('GlassSheet — scroll notifications', () {
+    testWidgets('removes touch glow when content starts scrolling',
+        (tester) async {
+      await tester.pumpWidget(_app(
+        const SizedBox(
+          height: 400,
+          child: GlassSheet(
+            child: SizedBox(
+              height: 1000,
+              child: Text('Scrollable content'),
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      final scrollView = find.byType(SingleChildScrollView);
+      expect(scrollView, findsOneWidget);
+      await tester.drag(scrollView, const Offset(0, -200));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+    });
+  });
+
   // ── showDragIndicator=false path ──────────────────────────────────────────
 
   group('GlassSheet — showDragIndicator=false', () {


### PR DESCRIPTION
## Description

The sheet handled the bottom safe area twice, which pushed the top drag handle too far down. This removes the redundant inner SafeArea while preserving the outer useSafeArea behavior.

Fixes # (not applicable)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 Visual / shader change (impacts rendering output)

## Platforms Tested

- Automated widget tests only; no platform-specific manual verification was performed.

## Checklist

- [x] My code follows the style guidelines of this project (flutter analyze passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable to this simple layout change)
- [x] I have made corresponding changes to the documentation / CHANGELOG.md (not applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (not applicable; existing tests cover this path)
- [x] New and existing unit/golden tests pass locally (targeted GlassSheet tests: 21 passed)
- [x] If this changes shader code, I have verified it compiles on both Metal (macOS) and SkSL/SPIR-V (Windows) (not applicable; no shader changes)
- [x] No dynamic indexing or unsupported GLSL builtins were introduced in shader code (not applicable; no shader changes)

## Screenshots / Recordings

### Before
<img width="460" height="88" alt="8b7f36975fd60dc118c4ccbce249bc83" src="https://github.com/user-attachments/assets/56797b0e-d69a-41d9-bf32-bf23b4fdd0ec" />


### After
<img width="459" height="74" alt="073806a29d92cb74b277840ce2dedfb9" src="https://github.com/user-attachments/assets/fe065d48-e7fa-4664-a946-60a297e14d98" />

## Test Command

fvm flutter analyze

fvm flutter test test/widgets/overlays/glass_sheet_test.dart test/widgets/overlays/glass_sheet_coverage_test.dart