### PR TITLE
feat(GlassPinnedBarChrome): route a hoisted capsule over a platform view to the backdrop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.4
+
+## Features
+
+- **`GlassPinnedBarChrome.platformViewBackdrop` — pinned chrome over a platform view (#310):** The shell drew a hoisted capsule with its own `GlassButton` on the shader path, whose captured backdrop excludes a platform view — so over a map the capsule had nothing to refract and rendered clear with a rim, whatever `buttonSettings` said, while the bar's own capsule blurred through a live `BackdropFilter`. The registration carries the flag now and the host forwards it to the capsule and menu it draws, resolved to the route being entered so a pop back over the view is on the backdrop from its first frame.
+
 # 1.4.3
 
 ## Features

--- a/docs/GLASS_NAVIGATION_TRANSITION.md
+++ b/docs/GLASS_NAVIGATION_TRANSITION.md
@@ -209,6 +209,13 @@ its own, and there is nothing to keep in sync with the item data.
 `chrome.hoisted` is there for a bar that wants to substitute *its own* chrome
 rather than the package's; reading it is not needed for the common case.
 
+`platformViewBackdrop` is for a bar floating over a native platform view — a
+map, a video. `buttonSettings` cannot cover this on its own: the shader reads a
+captured backdrop the platform view is never part of, so the shell's capsule
+has nothing to refract there. The flag routes it to a live `BackdropFilter`
+instead, as `GlassButton.platformViewBackdrop` does for the bar's own, and is
+applied in-route as well so the two agree across the hand-over.
+
 `leading`, `backButton`, `leadingItemsSupplementBackButton`, `onBack` and
 `buttonSettings` mean exactly what they do on `GlassAppBar.pinned` — a
 non-empty `leading` replaces the back button in `chrome.leading` unless

--- a/lib/widgets/surfaces/glass_navigation_shell.dart
+++ b/lib/widgets/surfaces/glass_navigation_shell.dart
@@ -21,6 +21,7 @@ class GlassNavBarRegistration {
     this.onBack,
     this.buttonSettings,
     this.presentSheet,
+    this.platformViewBackdrop = false,
   });
 
   /// The trailing cluster items for this route.
@@ -54,6 +55,17 @@ class GlassNavBarRegistration {
   /// the items itself. The item is then presented with a null anchor, which
   /// costs the morph and nothing else.
   final void Function(GlassBarSheetItem item)? presentSheet;
+
+  /// Whether the pinned chrome floats over a native platform view.
+  ///
+  /// The shell draws a hoisted cluster with its own [GlassButton], and the
+  /// shader that button uses reads a captured backdrop the platform view is
+  /// never part of — so over a map or a video the capsule has nothing to
+  /// refract and renders inert, whatever [buttonSettings] asks for. Only a
+  /// live `BackdropFilter` samples the composited view, and this is what
+  /// routes the shell's copy there, exactly as [GlassButton.platformViewBackdrop]
+  /// does for the bar's own.
+  final bool platformViewBackdrop;
 
   /// The tappable items in [actions], with spacers removed.
   List<GlassBarActionItem> get actionItems =>

--- a/lib/widgets/surfaces/glass_pinned_bar_chrome.dart
+++ b/lib/widgets/surfaces/glass_pinned_bar_chrome.dart
@@ -114,6 +114,7 @@ class GlassPinnedBarChrome extends StatefulWidget {
     this.leadingItemsSupplementBackButton = false,
     this.onBack,
     this.buttonSettings,
+    this.platformViewBackdrop = false,
     this.enabled = true,
   });
 
@@ -159,6 +160,15 @@ class GlassPinnedBarChrome extends StatefulWidget {
   /// Applied to the in-route buttons as well as the pinned ones, so the two
   /// look identical across the hand-over.
   final LiquidGlassSettings? buttonSettings;
+
+  /// Whether the bar floats over a native platform view — an iOS map, say.
+  ///
+  /// Forwarded to every capsule this bar draws, in-route and pinned alike, so
+  /// the two look identical across the hand-over. The glass shader reads a
+  /// captured backdrop the platform view is never part of, so without this a
+  /// capsule over one has nothing to refract; the flag routes it to the live
+  /// `BackdropFilter` instead, as [GlassButton.platformViewBackdrop] does.
+  final bool platformViewBackdrop;
 
   /// Whether this bar participates in pinning at all.
   ///
@@ -251,6 +261,7 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
         onBack: widget.onBack,
         buttonSettings: widget.buttonSettings,
         presentSheet: _presentSheet,
+        platformViewBackdrop: widget.platformViewBackdrop,
       ),
     );
   }
@@ -319,6 +330,7 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
       width: backSize,
       height: backSize,
       iconSize: GlassNavPinnedMetrics.iconSize,
+      platformViewBackdrop: widget.platformViewBackdrop,
       label: Localizations.of<CupertinoLocalizations>(
             context,
             CupertinoLocalizations,
@@ -399,6 +411,7 @@ class _GlassPinnedBarChromeState extends State<GlassPinnedBarChrome> {
           );
         }
         return GlassButtonGroup.icons(
+          platformViewBackdrop: widget.platformViewBackdrop,
           items: [
             for (final item in group.items)
               if (item is GlassBarMenuItem)

--- a/lib/widgets/surfaces/shared/glass_nav_pinned_host.dart
+++ b/lib/widgets/surfaces/shared/glass_nav_pinned_host.dart
@@ -1291,6 +1291,13 @@ class _PinnedGroupState extends State<_PinnedGroup> {
   @override
   Widget build(BuildContext context) {
     final state = widget.state;
+    // The route being entered, in flow terms rather than stack terms. A
+    // change of render path remounts the shell's surface, so it should flip
+    // on the first frame of a transition and never at its end: on a pop back
+    // over a platform view [GlassNavPinnedState.to] is still the route
+    // leaving, and reading it would have the returning capsule materialize
+    // through the shader and pop to the backdrop once settled.
+    final platformViewBackdrop = state.flowTo.platformViewBackdrop;
     // The forward-choreography clock: mirrored on a pop, with the group's
     // sides already swapped to match by the side above.
     final p = state.flowProgress;
@@ -1597,12 +1604,14 @@ class _PinnedGroupState extends State<_PinnedGroup> {
           // The fallback is never read: with no menu item there is no trigger
           // to open one. It matches GlassMenu's own default.
           menuWidth: menuItem?.menuWidth ?? 200,
+          platformViewBackdrop: platformViewBackdrop,
           triggerBuilder: (context, _) => toGroup.glass
               ? _buildShell(
                   cluster: cluster,
                   stretch:
                       lerpDouble(fromGroup.stretch, toGroup.stretch, clampedT)!,
                   morphScale: morphScale,
+                  platformViewBackdrop: platformViewBackdrop,
                 )
               : cluster,
         ),
@@ -1623,9 +1632,11 @@ class _PinnedGroupState extends State<_PinnedGroup> {
     required Widget cluster,
     required double stretch,
     required double morphScale,
+    required bool platformViewBackdrop,
   }) {
     return GlassButton.custom(
       onTap: () {},
+      platformViewBackdrop: platformViewBackdrop,
       // The radius scales with the gel so the shape stays a true scaled
       // capsule rather than squaring off as it inflates.
       shape: LiquidRoundedRectangle(

--- a/test/widgets/surfaces/glass_pinned_bar_chrome_test.dart
+++ b/test/widgets/surfaces/glass_pinned_bar_chrome_test.dart
@@ -36,6 +36,88 @@ void main() {
   Finder inBar(Finder matching) =>
       find.descendant(of: find.byType(AppBar), matching: matching);
 
+  group('platform view backdrop', () {
+    /// Whether every glass capsule the shell draws is on the backdrop route.
+    bool hostOnBackdrop(WidgetTester tester) => tester
+        .widgetList<GlassButton>(inHost(find.byType(GlassButton)))
+        .every((b) => b.platformViewBackdrop);
+
+    testWidgets('is off unless the bar says otherwise', (tester) async {
+      await tester.pumpWidget(shellApp(const _MaterialBarScreen(
+        title: 'Inbox',
+        actionIcon: CupertinoIcons.add,
+      )));
+      await settle(tester);
+
+      expect(inHost(find.byType(GlassButton)), findsWidgets);
+      expect(hostOnBackdrop(tester), isFalse);
+    });
+
+    testWidgets('reaches the capsule the shell draws', (tester) async {
+      await tester.pumpWidget(shellApp(const _MaterialBarScreen(
+        title: 'Map',
+        actionIcon: CupertinoIcons.add,
+        platformViewBackdrop: true,
+      )));
+      await settle(tester);
+
+      // The material slot alone cannot do this: the shader reads a captured
+      // backdrop the platform view is never part of, so only the flag moves
+      // the hoisted copy onto the live BackdropFilter the in-route one uses.
+      expect(inHost(find.byType(GlassButton)), findsWidgets);
+      expect(hostOnBackdrop(tester), isTrue);
+    });
+
+    testWidgets('reaches the in-route capsules too', (tester) async {
+      await tester.pumpWidget(shellApp(
+        const _MaterialBarScreen(
+          title: 'Map',
+          actionIcon: CupertinoIcons.add,
+          platformViewBackdrop: true,
+        ),
+        shell: false,
+      ));
+      await settle(tester);
+
+      final group = tester.widget<GlassButtonGroup>(
+        inBar(find.byType(GlassButtonGroup)),
+      );
+      expect(group.platformViewBackdrop, isTrue);
+    });
+
+    testWidgets('follows the route being entered, from its first frame',
+        (tester) async {
+      await tester.pumpWidget(shellApp(const _MaterialBarScreen(
+        title: 'Map',
+        actionIcon: CupertinoIcons.add,
+        platformViewBackdrop: true,
+      )));
+      await settle(tester);
+
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      navigator.push(MaterialPageRoute<void>(
+        builder: (_) => const _MaterialBarScreen(
+          title: 'Detail',
+          actionIcon: CupertinoIcons.share,
+        ),
+      ));
+      await settle(tester);
+      expect(hostOnBackdrop(tester), isFalse);
+
+      // A change of route remounts the shell's surface, so the flip has to
+      // land on the first frame of the pop rather than once it settles —
+      // otherwise the returning capsule materializes through the shader and
+      // pops to the backdrop at the end.
+      navigator.pop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(hostOnBackdrop(tester), isTrue);
+
+      await settle(tester);
+      expect(hostOnBackdrop(tester), isTrue);
+    });
+  });
+
   group('registration', () {
     testWidgets('a plain Material AppBar hands its items to the shell',
         (tester) async {
@@ -274,6 +356,7 @@ class _MaterialBarScreen extends StatelessWidget {
     this.onBack,
     this.backButton = true,
     this.enabled = true,
+    this.platformViewBackdrop = false,
   });
 
   final String title;
@@ -281,6 +364,7 @@ class _MaterialBarScreen extends StatelessWidget {
   final VoidCallback? onBack;
   final bool backButton;
   final bool enabled;
+  final bool platformViewBackdrop;
 
   @override
   Widget build(BuildContext context) {
@@ -291,6 +375,7 @@ class _MaterialBarScreen extends StatelessWidget {
       backButton: backButton,
       onBack: onBack,
       enabled: enabled,
+      platformViewBackdrop: platformViewBackdrop,
       builder: (context, chrome) => Scaffold(
         appBar: AppBar(
           title: Text(title),


### PR DESCRIPTION
## Description

`GlassNavPinnedHost._buildShell` draws a hoisted cluster with `GlassButton.custom(...)` and never passes `platformViewBackdrop`, so the capsule stays on the shader path — and the shader reads a captured backdrop a platform view is never part of. Over a map the shell's copy therefore has nothing to refract and renders clear with a rim and no blur, while the bar's own capsule, built with `GlassButton(platformViewBackdrop: true)`, blurs the view through a live `BackdropFilter`. The hand-over between the two is plainly visible.

`buttonSettings` cannot reach this. `platformViewMode: passthrough` decides what the shader does with the pixels it could not sample; it cannot make the shader sample a platform view. Only the widget flag switches `AdaptiveGlass` onto the `BackdropFilter` route, and the pinned host is the one place the package builds a `GlassButton` on a caller's behalf without offering it — every other surface that can sit over a platform view exposes the flag by that name and forwards it (`GlassButton`, `GlassButtonGroup`, `GlassChip` in #250, `GlassMenu`, `GlassModalSheet`, `GlassTabBar`).

The registration carries `platformViewBackdrop` now, beside `buttonSettings`, and the host forwards it to the shell capsule and the pull-down it draws. `GlassPinnedBarChrome` takes it too and applies it in-route as well — the back button and each `GlassButtonGroup` — so the two renderings agree across the hand-over. It defaults to `false`, so nothing changes for a bar that passes nothing.

It resolves to the route being **entered** (`flowTo`) rather than `state.to` the way `buttonSettings` and `horizontalInset` do, deliberately. A change of render path remounts the surface, so the flip has to land on the first frame of a transition and never at its end — and on a pop back over the view `to` is still the route leaving, so reading it would have the returning capsule materialize through the shader and pop to the backdrop once settled. `from || to` is wrong the other way: `from` at rest is the route below, so every route pushed over a map would get a frosted back button.

Four tests: the flag is off by default, it reaches the capsule the shell draws, it reaches the in-route capsules, and a pop back onto a bar that sets it is on the backdrop from its first frame. The second and fourth fail on main.

Fixes #310. Independent of #308; the two touch the same registration and will merge in either order.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Platforms Tested

- [x] iOS (Impeller)
- [ ] Android (Impeller)
- [ ] macOS
- [ ] Windows
- [ ] Web
- [ ] Linux

## Checklist

- [x] My code follows the style guidelines of this project (`flutter analyze` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (shaders, painting logic)
- [x] I have made corresponding changes to the documentation / CHANGELOG.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/golden tests pass locally (`flutter test`)